### PR TITLE
Automate .gitignore updates for skill installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 **.sw?
 tags
 .venv
+build/
 .worktrees/
 # Sphinx
 docs/_build/

--- a/src/rtl_buddy/skill_install.py
+++ b/src/rtl_buddy/skill_install.py
@@ -101,6 +101,38 @@ def _same_content(path: Path, text: str) -> bool:
     return hashlib.sha256(path.read_bytes()).hexdigest() == hashlib.sha256(text.encode()).hexdigest()
 
 
+def _update_gitignore(gitignore_path: Path, snippet: str, *, dry_run: bool) -> str:
+    snippet_lines = snippet.strip().splitlines()
+    comment_lines = [l for l in snippet_lines if l.startswith("#")]
+    pattern_lines = [l for l in snippet_lines if l and not l.startswith("#")]
+
+    existing_text = gitignore_path.read_text() if gitignore_path.is_file() else ""
+    existing_lines = {l.strip() for l in existing_text.splitlines()}
+
+    missing = [p for p in pattern_lines if p.strip() not in existing_lines]
+    if not missing:
+        return "already present"
+
+    lines_to_add = []
+    for cl in comment_lines:
+        if cl.strip() not in existing_lines:
+            lines_to_add.append(cl)
+    lines_to_add.extend(missing)
+
+    if dry_run:
+        return f"would add {len(missing)} pattern(s) (dry run)"
+
+    if not existing_text:
+        prefix = ""
+    elif existing_text.endswith("\n"):
+        prefix = "\n"
+    else:
+        prefix = "\n\n"
+
+    gitignore_path.open("a").write(prefix + "\n".join(lines_to_add) + "\n")
+    return f"added {len(missing)} pattern(s)"
+
+
 @app.command("install")
 def cmd_install(
     project: Annotated[bool, typer.Option("--project", help="install into the discovered project root instead of the user home")] = False,
@@ -157,11 +189,9 @@ def cmd_install(
         typer.echo(f"Wrote {changed} file(s); {unchanged} already up to date.")
 
     if scope == "project":
-        typer.echo("")
-        typer.echo("Add these lines to your project's .gitignore (skill files are machine-local):")
-        typer.echo("")
-        for line in _bundled_gitignore_snippet().splitlines():
-            typer.echo(f"  {line}")
+        gitignore_path = base / ".gitignore"
+        result = _update_gitignore(gitignore_path, _bundled_gitignore_snippet(), dry_run=dry_run)
+        typer.echo(f".gitignore: {result}")
 
 
 @app.command("uninstall")

--- a/tests/test_skill_install.py
+++ b/tests/test_skill_install.py
@@ -1,0 +1,91 @@
+from pathlib import Path
+
+import pytest
+
+from rtl_buddy.skill_install import _update_gitignore
+
+_SNIPPET = (
+    "# rtl_buddy skill (materialized by `rtl-buddy skill install --project`)\n"
+    ".claude/skills/rtl_buddy/\n"
+    ".agents/skills/rtl_buddy/\n"
+)
+
+
+def test_gitignore_created_when_missing(tmp_path):
+    gitignore = tmp_path / ".gitignore"
+    result = _update_gitignore(gitignore, _SNIPPET, dry_run=False)
+    assert result == "added 2 pattern(s)"
+    assert gitignore.exists()
+    text = gitignore.read_text()
+    assert ".claude/skills/rtl_buddy/" in text
+    assert ".agents/skills/rtl_buddy/" in text
+    assert "# rtl_buddy skill" in text
+
+
+def test_already_present(tmp_path):
+    gitignore = tmp_path / ".gitignore"
+    gitignore.write_text(_SNIPPET)
+    mtime = gitignore.stat().st_mtime
+    result = _update_gitignore(gitignore, _SNIPPET, dry_run=False)
+    assert result == "already present"
+    assert gitignore.stat().st_mtime == mtime
+
+
+def test_partial_update(tmp_path):
+    gitignore = tmp_path / ".gitignore"
+    gitignore.write_text(
+        "# rtl_buddy skill (materialized by `rtl-buddy skill install --project`)\n"
+        ".claude/skills/rtl_buddy/\n"
+    )
+    result = _update_gitignore(gitignore, _SNIPPET, dry_run=False)
+    assert result == "added 1 pattern(s)"
+    text = gitignore.read_text()
+    assert ".agents/skills/rtl_buddy/" in text
+    assert text.count(".claude/skills/rtl_buddy/") == 1
+    assert text.count("# rtl_buddy skill") == 1
+
+
+def test_dry_run_no_write(tmp_path):
+    gitignore = tmp_path / ".gitignore"
+    result = _update_gitignore(gitignore, _SNIPPET, dry_run=True)
+    assert result == "would add 2 pattern(s) (dry run)"
+    assert not gitignore.exists()
+
+
+def test_dry_run_already_present(tmp_path):
+    gitignore = tmp_path / ".gitignore"
+    gitignore.write_text(_SNIPPET)
+    result = _update_gitignore(gitignore, _SNIPPET, dry_run=True)
+    assert result == "already present"
+
+
+def test_no_trailing_newline(tmp_path):
+    gitignore = tmp_path / ".gitignore"
+    gitignore.write_text("*.log")
+    _update_gitignore(gitignore, _SNIPPET, dry_run=False)
+    text = gitignore.read_text()
+    assert text.startswith("*.log\n")
+    assert ".claude/skills/rtl_buddy/" in text
+    assert ".agents/skills/rtl_buddy/" in text
+
+
+def test_comment_not_duplicated(tmp_path):
+    gitignore = tmp_path / ".gitignore"
+    gitignore.write_text(
+        "# rtl_buddy skill (materialized by `rtl-buddy skill install --project`)\n"
+        ".claude/skills/rtl_buddy/\n"
+    )
+    _update_gitignore(gitignore, _SNIPPET, dry_run=False)
+    text = gitignore.read_text()
+    assert text.count("# rtl_buddy skill") == 1
+
+
+def test_patterns_present_comment_missing(tmp_path):
+    gitignore = tmp_path / ".gitignore"
+    gitignore.write_text(
+        ".claude/skills/rtl_buddy/\n"
+        ".agents/skills/rtl_buddy/\n"
+    )
+    result = _update_gitignore(gitignore, _SNIPPET, dry_run=False)
+    assert result == "already present"
+    assert "# rtl_buddy skill" not in gitignore.read_text()


### PR DESCRIPTION
## Summary
Refactored the skill installation process to automatically update the project's `.gitignore` file instead of just printing instructions to the user. This ensures that generated skill files are properly ignored without requiring manual intervention.

## Key Changes
- Added `_update_gitignore()` function that intelligently manages `.gitignore` entries:
  - Creates `.gitignore` if it doesn't exist
  - Detects and avoids duplicate entries (both patterns and comments)
  - Handles partial updates when some patterns are already present
  - Supports dry-run mode for preview without writing
  - Properly handles files with/without trailing newlines
  
- Updated `cmd_install()` to call `_update_gitignore()` instead of printing manual instructions
  - Now automatically adds rtl_buddy skill patterns to `.gitignore` during project-scoped installation
  - Respects the `--dry-run` flag for preview mode

- Added comprehensive test suite (`test_skill_install.py`) covering:
  - File creation when `.gitignore` is missing
  - Detection of already-present patterns
  - Partial updates when some patterns exist
  - Dry-run behavior
  - Edge cases (trailing newlines, comment deduplication)

## Implementation Details
- The function parses the gitignore snippet into comment lines and pattern lines
- Checks existing file content to determine what needs to be added
- Returns descriptive status messages for user feedback
- Appends new entries with appropriate spacing to maintain file readability

https://claude.ai/code/session_018XWzVcLW9d68h7LZ8nu5hf