### PR TITLE
Ship the rtl_buddy agent skill inside the CLI wheel

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,8 @@ This repo is the source-of-truth implementation of the `rtl_buddy` CLI.
 src/rtl_buddy/
 ├── __main__.py            # package entry point
 ├── rtl_buddy.py           # Typer CLI and top-level command flow
+├── skill_install.py       # `rtl-buddy skill ...` subcommands
+├── skill/                 # bundled agent skill (shipped in the wheel)
 ├── logging_utils.py       # log_event(), setup_logging(), console helpers
 ├── errors.py              # FatalRtlBuddyError, FilelistError, SetupScriptError
 ├── seed_mode.py           # seed handling enum
@@ -87,6 +89,28 @@ After meaningful `rtl_buddy` changes:
 1. **If any CLI command, flag, or help text changed**: run `python scripts/gen_cli_reference.py` and commit the updated `docs/reference/cli.md` in the same PR. The file is committed to the repo and must stay in sync — CI will catch drift via `python scripts/gen_cli_reference.py --check`.
 2. Update any downstream agent docs if command behavior, YAML schema, version expectations, or validation notes changed.
 3. Update downstream integrations to the intended commit as needed.
+
+## Skill Distribution
+
+The rtl_buddy agent skill ships inside this wheel at `src/rtl_buddy/skill/` and is materialized by `rtl-buddy skill install`. There is no separate skill repo — the legacy `rtl-buddy-codex-skill` repo is deprecated.
+
+### Rules when editing skill content
+
+- `src/rtl_buddy/skill/SKILL.md` is the single source consumed by both Claude Code (at `.claude/skills/rtl_buddy/`) and Codex (at `.agents/skills/rtl_buddy/` for project scope, `~/.codex/skills/rtl_buddy/` for user scope).
+- Keep `SKILL.md` ≤60 lines and agent-specific. Anything covered by the docs site should cite <https://rtl-buddy.github.io/rtl_buddy/>, not restate it.
+- Any edit to `SKILL.md` takes effect for users only after they re-run `rtl-buddy skill install`. `rtl-buddy skill status` surfaces stale installs via the `.rtl_buddy_skill_version` marker.
+- `src/rtl_buddy/skill/gitignore_snippet.txt` is printed by project-level installs and by `rtl-buddy skill print-gitignore`.
+- Package-data for the skill dir is declared in `pyproject.toml` under `[tool.setuptools.package-data]`. Adding new files to `src/rtl_buddy/skill/` requires updating that glob.
+
+### Install scope policy
+
+- **Default is user-level** (`~/.claude/skills/rtl_buddy/`, `~/.codex/skills/rtl_buddy/`). This is deliberate: the skill is workflow-pattern guidance that changes rarely across rtl_buddy versions, and a single copy per machine nudges users to keep rtl_buddy versions aligned across projects.
+- `--project` (or `--root PATH`) opts into project-level install at `<root>/.claude/skills/rtl_buddy/` and `<root>/.agents/skills/rtl_buddy/`. Claude Code's project-level precedence means a project-level copy overrides the user-level one when both exist — this is the escape hatch for projects that pin a divergent rtl_buddy major.
+- Do not flip the default to project-level without rediscussion; the precedence model makes user-level-plus-project-override the clean path.
+
+### Project root discovery
+
+`skill_install._discover_project_root()` reuses `config.root._discover_root_cfg()` (walks up for `root_config.yaml`), then falls back to walking up for `.git/`, then errors. This handles agents invoking from `verif/<suite>/` subdirs — `Path.cwd()` would be wrong.
 
 ## Release Workflow
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,6 +1,29 @@
 # For Agents
 
