### PR TITLE
Add PyPI publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,45 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      - name: Build package
+        run: uv build
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/rtl_buddy
+    permissions:
+      id-token: write
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,19 +21,27 @@ authors = [
 
 description = "RTL Buddy is a build-system with testplan, regression, workflow support for Verilog RTL codebases."
 readme = "README.md"
-license = { file = "LICENSE" }
+license = "BSD-3-Clause"
+license-files = ["LICENSE"]
 keywords = [ "SystemVerilog", "Verilog", "ASIC", "FPGA" ]
 
 classifiers = [
-  "Programming Language :: Python",
+  "Development Status :: 4 - Beta",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Topic :: Scientific/Engineering :: Electronic Design Automation (EDA)",
+  "Operating System :: POSIX :: Linux",
+  "Operating System :: MacOS",
 ]
 
 [project.urls]
-# Source = ""
-# Tracker
-# Changelog
-# Documentation
+Source = "https://github.com/rtl-buddy/rtl_buddy"
+Documentation = "https://rtl-buddy.github.io/rtl_buddy/"
+Tracker = "https://github.com/rtl-buddy/rtl_buddy/issues"
+
+[tool.setuptools_scm]
 
 [dependency-groups]
 docs = [


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/publish.yml` triggered on GitHub release using PyPI Trusted Publishing (OIDC — no stored API token)
- Fills in `[project.urls]` (Source, Documentation, Tracker)
- Updates `license` to SPDX string, drops deprecated classifier and table form
- Adds Development Status, Python version, and OS classifiers
- Adds `[tool.setuptools_scm]` to silence missing-config warning on `uv build`

## How it works

On every published GitHub release, the workflow:
1. Checks out with full history (`fetch-depth: 0`) so `setuptools-scm` can read the tag
2. Runs `uv build` to produce sdist + wheel into `dist/`
3. Uploads the artifacts and publishes via `pypa/gh-action-pypi-publish` using OIDC

## Before merging — one-time PyPI setup required

1. Register the package name on PyPI (first publish will claim it)
2. Go to **https://pypi.org/manage/account/publishing/** and add a Trusted Publisher:
   - Owner: `rtl-buddy`
   - Repo: `rtl_buddy`
   - Workflow: `publish.yml`
   - Environment: `pypi`
3. Create the `pypi` environment in the repo under **Settings → Environments**

🤖 Generated with [Claude Code](https://claude.com/claude-code)