### PR TITLE
Update docs and README for PyPI availability

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,16 +61,13 @@ Full documentation is at **[rtl-buddy.github.io/rtl_buddy](https://rtl-buddy.git
 
 ## Quick Start
 
-Run a test:
+The fastest way to get started is the **[rtl-buddy project template](https://github.com/rtl-buddy/rtl-buddy-project-template)** — a ready-to-run RTL project with example designs, tests, and full `rtl_buddy` integration.
+
+Once you have a project set up, the basic commands are:
 
 ```bash
-uv run rb test basic
-```
-
-Run a regression:
-
-```bash
-uv run rb regression
+uv run rb test basic      # run a single test
+uv run rb regression      # run the full regression
 ```
 
 For full usage, see the [Quick Start guide](https://rtl-buddy.github.io/rtl_buddy/quickstart/).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # `rtl_buddy`
 
+[![PyPI](https://img.shields.io/pypi/v/rtl_buddy)](https://pypi.org/project/rtl_buddy/)
+[![Python](https://img.shields.io/pypi/pyversions/rtl_buddy)](https://pypi.org/project/rtl_buddy/)
+[![License](https://img.shields.io/badge/license-BSD--3--Clause-blue)](LICENSE)
+[![Docs](https://img.shields.io/badge/docs-rtl--buddy.github.io-blue)](https://rtl-buddy.github.io/rtl_buddy/)
+
 `rtl_buddy` is a CLI for running RTL tests, regressions, filelist generation, and adjacent workflow automation in Verilog and SystemVerilog projects. It is designed to work well for both humans and AI agents.
 
 It is built to sit on top of the tools your project already uses, while giving you a cleaner, more repeatable interface for day-to-day verification work. The primary supported flows are Verilator and VCS-based compile, simulation, and regression workflows. Basic Verible command integration exists, while broader first-class Verible and PeakRDL workflows are on the roadmap.
@@ -47,17 +52,9 @@ Prerequisites:
   - `lcov` for LCOV and HTML coverage export
   - [Coverview](https://github.com/antmicro/coverview) for Coverview package generation
 
-See the [installation docs](https://rtl-buddy.github.io/rtl_buddy/install/) for the full setup guide.
-
 ## Documentation
 
 Full documentation is at **[rtl-buddy.github.io/rtl_buddy](https://rtl-buddy.github.io/rtl_buddy/)**.
-
-- [Installation](https://rtl-buddy.github.io/rtl_buddy/install/)
-- [Quick Start](https://rtl-buddy.github.io/rtl_buddy/quickstart/)
-- [Coverage](https://rtl-buddy.github.io/rtl_buddy/concepts/coverage/)
-- [CLI Reference](https://rtl-buddy.github.io/rtl_buddy/reference/cli/)
-- [YAML Formats](https://rtl-buddy.github.io/rtl_buddy/reference/yaml/)
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,11 @@ It is built to sit on top of the tools your project already uses, while giving y
 
 ## Installation
 
-`rtl_buddy` is installed into your project environment with `uv` directly from the Git repository. PyPI publication is planned but not yet available.
+`rtl_buddy` is available on [PyPI](https://pypi.org/project/rtl_buddy/) and installed into your project environment with `uv`:
+
+```bash
+uv add rtl_buddy
+```
 
 Prerequisites:
 
@@ -43,26 +47,17 @@ Prerequisites:
   - `lcov` for LCOV and HTML coverage export
   - [Coverview](https://github.com/antmicro/coverview) for Coverview package generation
 
-See [docs/install.md](docs/install.md) for the full install flow.
+See the [installation docs](https://rtl-buddy.github.io/rtl_buddy/install/) for the full setup guide.
 
 ## Documentation
 
-Full documentation lives in [`docs/`](docs/), is built with MkDocs, and is intended to be published on GitHub Pages.
+Full documentation is at **[rtl-buddy.github.io/rtl_buddy](https://rtl-buddy.github.io/rtl_buddy/)**.
 
-To preview the docs locally while developing:
-
-```bash
-uv sync --group docs
-uv run mkdocs serve
-```
-
-Useful entry points:
-
-- [Installation](docs/install.md)
-- [Quick Start](docs/quickstart.md)
-- [Coverage](docs/concepts/coverage.md)
-- [CLI Reference](docs/reference/cli.md)
-- [YAML Formats](docs/reference/yaml.md)
+- [Installation](https://rtl-buddy.github.io/rtl_buddy/install/)
+- [Quick Start](https://rtl-buddy.github.io/rtl_buddy/quickstart/)
+- [Coverage](https://rtl-buddy.github.io/rtl_buddy/concepts/coverage/)
+- [CLI Reference](https://rtl-buddy.github.io/rtl_buddy/reference/cli/)
+- [YAML Formats](https://rtl-buddy.github.io/rtl_buddy/reference/yaml/)
 
 ## Quick Start
 
@@ -78,8 +73,8 @@ Run a regression:
 uv run rb regression
 ```
 
-For full usage, see [docs/quickstart.md](docs/quickstart.md).
+For full usage, see the [Quick Start guide](https://rtl-buddy.github.io/rtl_buddy/quickstart/).
 
 ## Known Issues
 
-See [docs/known-issues.md](docs/known-issues.md).
+See the [known issues page](https://rtl-buddy.github.io/rtl_buddy/known-issues/).

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,6 +1,6 @@
 # Installation
 
-`rtl_buddy` is now published as a standalone open-source repo and is intended to be installed into your project environment with `uv`.
+`rtl_buddy` is available on PyPI and installed into your project environment with `uv`.
 
 ## Prerequisites
 
@@ -16,16 +16,10 @@
 
 ## Install Into A Project With `uv`
 
-Add `rtl_buddy` to your project environment from the public Git repo:
+Add `rtl_buddy` to your project environment:
 
 ```bash
-uv add "rtl_buddy @ git+ssh://git@github.com/rtl-buddy/rtl_buddy.git@<tag-or-sha>"
-```
-
-If your environment cannot use SSH, use the HTTPS form instead:
-
-```bash
-uv add "rtl_buddy @ git+https://github.com/rtl-buddy/rtl_buddy.git@<tag-or-sha>"
+uv add rtl_buddy
 ```
 
 Then verify the install:
@@ -36,10 +30,10 @@ uv run rb --version
 
 ## Updating
 
-To move a project to a newer `rtl_buddy` version, update the pinned git ref in your project and resync the environment:
+To move a project to a newer `rtl_buddy` version:
 
 ```bash
-uv lock
+uv add rtl_buddy@latest
 uv sync
 ```
 


### PR DESCRIPTION
## Summary

- `README.md`: installation now shows `uv add rtl_buddy`; documentation section links to GitHub Pages instead of local `docs/` paths; local preview instructions removed
- `docs/install.md`: simplified to PyPI install path; updating section uses `uv add rtl_buddy@latest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)