-This page covers how AI agents should interact with `rtl_buddy`. It describes machine mode, log formats, and the recommended validation workflow.
+This page covers how AI agents should interact with `rtl_buddy`. It describes the bundled skill, machine mode, log formats, and the recommended validation workflow.
+
+## Agent Skill Install
+
+The `rtl_buddy` wheel bundles an agent skill for Claude Code and Codex. Users run a one-time install to materialize it into their agent skill directories:
+
+```bash
+rtl-buddy skill install             # default: user-level
+rtl-buddy skill install --project   # project-level (overrides user-level for that project)
+rtl-buddy skill install --root PATH # explicit target (implies project-level layout)
+rtl-buddy skill status              # report installed version vs current
+rtl-buddy skill uninstall           # remove skill files
+```
+
+Targets:
+
+| Scope | Claude Code | Codex |
+|-------|-------------|-------|
+| User (default) | `~/.claude/skills/rtl_buddy/SKILL.md` | `~/.codex/skills/rtl_buddy/SKILL.md` |
+| Project (`--project`) | `<root>/.claude/skills/rtl_buddy/SKILL.md` | `<root>/.agents/skills/rtl_buddy/SKILL.md` |
+
+User-level is the recommended default — one install per machine, one place to keep current. Project-level is an opt-in override for projects pinned to a divergent `rtl_buddy` major; Claude Code's resolution order puts the project copy first, so both can coexist.
+
+For project-level installs, add the target dirs to your project's `.gitignore` — the install command prints the exact lines. `rtl-buddy skill install --project` discovers the project root via `root_config.yaml` (falling back to `.git/`), so it is safe to run from a `verif/` subdirectory.
 
 ## Always use machine mode
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -38,3 +38,21 @@ uv sync
 ```
 
 Commit the resulting lockfile change in your project repo.
+
+## Set Up The Agent Skill
+
+`rtl_buddy` ships an agent skill for Claude Code and Codex. After installing `rtl_buddy`, run once per machine:
+
+```bash
+uv run rtl-buddy skill install
+```
+
+This writes `SKILL.md` to `~/.claude/skills/rtl_buddy/` and `~/.codex/skills/rtl_buddy/`. Agents pick it up automatically. Re-run after upgrading `rtl_buddy` to refresh the content.
+
+To install at project scope instead (overrides the user-level copy for that project):
+
+```bash
+uv run rtl-buddy skill install --project
+```
+
+See [For Agents](agents.md) for scope semantics and `.gitignore` guidance.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -43,6 +43,7 @@ Usage: rtl-buddy [OPTIONS] COMMAND [ARGS]...
 │ regression  run rtl regression                                                       │
 │ filelist    generate filelists using models.yaml                                     │
 │ verible     run verible cmd                                                          │
+│ skill       manage the rtl_buddy agent skill                                         │
 ╰──────────────────────────────────────────────────────────────────────────────────────╯
 ```
 
@@ -177,5 +178,24 @@ Usage: rtl-buddy verible [OPTIONS] CMD [VERIBLE_ARGS]...
 ╰──────────────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ────────────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                          │
+╰──────────────────────────────────────────────────────────────────────────────────────╯
+```
+
+## skill
+
+```text
+Usage: rtl-buddy skill [OPTIONS] COMMAND [ARGS]...                                     
+                                                                                        
+ manage the rtl_buddy agent skill                                                       
+                                                                                        
+╭─ Options ────────────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                          │
+╰──────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────────────╮
+│ install          Install the bundled rtl_buddy skill.                                │
+│ uninstall        Remove the installed rtl_buddy skill files from the selected scope. │
+│ status           Report whether the skill is installed and whether it matches the    │
+│                  current package version.                                            │
+│ print-gitignore  Print the gitignore lines for project-level skill installs.         │
 ╰──────────────────────────────────────────────────────────────────────────────────────╯
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,9 @@ Tracker = "https://github.com/rtl-buddy/rtl_buddy/issues"
 
 [tool.setuptools_scm]
 
+[tool.setuptools.package-data]
+"rtl_buddy.skill" = ["SKILL.md", "gitignore_snippet.txt"]
+
 [dependency-groups]
 docs = [
   "mkdocs>=1.6.0",

--- a/scripts/gen_cli_reference.py
+++ b/scripts/gen_cli_reference.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).parent.parent
 OUTPUT = REPO_ROOT / "docs" / "reference" / "cli.md"
