### PR TITLE
Switch Verible to system install via brew

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Prerequisites:
 - A simulator on `PATH`
   - Verilator is the recommended open-source starting point
   - VCS is also supported as a first-class flow
-- Optional Verible binaries if you want to use `uv run rb verible ...`
+- Optional: Verible if you want to use `uv run rb verible ...` — e.g. `brew tap chipsalliance/verible && brew install verible` on macOS, or see [Verible releases](https://github.com/chipsalliance/verible/releases) for other platforms
 - Optional system-level coverage tools:
   - `lcov` for LCOV and HTML coverage export
   - [Coverview](https://github.com/antmicro/coverview) for Coverview package generation

--- a/docs/concepts/root-config.md
+++ b/docs/concepts/root-config.md
@@ -33,7 +33,7 @@ cfg-rtl-builder:
 
 cfg-verible:
   - name: "verible-macos"
-    path: "tools/verible/macos/active/bin"
+    path: "/opt/homebrew/bin"
     extra_args:
       lint:
         - "--rules=-module-filename"

--- a/docs/concepts/root-config.md
+++ b/docs/concepts/root-config.md
@@ -59,7 +59,7 @@ Defines simulation tool configurations. Each entry has:
 
 **`cfg-verible`**
 
-Defines Verible tool configurations for lint and syntax checks.
+Defines Verible tool configurations for lint and syntax checks. `path` is the directory containing Verible executables — absolute or relative to `root_config.yaml`.
 
 **`cfg-rtl-reg`**
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -7,7 +7,7 @@
 - Python 3.11 or later
 - `uv`
 - Simulation tool on `PATH`: Verilator (macOS/Linux) or VCS (Linux)
-- Optional Verible binaries if you want to use `uv run rb verible ...`
+- Optional: Verible if you want to use `uv run rb verible ...` — e.g. `brew tap chipsalliance/verible && brew install verible` on macOS, or see [Verible releases](https://github.com/chipsalliance/verible/releases) for other platforms
 - Optional system-level coverage tools:
   - `lcov` for `.info` export and HTML reports
   - Antmicro `coverview` for Coverview package generation

--- a/docs/reference/yaml.md
+++ b/docs/reference/yaml.md
@@ -41,7 +41,7 @@ cfg-rtl-builder:
 
 cfg-verible:
   - name: "verible-macos"
-    path: "tools/verible/macos/active/bin"
+    path: "/opt/homebrew/bin"
     extra_args:
       lint:
         - "--rules=-module-filename"

--- a/docs/reference/yaml.md
+++ b/docs/reference/yaml.md
@@ -68,6 +68,7 @@ cfg-rtl-reg:
 - `cfg-coverage` is keyed by simulator family (e.g. `verilator`). `use-lcov: true` enables `.info` export and LCOV HTML generation when `--coverage-html` is used.
 - `cfg-coverview` is keyed by simulator family. `generate-tables` sets the coverage type for Coverview tables. `config` is a dict of inline Coverview JSON configuration values.
 - `cfg-rtl-reg.reg-cfg-path` is the fallback regression file for `rtl-buddy regression` when no `./regression.yaml` exists in the cwd.
+- `cfg-verible[].path` is the directory containing Verible executables. Absolute paths are used as-is; relative paths are resolved from the directory containing `root_config.yaml`.
 
 ---
 

--- a/src/rtl_buddy/config/root.py
+++ b/src/rtl_buddy/config/root.py
@@ -105,7 +105,7 @@ class RootConfig:
       self.rtl_builder_cfgs = { cfg.get_name(): cfg for cfg in data.builders }
 
       # Populate verible configs
-      self.verible_cfgs = { cfg.name: cfg.initialise(self.root_cfg_path) for cfg in data.veribles }
+      self.verible_cfgs = { cfg.name: cfg.initialise() for cfg in data.veribles }
 
       # Populate coverage configs
       self.coverage_cfgs = {

--- a/src/rtl_buddy/config/root.py
+++ b/src/rtl_buddy/config/root.py
@@ -105,7 +105,7 @@ class RootConfig:
       self.rtl_builder_cfgs = { cfg.get_name(): cfg for cfg in data.builders }
 
       # Populate verible configs
-      self.verible_cfgs = { cfg.name: cfg.initialise() for cfg in data.veribles }
+      self.verible_cfgs = { cfg.name: cfg.initialise(self.root_cfg_path) for cfg in data.veribles }
 
       # Populate coverage configs
       self.coverage_cfgs = {

--- a/src/rtl_buddy/config/verible.py
+++ b/src/rtl_buddy/config/verible.py
@@ -14,14 +14,12 @@ class VeribleConfig:
 
   Attributes:
     name (str): Unique verible identifier.
-    path (str): Path to the Verible executable directory.
+    path (str): Path to the directory containing Verible executables.
     extra_args (dict[str, list[str]]): List of arguments to be supplied to verible, grouped by command.
-    root_cfg_path (str): Directory of the root configuration
   """
   name: str
   path: str
   extra_args: dict[str, list[str]]
-  root_cfg_path: str
   available: bool
 
   def get_name(self):
@@ -42,26 +40,16 @@ class VeribleConfig:
     Returns:
       extra_args (list[str]): The list of extra_args associated with the command. If none are found, returns an empty array.
     """
-    #logger.info(pprint.pformat(self.cfg))
     return self.extra_args[cmd] if cmd in self.extra_args else []
-
-  def get_path(self):
-    """
-    Retrieves the path to the Verible executable directory.
-
-    Returns:
-      path (str): The path.
-    """
-    return os.path.join(os.path.dirname(self.root_cfg_path), self.path)
 
   def get_exe_path(self, exe_name):
     """
-    Retrieves the path to the Verible executable.
+    Retrieves the full path to a Verible executable.
 
     Returns:
       path (str): The path.
     """
-    return os.path.join(self.get_path(), exe_name)
+    return os.path.join(self.path, exe_name)
 
   def __str__(self):
     return pprint.pformat(self)
@@ -71,13 +59,12 @@ class VeribleConfigFile:
   name: str
   path: str
   extra_args: dict[str, list[str]]
-  
-  def initialise(self, root_cfg_path:str) -> VeribleConfig:
-    res = VeribleConfig(self.name, self.path, self.extra_args, root_cfg_path, False)
-    full_path = res.get_path()
-    if not os.path.exists(full_path):
-      log_event(logger, logging.DEBUG, "verible.path_missing", name=res.get_name(), path=full_path)
+
+  def initialise(self) -> VeribleConfig:
+    res = VeribleConfig(self.name, self.path, self.extra_args, False)
+    if not os.path.exists(self.path):
+      log_event(logger, logging.DEBUG, "verible.path_missing", name=res.get_name(), path=self.path)
     else:
-     res.available = True
+      res.available = True
 
     return res

--- a/src/rtl_buddy/config/verible.py
+++ b/src/rtl_buddy/config/verible.py
@@ -2,6 +2,7 @@ import logging
 logger = logging.getLogger(__name__)
 import pprint
 import os
+from pathlib import Path
 
 from dataclasses import dataclass
 from serde import serde, field
@@ -60,10 +61,11 @@ class VeribleConfigFile:
   path: str
   extra_args: dict[str, list[str]]
 
-  def initialise(self) -> VeribleConfig:
-    res = VeribleConfig(self.name, self.path, self.extra_args, False)
-    if not os.path.exists(self.path):
-      log_event(logger, logging.DEBUG, "verible.path_missing", name=res.get_name(), path=self.path)
+  def initialise(self, root_cfg_path: str) -> VeribleConfig:
+    resolved = str(Path(root_cfg_path).parent / self.path)
+    res = VeribleConfig(self.name, resolved, self.extra_args, False)
+    if not os.path.exists(resolved):
+      log_event(logger, logging.DEBUG, "verible.path_missing", name=res.get_name(), path=resolved)
     else:
       res.available = True
 


### PR DESCRIPTION
## Summary

- **Support relative and absolute Verible paths.** \`cfg-verible[].path\` accepts both: absolute paths are used as-is; relative paths are resolved from the \`root_config.yaml\` directory using \`pathlib\`. \`VeribleConfig\` no longer carries \`root_cfg_path\` as a field — resolution happens once at load time in \`initialise()\`.
- **No breaking change for vendored installs.** Projects that vendor Verible under e.g. \`tools/verible/macos/active/bin\` and point \`path\` at that relative path continue to work unchanged. This PR makes the resolution semantics explicit and also enables absolute system paths like \`/opt/homebrew/bin\`.
- **Document brew install as the recommended path.** Prerequisites in \`README.md\`, \`docs/install.md\`, and the YAML reference/concepts docs now show \`brew tap chipsalliance/verible && brew install verible\` as the recommended install, with a link to Verible releases for other platforms.

## What changed

| File | Change |
|---|---|
| \`src/rtl_buddy/config/verible.py\` | Remove \`root_cfg_path\` field; resolve \`path\` in \`initialise(root_cfg_path)\` using pathlib — absolute wins, relative joins with config dir |
| \`src/rtl_buddy/config/root.py\` | Pass \`root_cfg_path\` back to \`cfg.initialise()\` |
| \`docs/install.md\`, \`README.md\` | Add brew tap/install instructions for Verible |
| \`docs/reference/yaml.md\`, \`docs/concepts/root-config.md\` | Update \`path\` example to \`/opt/homebrew/bin\`; document absolute-or-relative resolution |

## Test plan

- [ ] Confirm \`uv run rb verible syntax <file>\` works with Verible installed via brew on macOS (\`path: /opt/homebrew/bin\`)
- [ ] Confirm \`available = False\` and clean error when \`path\` does not exist
- [ ] Confirm a relative \`path\` (e.g. \`tools/verible/macos/active/bin\`) resolves correctly from the \`root_config.yaml\` directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)