-SUBCOMMANDS = ["test", "randtest", "regression", "filelist", "verible"]
+SUBCOMMANDS = ["test", "randtest", "regression", "filelist", "verible", "skill"]
 
 HEADER = """\
 # CLI Reference

--- a/src/rtl_buddy/rtl_buddy.py
+++ b/src/rtl_buddy/rtl_buddy.py
@@ -19,6 +19,7 @@ from .logging_utils import emit_console_text, is_machine_mode, log_event, render
 from .runner.test_results import SetupFailResults, SkipResults
 from .runner.test_runner import RunDepth, TestRunner
 from .seed_mode import SeedMode
+from .skill_install import app as skill_app
 from .tools.coverage import CoverageReporter
 from .tools.verible import Verible
 from .tools.vlog_filelist import VlogFilelist
@@ -61,6 +62,7 @@ class RtlBuddy():
     self.app.command("regression", help="run rtl regression")(self.do_rtl_regression)
     self.app.command("filelist", help="generate filelists using models.yaml")(self.do_gen_model_filelist)
     self.app.command("verible", help="run verible cmd")(self.do_verible)
+    self.app.add_typer(skill_app, name="skill", help="manage the rtl_buddy agent skill")
 
     if '.' not in os.environ["PATH"].split(os.pathsep):
       os.environ["PATH"] = '.' + os.pathsep + os.environ["PATH"]
@@ -108,9 +110,13 @@ class RtlBuddy():
     if ctx.resilient_parsing or any(arg in {"--help", "-h"} for arg in rtl_buddy_argv):
       return
 
+    if ctx.invoked_subcommand == "skill":
+      return
+
     setup_logging(debug=debug, verbose=verbose, color=color, machine=machine)
 
     log_event(logger, logging.INFO, "cli.start", version=version("rtl-buddy"))
+
     if ctx.invoked_subcommand in self._GIT_COMMANDS and not self._is_test_list_invocation(ctx):
       self.show_git_rev()
 

--- a/src/rtl_buddy/skill/SKILL.md
+++ b/src/rtl_buddy/skill/SKILL.md
@@ -5,7 +5,9 @@ description: Use rtl_buddy to orchestrate SystemVerilog compile/sim workflows, r
 
 # rtl_buddy
 
-You are running [`rtl_buddy`](https://rtl-buddy.github.io/rtl_buddy/) — a Verilog/SV build and regression driver. This skill covers agent-specific conventions. Everything else lives in the docs site; fetch it when you need CLI or YAML detail.
+You are running [`rtl_buddy`](https://rtl-buddy.github.io/rtl_buddy/) — a Verilog/SV build and regression driver. It is a CLI tool that makes running tests, regressions and more easy, with configuration done in YAML files.
+
+This skill covers agent-specific conventions. Everything else lives in the docs site; fetch it when you need CLI or YAML detail.
 
 A docs-query MCP tool is planned. Until it ships, use WebFetch on <https://rtl-buddy.github.io/rtl_buddy/> for authoritative reference.
 
@@ -28,6 +30,15 @@ rtl-buddy --version
 ```
 
 This skill ships with the CLI, so its content matches the installed major. Surface any observed behavior differences in your summary.
+
+## YAML types
+
+rtl_buddy reads four YAML file types. The names are conventional — paths are set in `root_config.yaml` or passed with `-c`. See <https://rtl-buddy.github.io/rtl_buddy/> for exact schemas.
+
+- **`root_config.yaml`** — project root. Selects platform, builders, builder modes, verible path, coverage config, and the default `regression.yaml` path. Discovered by walking up from the invocation directory.
+- **`regression.yaml`** — lists the suite `tests.yaml` paths and reg-levels that `regression` iterates over.
+- **`tests.yaml`** — per-suite. Declares `testbenches` (TB filelists) and `tests` that map test names to a model, model_path, and testbench. Lives in each verification suite dir.
+- **`models.yaml`** — per-design. Maps model names to source/include filelists; consumed by `filelist` and referenced from `tests.yaml`.
 
 ## Multi-suite discovery and CWD rules
 

--- a/src/rtl_buddy/skill/SKILL.md
+++ b/src/rtl_buddy/skill/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: rtl-buddy
+description: Use rtl_buddy to orchestrate SystemVerilog compile/sim workflows, randomized tests, regressions, filelist generation, and verible checks. Trigger this skill when asked to run or debug rtl_buddy commands or interpret root_config.yaml, tests.yaml, models.yaml, and regression.yaml.
+---
+
+# rtl_buddy
+
+You are running [`rtl_buddy`](https://rtl-buddy.github.io/rtl_buddy/) — a Verilog/SV build and regression driver. This skill covers agent-specific conventions. Everything else lives in the docs site; fetch it when you need CLI or YAML detail.
+
+A docs-query MCP tool is planned. Until it ships, use WebFetch on <https://rtl-buddy.github.io/rtl_buddy/> for authoritative reference.
+
+## Always use `--machine`
+
+All agent invocations must use `--machine` so `rtl_buddy.log` is written as JSONL and console output is plain text:
+
+```bash
+rtl-buddy --machine <subcommand> ...
+```
+
+See <https://rtl-buddy.github.io/rtl_buddy/agents/> for the JSONL schema and exit codes (0 pass, 1 test failures, 2 fatal).
+
+## Version check
+
+Report the installed version at the top of every run summary:
+
+```bash
+rtl-buddy --version
+```
+
+This skill ships with the CLI, so its content matches the installed major. Surface any observed behavior differences in your summary.
+
+## Multi-suite discovery and CWD rules
+
+Tests are defined in one or more `tests.yaml` files, and their referenced testbench/model paths are typically relative. Running from the wrong directory causes path failures.
+
+1. Discover suites:
+   ```bash
+   rg --files -g '**/tests.yaml'
+   ```
+2. Run `test` / `randtest` **from each suite's directory**.
+3. Run `regression` from the repo root so `root_config.yaml` and `design/regression.yaml` resolve naturally.
+4. Summarize results per suite, not just globally.
+
+## Log locations
+
+- `rtl_buddy.log` — JSONL in `--machine` mode; written to the CWD you invoked from.
+- `logs/<test>.log`, `logs/<test>.err`, `logs/<test>.randseed` — per-test artifacts in the same CWD.
+- `logs/<test>.compile.log` — written only on compile failure.
+- Symlinks `test.log`, `test.err`, `test.randseed` point at the latest run.
+
+For multi-suite runs, each suite directory has its own `rtl_buddy.log` and `logs/`. Report logs per suite.
+
+## Where to look next
+
+- CLI reference: <https://rtl-buddy.github.io/rtl_buddy/reference/cli/>
+- YAML schemas and coverage workflow: <https://rtl-buddy.github.io/rtl_buddy/>
+- Known issues: <https://rtl-buddy.github.io/rtl_buddy/known-issues/>

--- a/src/rtl_buddy/skill/gitignore_snippet.txt
+++ b/src/rtl_buddy/skill/gitignore_snippet.txt
@@ -1,0 +1,3 @@
+# rtl_buddy skill (materialized by `rtl-buddy skill install --project`)
+.claude/skills/rtl_buddy/
+.agents/skills/rtl_buddy/

--- a/src/rtl_buddy/skill_install.py
+++ b/src/rtl_buddy/skill_install.py
@@ -1,0 +1,226 @@
+"""`rtl-buddy skill ...` subcommands: materialize the bundled agent skill.
+
+Skill content ships inside the wheel at `rtl_buddy.skill`. There is no
+PEP 517 post-install hook, so users run `rtl-buddy skill install` once to
+copy `SKILL.md` to the Claude Code / Codex skill directories. Default scope
+is user-level; `--project` (or `--root PATH`) opts into project-level, which
+Claude Code resolves with higher precedence than user-level.
+"""
+from __future__ import annotations
+
+import hashlib
+import os
+from importlib.metadata import version as _pkg_version
+from importlib.resources import files as _resource_files
+from pathlib import Path
+from typing import Optional
+
+import typer
+from typing_extensions import Annotated
+
+from .config.root import _discover_root_cfg
+from .errors import FatalRtlBuddyError
+
+
+SKILL_DIRNAME = "rtl_buddy"
+SKILL_FILENAME = "SKILL.md"
+VERSION_MARKER = ".rtl_buddy_skill_version"
+PACKAGE_NAME = "rtl-buddy"
+
+app = typer.Typer(help="manage the rtl_buddy agent skill", no_args_is_help=True)
+
+
+def _package_version() -> str:
+    return _pkg_version(PACKAGE_NAME)
+
+
+def _bundled_skill_text() -> str:
+    return _resource_files("rtl_buddy.skill").joinpath(SKILL_FILENAME).read_text()
+
+
+def _bundled_gitignore_snippet() -> str:
+    return _resource_files("rtl_buddy.skill").joinpath("gitignore_snippet.txt").read_text()
+
+
+def _find_git_root(start: Path) -> Optional[Path]:
+    for candidate in [start, *start.parents]:
+        if (candidate / ".git").exists():
+            return candidate
+    return None
+
+
+def _discover_project_root() -> Path:
+    """Find project root via rtl_buddy's own root_config.yaml discovery, then .git."""
+    cfg_path = _discover_root_cfg()
+    if cfg_path is not None:
+        return Path(cfg_path).parent
+    git_root = _find_git_root(Path.cwd())
+    if git_root is not None:
+        return git_root
+    raise FatalRtlBuddyError(
+        "skill install --project: cannot locate project root "
+        "(no root_config.yaml or .git found above cwd). "
+        "Pass --root PATH or run from inside a project."
+    )
+
+
+def _resolve_root(project: bool, root: Optional[Path]) -> tuple[str, Path]:
+    """Return (scope_label, target_root) for the requested scope.
+
+    scope_label is 'user' or 'project' and drives per-scope target dirs.
+    """
+    if project and root is not None:
+        raise FatalRtlBuddyError("--project and --root are mutually exclusive.")
+    if root is not None:
+        return "project", root.expanduser().resolve()
+    if project:
+        return "project", _discover_project_root().resolve()
+    return "user", Path.home()
+
+
+def _targets(scope: str, base: Path, include_claude: bool, include_codex: bool) -> list[tuple[str, Path]]:
+    """Return the (label, dir) pairs that should receive a copy of SKILL.md."""
+    if scope == "user":
+        claude = base / ".claude" / "skills" / SKILL_DIRNAME
+        codex = base / ".codex" / "skills" / SKILL_DIRNAME
+    else:
+        claude = base / ".claude" / "skills" / SKILL_DIRNAME
+        codex = base / ".agents" / "skills" / SKILL_DIRNAME
+
+    out: list[tuple[str, Path]] = []
+    if include_claude:
+        out.append(("claude", claude))
+    if include_codex:
+        out.append(("codex", codex))
+    return out
+
+
+def _same_content(path: Path, text: str) -> bool:
+    if not path.is_file():
+        return False
+    return hashlib.sha256(path.read_bytes()).hexdigest() == hashlib.sha256(text.encode()).hexdigest()
+
+
+@app.command("install")
+def cmd_install(
+    project: Annotated[bool, typer.Option("--project", help="install into the discovered project root instead of the user home")] = False,
+    root: Annotated[Optional[Path], typer.Option("--root", help="explicit target root (implies project-level layout)")] = None,
+    no_claude: Annotated[bool, typer.Option("--no-claude", help="skip writing the Claude Code target")] = False,
+    no_codex: Annotated[bool, typer.Option("--no-codex", help="skip writing the Codex target")] = False,
+    dry_run: Annotated[bool, typer.Option("--dry-run", help="print what would be written and exit")] = False,
+    force: Annotated[bool, typer.Option("--force", help="overwrite even when content matches")] = False,
+):
+    """Install the bundled rtl_buddy skill.
+
+    Default scope is user-level (`~/.claude/skills/rtl_buddy/` and
+    `~/.codex/skills/rtl_buddy/`). Use `--project` to install into the
+    discovered project root instead; project-level copies take precedence
+    over user-level when both exist.
+    """
+    scope, base = _resolve_root(project, root)
+    targets = _targets(scope, base, include_claude=not no_claude, include_codex=not no_codex)
+    if not targets:
+        raise FatalRtlBuddyError("--no-claude and --no-codex leave nothing to install.")
+
+    skill_text = _bundled_skill_text()
+    ver = _package_version()
+
+    typer.echo(f"Scope:   {scope}")
+    typer.echo(f"Base:    {base}")
+    typer.echo(f"Version: {ver}")
+    typer.echo("")
+
+    changed = 0
+    unchanged = 0
+    for label, target_dir in targets:
+        skill_path = target_dir / SKILL_FILENAME
+        marker_path = target_dir / VERSION_MARKER
+        content_matches = _same_content(skill_path, skill_text)
+        marker_matches = marker_path.is_file() and marker_path.read_text().strip() == ver
+        needs_write = force or not content_matches or not marker_matches
+
+        action = "write" if needs_write else "skip (up to date)"
+        typer.echo(f"  [{label:>6}] {skill_path}  — {action}")
+
+        if needs_write and not dry_run:
+            target_dir.mkdir(parents=True, exist_ok=True)
+            skill_path.write_text(skill_text)
+            marker_path.write_text(ver + "\n")
+            changed += 1
+        elif not needs_write:
+            unchanged += 1
+
+    typer.echo("")
+    if dry_run:
+        typer.echo("Dry run — no files written.")
+    else:
+        typer.echo(f"Wrote {changed} file(s); {unchanged} already up to date.")
+
+    if scope == "project":
+        typer.echo("")
+        typer.echo("Add these lines to your project's .gitignore (skill files are machine-local):")
+        typer.echo("")
+        for line in _bundled_gitignore_snippet().splitlines():
+            typer.echo(f"  {line}")
+
+
+@app.command("uninstall")
+def cmd_uninstall(
+    project: Annotated[bool, typer.Option("--project", help="uninstall from the discovered project root instead of the user home")] = False,
+    root: Annotated[Optional[Path], typer.Option("--root", help="explicit target root (implies project-level layout)")] = None,
+    no_claude: Annotated[bool, typer.Option("--no-claude", help="skip the Claude Code target")] = False,
+    no_codex: Annotated[bool, typer.Option("--no-codex", help="skip the Codex target")] = False,
+):
+    """Remove the installed rtl_buddy skill files from the selected scope."""
+    scope, base = _resolve_root(project, root)
+    targets = _targets(scope, base, include_claude=not no_claude, include_codex=not no_codex)
+
+    removed = 0
+    for label, target_dir in targets:
+        skill_path = target_dir / SKILL_FILENAME
+        marker_path = target_dir / VERSION_MARKER
+        if skill_path.is_file():
+            skill_path.unlink()
+            removed += 1
+            typer.echo(f"  [{label:>6}] removed {skill_path}")
+        if marker_path.is_file():
+            marker_path.unlink()
+        if target_dir.is_dir() and not any(target_dir.iterdir()):
+            target_dir.rmdir()
+
+    if removed == 0:
+        typer.echo("Nothing to remove.")
+
+
+@app.command("status")
+def cmd_status(
+    project: Annotated[bool, typer.Option("--project", help="report status for the discovered project root instead of the user home")] = False,
+    root: Annotated[Optional[Path], typer.Option("--root", help="explicit target root (implies project-level layout)")] = None,
+):
+    """Report whether the skill is installed and whether it matches the current package version."""
+    scope, base = _resolve_root(project, root)
+    targets = _targets(scope, base, include_claude=True, include_codex=True)
+    current = _package_version()
+
+    typer.echo(f"Scope:   {scope}")
+    typer.echo(f"Base:    {base}")
+    typer.echo(f"Version: {current} (installed rtl_buddy)")
+    typer.echo("")
+
+    for label, target_dir in targets:
+        marker = target_dir / VERSION_MARKER
+        skill_path = target_dir / SKILL_FILENAME
+        if not skill_path.is_file():
+            state = "not installed"
+        elif marker.is_file():
+            on_disk = marker.read_text().strip()
+            state = f"installed @ {on_disk}" + ("" if on_disk == current else " (stale — re-run `rtl-buddy skill install`)")
+        else:
+            state = "installed (version unknown — re-run `rtl-buddy skill install`)"
+        typer.echo(f"  [{label:>6}] {target_dir}  — {state}")
+
+
+@app.command("print-gitignore")
+def cmd_print_gitignore():
+    """Print the gitignore lines for project-level skill installs."""
+    typer.echo(_bundled_gitignore_snippet(), nl=False)


### PR DESCRIPTION
## Summary

- Bundles the rtl_buddy agent skill inside the CLI wheel (`src/rtl_buddy/skill/SKILL.md`), replacing the out-of-tree skill repo flow.
- Adds `rtl-buddy skill {install,uninstall,status,print-gitignore}` to materialize the skill into Claude Code and Codex skill dirs.
- Default scope is **user-level** (`~/.claude/skills/rtl_buddy/`, `~/.codex/skills/rtl_buddy/`); `--project` / `--root PATH` opts into project-level. Claude Code's project-level precedence means both can coexist — project override wins when needed. Project root discovered via the existing `_discover_root_cfg()`, with `.git/` fallback.
- Trims skill content to ≤60 lines of agent-specific guidance; cites <https://rtl-buddy.github.io/rtl_buddy/> for CLI reference, YAML schemas, coverage workflow. A doc-query MCP tool is noted as planned.
- Docs: new sections in `docs/install.md` and `docs/agents.md`; `AGENTS.md` gains a **Skill Distribution** section to anchor future edits.

## Test plan

- [x] `pip install <wheel> && rtl-buddy skill install` writes `SKILL.md` and `.rtl_buddy_skill_version` to `~/.claude/skills/rtl_buddy/` and `~/.codex/skills/rtl_buddy/`.
- [x] Re-running is idempotent (`skip (up to date)`); `--force` rewrites; `--dry-run` writes nothing.
- [x] `rtl-buddy skill install --project` invoked from a `verif/sandbox/` subdir still installs at the discovered project root — no files under the subdir.
- [x] `rtl-buddy skill install --root PATH` writes to an explicit target with project-level layout.
- [x] `rtl-buddy skill install --project` from a dir with no discoverable root errors cleanly.
- [x] `rtl-buddy skill status` reports per-target installed version vs current package version.
- [x] `rtl-buddy skill uninstall` removes `SKILL.md` + version marker + empty `rtl_buddy/` dir; leaves `.claude/skills/` / `.agents/skills/` alone.
- [x] Wheel `unzip -l` confirms `rtl_buddy/skill/SKILL.md`, `gitignore_snippet.txt`, `skill_install.py` ship.
- [x] `python scripts/gen_cli_reference.py --check` passes after regeneration.
- [x] Validate end-to-end in the template repo against the dev branch (follow-up).

## Follow-ups (not in this PR)

- `rtl-buddy-project-template`: drop the skill submodule, `.gitignore` the target dirs, document `rtl-buddy skill install` in its AGENTS.md.
- `rtl-buddy-codex-skill`: deprecation banner + archive after one validation cycle.

Closes #4 
🤖 Generated with [Claude Code](https://claude.com/claude-code)