### PR TITLE
feat: improve artefact handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,8 +32,10 @@ src/rtl_buddy/
 - `rtl_buddy.py` owns CLI wiring, global options, and command dispatch.
 - `RootConfig` selects platform, builder, verible, and regression config from `root_config.yaml`.
 - `TestRunner` drives PRE, COMPILE, SIM, and POST with early-stop support.
-- `VlogSim` handles compile/sim command construction, log paths, seeds, and timeout behavior.
-- `VlogFilelist` handles `.f` parsing and transformations.
+- `VlogSim` captures the suite cwd once, but both compile and sim now run from per-test workspaces under `artefacts/<sanitized-test>/`; repeated runs use `artefacts/<sanitized-test>/run-0001/`, while `test.log`, `test.err`, and `test.randseed` in the suite directory remain latest-run symlinks.
+- Compile-side generated files such as `run.f`, `compile.log`, builder outputs, and relative `builder-simv` paths are resolved from the per-test artefact root, not from the suite directory.
+- `VlogFilelist` handles `.f` parsing and transformations. It resolves model entries from the real `models.yaml` location, resolves testbench entries from the suite cwd, and writes paths relative to the directory containing the generated `run.f`.
+- Nested raw coverage paths such as `artefacts/<test>/run-0001/coverage.dat` must preserve the suite-root hint during LCOV/Coverview `SF:` rewriting. When updating coverage path logic, make sure duplicate basenames still resolve against the originating suite root instead of falling back to repo-wide basename matching.
 - Hook scripts (`sweep`, `preproc`, `postproc`) are executed dynamically and should be treated as compatibility-sensitive APIs.
 
 ## Validation

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ uv run rb regression      # run the full regression
 
 For full usage, see the [Quick Start guide](https://rtl-buddy.github.io/rtl_buddy/quickstart/).
 
-Runtime artefacts are stored under `artefacts/{sanitized_test_name}/`. Single runs write files such as `test.log`, `test.err`, `test.randseed`, and `coverage.dat` there directly; repeated runs use nested directories such as `artefacts/{sanitized_test_name}/run-0001/`. The suite root keeps `test.log`, `test.err`, and `test.randseed` symlinked to the latest run for convenience.
+Runtime artefacts are stored under `artefacts/{sanitized_test_name}/`. Single runs write files such as `test.log`, `test.err`, `test.randseed`, and `coverage.dat` there directly, while repeated runs use nested directories such as `artefacts/{sanitized_test_name}/run-0001/`. The suite root always keeps `test.log`, `test.err`, and `test.randseed` symlinked to the latest run for convenience.
 
 ## Known Issues
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ uv run rb regression      # run the full regression
 
 For full usage, see the [Quick Start guide](https://rtl-buddy.github.io/rtl_buddy/quickstart/).
 
+Runtime artefacts are stored under `artefacts/{sanitized_test_name}/`. Single runs write files such as `test.log`, `test.err`, `test.randseed`, and `coverage.dat` there directly; repeated runs use nested directories such as `artefacts/{sanitized_test_name}/run-0001/`. The suite root keeps `test.log`, `test.err`, and `test.randseed` symlinked to the latest run for convenience.
+
 ## Known Issues
 
 See the [known issues page](https://rtl-buddy.github.io/rtl_buddy/known-issues/).

--- a/src/rtl_buddy/tools/coverview.py
+++ b/src/rtl_buddy/tools/coverview.py
@@ -138,6 +138,27 @@ class CoverviewPacker:
       return None
     return result
 
+  def _metric_source_roots_from_raw_path(self, raw_path: str) -> list[str]:
+    """
+    Build preferred source roots for raw coverage-derived `.info` rewriting.
+
+    The raw database may live directly under `artefacts/` or under nested
+    per-test/per-run directories such as `artefacts/<test>/run-0001/`.
+    """
+    raw_dir = Path(os.path.dirname(raw_path)).resolve()
+    roots: list[Path] = [raw_dir]
+    seen = {str(raw_dir)}
+
+    for ancestor in raw_dir.parents:
+      if ancestor.name in {"logs", "artefacts"}:
+        suite_root = ancestor.parent
+        if str(suite_root) not in seen:
+          roots.append(suite_root)
+          seen.add(str(suite_root))
+        break
+
+    return [str(root) for root in roots]
+
   def _get_info_process(self):
     """
     Resolve the info-process executable from PATH or the active virtual environment.
@@ -352,14 +373,10 @@ class CoverviewPacker:
     )
     if result is None or not os.path.exists(metric_info):
       return None
-    raw_dir = Path(os.path.dirname(raw_path)).resolve()
-    metric_source_roots = [raw_dir]
-    if raw_dir.name == "logs":
-      metric_source_roots.append(raw_dir.parent)
     self._rewrite_sf_relative_to_project_root(
       metric_info,
       base_dir=os.path.dirname(raw_path),
-      source_roots=[str(root) for root in metric_source_roots],
+      source_roots=self._metric_source_roots_from_raw_path(raw_path),
     )
     return metric_info
 

--- a/src/rtl_buddy/tools/coverview.py
+++ b/src/rtl_buddy/tools/coverview.py
@@ -144,6 +144,7 @@ class CoverviewPacker:
 
     The raw database may live directly under `artefacts/` or under nested
     per-test/per-run directories such as `artefacts/<test>/run-0001/`.
+    Also handles the legacy `logs/` layout for backward compatibility.
     """
     raw_dir = Path(os.path.dirname(raw_path)).resolve()
     roots: list[Path] = [raw_dir]

--- a/src/rtl_buddy/tools/vlog_cov.py
+++ b/src/rtl_buddy/tools/vlog_cov.py
@@ -197,7 +197,7 @@ class VlogCov:
       basename_matches = []
       normalized_suffix = "/" + "/".join(parts)
       search_roots = source_roots + [root for root in repo_roots if root not in source_roots]
-      ignored_dirs = {"coverage_annotated", "cov_annot", "coverage_merge.html", "logs"}
+      ignored_dirs = {"coverage_annotated", "cov_annot", "coverage_merge.html", "logs", "artefacts"}
       for search_root in search_roots:
         for match in search_root.rglob(basename):
           match = match.resolve()

--- a/src/rtl_buddy/tools/vlog_filelist.py
+++ b/src/rtl_buddy/tools/vlog_filelist.py
@@ -121,21 +121,23 @@ class VlogFilelist:
 
     return entries
 
-  def _process(self, entries, flatten=False, strip=False, deduplicate=False):
+  def _process(self, entries, output_dir, flatten=False, strip=False, deduplicate=False):
     """Do flatten, strip, and deduplicate after all lines are collected at the top level."""
+    output_dir = os.path.abspath(output_dir)
     out_lines = []
     for line_path, line_option in entries:
-      line_path = os.path.relpath(line_path) # simplifies path
+      resolved_line_path = os.path.normpath(os.path.join(output_dir, line_path))
+      line_path = os.path.relpath(resolved_line_path, start=output_dir) # simplifies path relative to the filelist location
       # File or dir exists check
       if line_option == '+incdir+' or line_option == '-y ':
-        if not os.path.isdir(line_path):
+        if not os.path.isdir(resolved_line_path):
           self._fail(
             "filelist.directory_missing",
             f'{line_path} is not a directory',
             path=line_path,
           )
       elif line_option != '+libext+':
-        if not os.path.isfile(line_path):
+        if not os.path.isfile(resolved_line_path):
           self._fail(
             "filelist.source_missing",
             f'{line_path} file does not exist',
@@ -165,17 +167,20 @@ class VlogFilelist:
     log_event(logger, logging.DEBUG, "filelist.write_start", output=output_filepath)
 
     # Get filelist from models
-    path_prefix = os.path.relpath(os.path.dirname(self.model_cfg.get_model_path()) or ".", os.path.dirname(output_filepath) or ".") # Path from output dir to model dir
     model_filelist = self.model_cfg.get_filelist()
-
-    entries = self._extract(model_filelist, unroll, os.path.join(path_prefix, "models.yaml"))
+    entries = self._extract(model_filelist, unroll, os.path.abspath(self.model_cfg.get_model_path()))
 
     # Get filelist from tests. assume tests.yaml is in the same dir
     if test_filelist:
-      path_prefix = os.path.relpath(".", os.path.dirname(output_filepath) or ".")
-      entries.extend(self._extract(test_filelist, unroll, path_prefix))
+      entries.extend(self._extract(test_filelist, unroll, os.path.join(os.path.abspath("."), "tests.yaml")))
 
-    lines = self._process(entries, flatten=flatten, strip=strip, deduplicate=deduplicate)
+    lines = self._process(
+      entries,
+      output_dir=os.path.dirname(output_filepath) or ".",
+      flatten=flatten,
+      strip=strip,
+      deduplicate=deduplicate,
+    )
 
     with open(output_filepath, "w") as f:
       f.write("// rtl-buddy generated model filelist\n")

--- a/src/rtl_buddy/tools/vlog_sim.py
+++ b/src/rtl_buddy/tools/vlog_sim.py
@@ -23,6 +23,7 @@ from .vlog_cov import VlogCov
 import time
 import pprint
 import subprocess
+from pathlib import Path
 
 from ..errors import FatalRtlBuddyError
 from ..logging_utils import log_event, task_status
@@ -55,12 +56,12 @@ class VlogSim:
     self.replay_run_id = replay_run_id
     self.testbench = self.test_cfg.get_testbench()
     self.vlog_post = None
+    self.suite_work_dir = os.path.abspath(os.getcwd())
 
-    output_dir = "logs"
-    if not os.path.exists(output_dir):
-      os.makedirs(output_dir)
+    output_dir = Path(self.suite_work_dir) / "artefacts"
+    output_dir.mkdir(parents=True, exist_ok=True)
 
-    self.output_dir = output_dir
+    self.output_dir = str(output_dir)
 
   def _get_build_tag(self):
     """
@@ -74,20 +75,46 @@ class VlogSim:
     """
     return f"obj_dir_{self._get_build_tag()}"
 
+  def _get_compile_work_dir(self):
+    return self._get_artifact_dir()
+
   def _get_simv_path(self):
     """
     Return the simulator executable path for this test/build.
     """
     rtl_builder_exe = self.rtl_builder_cfg.get_exe()
     if os.path.basename(rtl_builder_exe).startswith("verilator"):
-      return f"{self._get_build_dir()}/simv"
-    return self.rtl_builder_cfg.get_simv()
+      return str(Path(self._get_compile_work_dir()) / self._get_build_dir() / "simv")
+    simv_path = self.rtl_builder_cfg.get_simv()
+    if os.path.isabs(simv_path):
+      return simv_path
+    return str(Path(self._get_compile_work_dir()) / simv_path)
+
+  def _get_artifact_dir(self, run_id=None):
+    artifact_dir = Path(self.output_dir) / self._get_build_tag()
+    if run_id is not None:
+      artifact_dir /= f"run-{run_id:04d}"
+    return str(artifact_dir)
+
+  def _ensure_artifact_dir(self, run_id=None):
+    artifact_dir = Path(self._get_artifact_dir(run_id=run_id))
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    return str(artifact_dir)
+
+  def _get_compile_transcript_path(self):
+    return str(Path(self._get_compile_work_dir()) / "compile.log")
+
+  def _get_filelist_path(self):
+    return str(Path(self._get_compile_work_dir()) / "run.f")
 
   def _get_log_path(self, run_id=None):
-    log_path = f"{self.output_dir}/{self.test_name}"
-    if run_id is not None:
-      log_path += f"_{run_id:04d}"     # Append run_id if test rand
-    return log_path
+    return str(Path(self._get_artifact_dir(run_id=run_id)) / "test.log")
+
+  def _get_err_path(self, run_id=None):
+    return str(Path(self._get_artifact_dir(run_id=run_id)) / "test.err")
+
+  def _get_randseed_path(self, run_id=None):
+    return str(Path(self._get_artifact_dir(run_id=run_id)) / "test.randseed")
 
   def _coverage_enabled(self):
     compile_opts = self.rtl_builder_cfg.get_compile_time_opts(self.rtl_builder_mode)
@@ -100,21 +127,20 @@ class VlogSim:
     return self.rtl_builder_cfg.get_simulator_family()
 
   def _get_cov_path(self, run_id=None):
-    cov_path = f"{self.output_dir}/{self.test_name}"
-    if run_id is not None:
-      cov_path += f"_{run_id:04d}"
-    cov_path += ".coverage.dat"
-    return cov_path
+    return str(Path(self._get_artifact_dir(run_id=run_id)) / "coverage.dat")
 
   def _get_cov_abspath(self, run_id=None):
-    return os.path.abspath(self._get_cov_path(run_id=run_id))
+    return str(Path(self._get_cov_path(run_id=run_id)).resolve())
 
-  def _append_hier_instance_seed(self, randseed_fp, *, run_cmd, test, run_id):
+  def _get_suite_symlink_path(self, name):
+    return str(Path(self.suite_work_dir) / name)
+
+  def _append_hier_instance_seed(self, randseed_fp, *, artifact_dir, run_cmd, test, run_id):
     if 'hier_inst_seed' not in run_cmd:
       return
 
-    hier_seed_path = "HierInstanceSeed.txt"
-    if not os.path.exists(hier_seed_path):
+    hier_seed_path = Path(artifact_dir) / "HierInstanceSeed.txt"
+    if not hier_seed_path.exists():
       log_event(
         logger,
         logging.WARNING,
@@ -188,6 +214,7 @@ class VlogSim:
   def compile(self):
     rtl_builder_cfg = self.rtl_builder_cfg
     log_event(logger, logging.DEBUG, "compile.config", test=self.test_name, config=pprint.pformat(rtl_builder_cfg))
+    compile_work_dir = self._ensure_artifact_dir()
     
     run_cmd = [ rtl_builder_cfg.get_exe() ]
 
@@ -200,22 +227,24 @@ class VlogSim:
     # add test plus-defines
     run_cmd += self._get_plusdefines()
 
-    # generate run.f for sim
-    self._write_filelist("run.f")  # raises FilelistError on bad path; caught by TestRunner
-    run_cmd += ["-f", "run.f"]
+    # Keep compile outputs in the suite work dir, but pass explicit paths so sim cwd can vary later.
+    filelist_path = self._get_filelist_path()
+    self._write_filelist(filelist_path)  # raises FilelistError on bad path; caught by TestRunner
+    run_cmd += ["-f", filelist_path]
     run_str = " ".join(run_cmd)
     log_event(logger, logging.INFO, "compile.start", test=self.test_name, command=run_str, builder=rtl_builder_cfg.get_name())
     s_time = time.time()
     with task_status(f"Compiling {self.test_name}", spinner="dots12"):
       try:
-        result = subprocess.run(run_cmd, capture_output=True, text=True)
+        result = subprocess.run(run_cmd, capture_output=True, text=True, cwd=compile_work_dir)
       except FileNotFoundError:
         log_event(logger, logging.ERROR, "compile.builder_missing", test=self.test_name, executable=run_cmd[0])
         raise FatalRtlBuddyError(f'Builder not found. Run exe: {run_cmd[0]}')
 
     e_time = time.time()
     if result.returncode!=0:
-      transcript_path = f"{self.output_dir}/{self.test_name}.compile.log"
+      transcript_path = self._get_compile_transcript_path()
+      Path(transcript_path).parent.mkdir(parents=True, exist_ok=True)
       with open(transcript_path, "w") as transcript_fp:
         transcript_fp.write(f"Command: {run_str}\n\n")
         transcript_fp.write("=== stderr ===\n")
@@ -255,25 +284,28 @@ class VlogSim:
     """
     run_id = self.run_id if run_id is None else run_id
     replay_run_id = self.replay_run_id if replay_run_id is None else replay_run_id
+    artifact_dir = self._ensure_artifact_dir(run_id=run_id)
     log_path = self._get_log_path(run_id=run_id)
+    err_path = self._get_err_path(run_id=run_id)
+    randseed_path = self._get_randseed_path(run_id=run_id)
 
     run_cmd = [ self._get_simv_path() ]
 
     if seed_mode == SeedMode.REPLAY:
       seed_source_run_id = replay_run_id if replay_run_id is not None else run_id
-      seed_source_path = self._get_log_path(run_id=seed_source_run_id)
+      seed_source_path = self._get_randseed_path(run_id=seed_source_run_id)
       try:
-        seed = int(open(f"{seed_source_path}.randseed").readline().strip())
+        seed = int(open(seed_source_path).readline().strip())
       except (FileNotFoundError, ValueError):
-        err_msg = f"Replay seed missing or invalid at {seed_source_path}.randseed"
-        log_event(logger, logging.ERROR, "sim.replay_seed_missing", test=self.test_name, seed_path=f"{seed_source_path}.randseed")
-        with open(f"{log_path}.log", "w+") as test_out_fp:
+        err_msg = f"Replay seed missing or invalid at {seed_source_path}"
+        log_event(logger, logging.ERROR, "sim.replay_seed_missing", test=self.test_name, seed_path=seed_source_path)
+        with open(log_path, "w+") as test_out_fp:
           test_out_fp.write("FAIL replay seed missing\n")
           test_out_fp.write(f"ERR: {err_msg}\n")
-        with open(f"{log_path}.err", "w+") as test_err_fp:
+        with open(err_path, "w+") as test_err_fp:
           test_err_fp.write(err_msg + "\n")
-        force_symlink(f"{log_path}.err", "test.err")
-        force_symlink(f"{log_path}.log", "test.log")
+        force_symlink(err_path, self._get_suite_symlink_path("test.err"))
+        force_symlink(log_path, self._get_suite_symlink_path("test.log"))
         return 1
 
     elif seed_mode == SeedMode.NEW:
@@ -301,9 +333,9 @@ class VlogSim:
     if is_custom:
       log_event(logger, logging.INFO, "sim.timeout_override", test=self.test_name, run_id=run_id, timeout_sec=timeout)
     artifact_paths = {
-      "log": f"{log_path}.log",
-      "err": f"{log_path}.err",
-      "randseed": f"{log_path}.randseed",
+      "log": log_path,
+      "err": err_path,
+      "randseed": randseed_path,
     }
     log_event(logger, logging.DEBUG, "sim.output_paths", test=self.test_name, run_id=run_id, **artifact_paths)
     s_time = time.time()
@@ -311,10 +343,11 @@ class VlogSim:
 
     # subprocess pipe stderr to test.err, stdout to test.log
     with task_status(f"Running simulation {self.test_name}{'' if run_id is None else f' #{run_id:04d}'}", spinner="dots12"):
-      with open(f"{log_path}.err", "w+") as test_err_fp:
-        with open(f"{log_path}.log", "w+") as test_out_fp:
+      with open(err_path, "w+") as test_err_fp:
+        with open(log_path, "w+") as test_out_fp:
           with subprocess.Popen(run_cmd, \
             preexec_fn=os.setpgrp,
+            cwd=artifact_dir,
             stdout=test_out_fp,
             stderr=test_err_fp) as process:
               def signal_handler(_no, _frame):
@@ -342,13 +375,19 @@ class VlogSim:
                   **artifact_paths,
                 )
 
-    with open(f"{log_path}.randseed", "w") as f:
+    with open(randseed_path, "w") as f:
       f.write(str(seed) + '\n')
-      self._append_hier_instance_seed(f, run_cmd=run_cmd, test=self.test_name, run_id=run_id)
+      self._append_hier_instance_seed(
+        f,
+        artifact_dir=artifact_dir,
+        run_cmd=run_cmd,
+        test=self.test_name,
+        run_id=run_id,
+      )
 
-    force_symlink(f"{log_path}.err", "test.err")
-    force_symlink(f"{log_path}.log", "test.log")
-    force_symlink(f"{log_path}.randseed", "test.randseed")
+    force_symlink(err_path, self._get_suite_symlink_path("test.err"))
+    force_symlink(log_path, self._get_suite_symlink_path("test.log"))
+    force_symlink(randseed_path, self._get_suite_symlink_path("test.randseed"))
 
     if returncode!=0:
       log_event(
@@ -376,11 +415,11 @@ class VlogSim:
     log_path = self._get_log_path(run_id=run_id)
 
     if self.test_cfg.uvm:
-      self.vlog_post = UvmVlogPost(name=self.test_name, path=f"{log_path}.log", max_warns=self.test_cfg.uvm.max_warns, max_errors=self.test_cfg.uvm.max_errors)
+      self.vlog_post = UvmVlogPost(name=self.test_name, path=log_path, max_warns=self.test_cfg.uvm.max_warns, max_errors=self.test_cfg.uvm.max_errors)
     
     # default post-processing (VlogPost)
     else:  
-      self.vlog_post = VlogPost(name=self.test_name, path=f"{log_path}.log")
+      self.vlog_post = VlogPost(name=self.test_name, path=log_path)
     results = self.vlog_post.get_results()
     if self._coverage_enabled():
       cov = VlogCov(
@@ -390,7 +429,7 @@ class VlogSim:
       )
       cov_results = cov.collect(
         self._get_cov_abspath(run_id=run_id),
-        source_roots=[os.getcwd()],
+        source_roots=[self.suite_work_dir],
       )
       if cov_results is not None:
         results.results["coverage"] = cov_results.to_dict()

--- a/src/rtl_buddy/tools/vlog_sim.py
+++ b/src/rtl_buddy/tools/vlog_sim.py
@@ -246,7 +246,6 @@ class VlogSim:
     e_time = time.time()
     if result.returncode!=0:
       transcript_path = self._get_compile_transcript_path()
-      Path(transcript_path).parent.mkdir(parents=True, exist_ok=True)
       with open(transcript_path, "w") as transcript_fp:
         transcript_fp.write(f"Command: {run_str}\n\n")
         transcript_fp.write("=== stderr ===\n")

--- a/tests/test_coverage_paths.py
+++ b/tests/test_coverage_paths.py
@@ -1,6 +1,7 @@
 from types import SimpleNamespace
 
 from rtl_buddy.tools.coverage import CoverageReporter
+from rtl_buddy.tools.coverview import CoverviewPacker
 from rtl_buddy.tools import vlog_sim as vlog_sim_module
 from rtl_buddy.tools.vlog_cov import CoverageMetrics, VlogCov
 
@@ -56,7 +57,7 @@ def test_vlog_cov_resolve_source_path_prefers_unique_suite_root_match(tmp_path):
 
   resolved = cov._resolve_source_path(
     "tb_top.sv",
-    base_dir=sandbox_dir / "logs",
+    base_dir=sandbox_dir / "artefacts",
     source_roots=[str(sandbox_dir)],
   )
 
@@ -67,12 +68,13 @@ def test_coverage_reporter_generate_unmerged_artifacts_passes_suite_source_root(
   captured = {}
 
   class FakeCov:
-    def generate_artifacts(self, raw_path, outdir, html_output, artifact_name, source_roots):
+    def generate_artifacts(self, raw_path, outdir, html_output, artifact_name, source_roots, html_outdir=None):
       captured["raw_path"] = raw_path
       captured["outdir"] = outdir
       captured["html_output"] = html_output
       captured["artifact_name"] = artifact_name
       captured["source_roots"] = list(source_roots)
+      captured["html_outdir"] = html_outdir
       return CoverageMetrics(lcov_path=str(tmp_path / "coverage.info"))
 
   reporter = CoverageReporter(DummyRootCfg(tmp_path))
@@ -100,12 +102,13 @@ def test_coverage_reporter_merge_passes_source_roots(monkeypatch, tmp_path):
   captured = {}
 
   class FakeCov:
-    def merge(self, raw_paths, outdir, merge_basename, html_output, source_roots):
+    def merge(self, raw_paths, outdir, merge_basename, html_output, source_roots, html_outdir=None):
       captured["raw_paths"] = list(raw_paths)
       captured["outdir"] = outdir
       captured["merge_basename"] = merge_basename
       captured["html_output"] = html_output
       captured["source_roots"] = list(source_roots)
+      captured["html_outdir"] = html_outdir
       return CoverageMetrics(line=0.5)
 
   reporter = CoverageReporter(DummyRootCfg(tmp_path))
@@ -184,7 +187,50 @@ def test_vlog_cov_build_annotate_cwd_keeps_basename_paths_in_suite_root(tmp_path
   assert copied_tb.read_text() == expected_tb.read_text()
 
 
-def test_vlog_sim_post_passes_cwd_as_coverage_source_root(monkeypatch, tmp_path):
+def test_coverview_metric_source_roots_include_suite_root_for_nested_artefacts(tmp_path):
+  repo_root = tmp_path / "repo"
+  suite_dir = repo_root / "verif" / "sandbox"
+  suite_dir.mkdir(parents=True)
+  raw_path = suite_dir / "artefacts" / "basic" / "run-0001" / "coverage.dat"
+  raw_path.parent.mkdir(parents=True)
+  raw_path.write_text("raw")
+
+  packer = CoverviewPacker(cfg=None, project_root=str(repo_root))
+
+  assert packer._metric_source_roots_from_raw_path(str(raw_path)) == [
+    str(raw_path.parent.resolve()),
+    str(suite_dir.resolve()),
+  ]
+
+
+def test_coverview_rewrite_prefers_suite_root_for_nested_artefacts_duplicate_basenames(tmp_path):
+  repo_root = tmp_path / "repo"
+  suite_dir = repo_root / "verif" / "sandbox"
+  other_dir = repo_root / "verif" / "template"
+  suite_dir.mkdir(parents=True)
+  other_dir.mkdir(parents=True)
+  suite_tb = suite_dir / "tb_top.sv"
+  other_tb = other_dir / "tb_top.sv"
+  suite_tb.write_text("module tb_top;\nendmodule\n")
+  other_tb.write_text("module tb_top;\nendmodule\n")
+
+  raw_path = suite_dir / "artefacts" / "basic" / "run-0001" / "coverage.dat"
+  raw_path.parent.mkdir(parents=True)
+  raw_path.write_text("raw")
+  info_path = tmp_path / "coverage_toggle.info"
+  info_path.write_text(f"SF:{suite_tb.name}\nDA:1,1\nend_of_record\n")
+
+  packer = CoverviewPacker(cfg=None, project_root=str(repo_root))
+  packer._rewrite_sf_relative_to_project_root(
+    str(info_path),
+    base_dir=str(raw_path.parent),
+    source_roots=packer._metric_source_roots_from_raw_path(str(raw_path)),
+  )
+
+  assert info_path.read_text() == "SF:verif/sandbox/tb_top.sv\nDA:1,1\nend_of_record\n"
+
+
+def test_vlog_sim_post_passes_suite_work_dir_as_coverage_source_root(monkeypatch, tmp_path):
   captured = {}
 
   class FakeCov:
@@ -206,18 +252,18 @@ def test_vlog_sim_post_passes_cwd_as_coverage_source_root(monkeypatch, tmp_path)
   sim.root_cfg = DummyRootCfg(tmp_path)
   sim.run_id = None
   sim.vlog_post = None
+  sim.suite_work_dir = str(tmp_path / "verif" / "sandbox")
   sim._coverage_enabled = lambda: True
   sim._get_simulator_family = lambda: "verilator"
-  sim._get_cov_abspath = lambda run_id=None: str(tmp_path / "logs" / "basic.coverage.dat")
-  sim._get_log_path = lambda run_id=None: str(tmp_path / "logs" / "basic")
+  sim._get_cov_abspath = lambda run_id=None: str(tmp_path / "artefacts" / "basic" / "coverage.dat")
+  sim._get_log_path = lambda run_id=None: str(tmp_path / "artefacts" / "basic" / "test.log")
 
   monkeypatch.setattr(vlog_sim_module, "VlogPost", FakePost)
   monkeypatch.setattr(vlog_sim_module, "VlogCov", lambda **_kwargs: FakeCov())
   (tmp_path / "verif" / "sandbox").mkdir(parents=True, exist_ok=True)
-  monkeypatch.chdir(tmp_path / "verif" / "sandbox")
 
   results = sim.post()
 
-  assert captured["raw_path"].endswith("basic.coverage.dat")
+  assert captured["raw_path"].endswith("coverage.dat")
   assert captured["source_roots"] == [str(tmp_path / "verif" / "sandbox")]
   assert results.results["coverage"]["toggle"] == 0.3

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -88,16 +88,16 @@ def test_human_sim_failure_message_lists_artifacts(tmp_path):
     test="basic",
     run_id=1,
     returncode=9,
-    log="logs/basic_0001.log",
-    err="logs/basic_0001.err",
-    randseed="logs/basic_0001.randseed",
+    log="artefacts/basic/run-0001/test.log",
+    err="artefacts/basic/run-0001/test.err",
+    randseed="artefacts/basic/run-0001/test.randseed",
   )
 
   file_text = log_path.read_text()
   assert "basic #0001: simulation failed (returncode 9)" in file_text
-  assert "logs/basic_0001.log" in file_text
-  assert "logs/basic_0001.err" in file_text
-  assert "logs/basic_0001.randseed" in file_text
+  assert "artefacts/basic/run-0001/test.log" in file_text
+  assert "artefacts/basic/run-0001/test.err" in file_text
+  assert "artefacts/basic/run-0001/test.randseed" in file_text
 
 
 def test_render_summary_logs_plain_text_once(tmp_path, capsys):
@@ -244,6 +244,47 @@ def test_vlog_filelist_missing_source_raises_fatal(tmp_path):
     vlog_fl.write_output()
 
   assert "filelist source missing" in log_path.read_text()
+
+
+def test_vlog_filelist_entries_are_relative_to_output_dir(tmp_path):
+  model_dir = tmp_path / "design"
+  model_dir.mkdir()
+  model_path = model_dir / "models.yaml"
+  src_file = model_dir / "rtl.sv"
+  src_file.write_text("module rtl;\nendmodule\n")
+  model_path.write_text("models: []\n")
+  model_cfg = DummyModelCfg(model_path, ["rtl.sv\n"])
+
+  output_path = tmp_path / "artefacts" / "basic" / "run.f"
+  output_path.parent.mkdir(parents=True)
+  vlog_fl = VlogFilelist(name="rtl_buddy/vlog_filelist", model_cfg=model_cfg, output_path=output_path)
+
+  vlog_fl.write_output()
+
+  file_text = output_path.read_text()
+  assert "../../design/rtl.sv" in file_text
+
+
+def test_vlog_filelist_nested_model_includes_resolve_from_models_yaml(tmp_path):
+  model_dir = tmp_path / "design"
+  nested_dir = model_dir / "rtl"
+  nested_dir.mkdir(parents=True)
+  model_path = model_dir / "models.yaml"
+  nested_filelist = model_dir / "nested.f"
+  src_file = nested_dir / "rtl.sv"
+  src_file.write_text("module rtl;\nendmodule\n")
+  nested_filelist.write_text("rtl/rtl.sv\n")
+  model_path.write_text("models: []\n")
+  model_cfg = DummyModelCfg(model_path, ["-F nested.f\n"])
+
+  output_path = tmp_path / "artefacts" / "basic" / "run.f"
+  output_path.parent.mkdir(parents=True)
+  vlog_fl = VlogFilelist(name="rtl_buddy/vlog_filelist", model_cfg=model_cfg, output_path=output_path)
+
+  vlog_fl.write_output(unroll=True)
+
+  file_text = output_path.read_text()
+  assert "../../design/rtl/rtl.sv" in file_text
 
 
 def test_verible_path_missing_is_debug_only(tmp_path):

--- a/tests/test_vlog_sim_paths.py
+++ b/tests/test_vlog_sim_paths.py
@@ -1,0 +1,294 @@
+from contextlib import nullcontext
+from pathlib import Path
+from types import SimpleNamespace
+
+from rtl_buddy.seed_mode import SeedMode
+from rtl_buddy.tools import vlog_sim as vlog_sim_module
+
+
+class DummyBuilderCfg:
+  def __init__(self, *, exe="vcs", simv="simv", simulator_family="vcs", compile_opts=None, run_opts=None, seed=1234):
+    self.exe = exe
+    self.simv = simv
+    self.simulator_family = simulator_family
+    self.compile_opts = compile_opts or []
+    self.run_opts = run_opts or []
+    self.seed = seed
+
+  def get_exe(self):
+    return self.exe
+
+  def get_simv(self):
+    return self.simv
+
+  def get_seed(self):
+    return self.seed
+
+  def get_compile_time_opts(self, _mode):
+    return list(self.compile_opts)
+
+  def get_run_time_opts(self, _mode, seed=None):
+    opts = list(self.run_opts)
+    if seed is not None:
+      opts.append(f"+seed={seed}")
+    return opts
+
+  def get_simulator_family(self):
+    return self.simulator_family
+
+  def get_name(self):
+    return self.simulator_family
+
+
+class DummyRootCfg:
+  def __init__(self, builder_cfg):
+    self.builder_cfg = builder_cfg
+
+  def get_rtl_builder_cfg(self):
+    return self.builder_cfg
+
+  def get_use_lcov(self, _simulator_name):
+    return False
+
+
+class DummyModelCfg:
+  def __init__(self, model_path):
+    self.model_path = str(model_path)
+
+  def get_model_path(self):
+    return self.model_path
+
+  def get_filelist(self):
+    return []
+
+
+class DummyTestbenchCfg:
+  def get_filelist(self):
+    return []
+
+
+class DummyTestCfg:
+  def __init__(self, name, model_path):
+    self.name = name
+    self.model = DummyModelCfg(model_path)
+    self.tb = DummyTestbenchCfg()
+    self.pd = None
+    self.uvm = None
+
+  def get_name(self):
+    return self.name
+
+  def get_model(self):
+    return self.model
+
+  def get_testbench(self):
+    return self.tb
+
+  def get_plusargs(self):
+    return None
+
+  def get_plusdefines(self):
+    return {}
+
+  def get_timeout(self):
+    return 60, False
+
+  def get_preproc_path(self):
+    return None
+
+
+def _make_sim(tmp_path, monkeypatch, *, test_name="basic", builder_cfg=None):
+  monkeypatch.chdir(tmp_path)
+  builder_cfg = builder_cfg or DummyBuilderCfg()
+  root_cfg = DummyRootCfg(builder_cfg)
+  test_cfg = DummyTestCfg(test_name, tmp_path / "models.yaml")
+  return vlog_sim_module.VlogSim(
+    name="rtl_buddy/vlog_sim",
+    root_cfg=root_cfg,
+    test_cfg=test_cfg,
+    rtl_builder_mode="sim",
+    sim_mode={"sim_to_stdout": True},
+  )
+
+
+def test_vlog_sim_paths_are_nested_under_suite_logs(tmp_path, monkeypatch):
+  sim = _make_sim(tmp_path, monkeypatch)
+
+  assert sim.suite_work_dir == str(tmp_path)
+  assert sim._get_artifact_dir() == str(tmp_path / "artefacts" / "basic")
+  assert sim._get_artifact_dir(run_id=1) == str(tmp_path / "artefacts" / "basic" / "run-0001")
+  assert sim._get_log_path(run_id=1) == str(tmp_path / "artefacts" / "basic" / "run-0001" / "test.log")
+  assert sim._get_err_path(run_id=1) == str(tmp_path / "artefacts" / "basic" / "run-0001" / "test.err")
+  assert sim._get_randseed_path(run_id=1) == str(tmp_path / "artefacts" / "basic" / "run-0001" / "test.randseed")
+  assert sim._get_cov_path(run_id=1) == str(tmp_path / "artefacts" / "basic" / "run-0001" / "coverage.dat")
+
+
+def test_vlog_sim_resolves_relative_simv_paths_against_suite_work_dir(tmp_path, monkeypatch):
+  sim = _make_sim(
+    tmp_path,
+    monkeypatch,
+    builder_cfg=DummyBuilderCfg(exe="vcs", simv="bin/simv"),
+  )
+
+  assert sim._get_simv_path() == str(tmp_path / "artefacts" / "basic" / "bin" / "simv")
+
+
+def test_vlog_sim_resolves_verilator_simv_from_build_dir(tmp_path, monkeypatch):
+  sim = _make_sim(
+    tmp_path,
+    monkeypatch,
+    builder_cfg=DummyBuilderCfg(exe="/usr/bin/verilator", simv="ignored", simulator_family="verilator"),
+  )
+
+  assert sim._get_simv_path() == str(tmp_path / "artefacts" / "basic" / "obj_dir_basic" / "simv")
+
+
+def test_vlog_sim_compile_uses_explicit_filelist_path_and_suite_cwd(tmp_path, monkeypatch):
+  captured = {}
+  sim = _make_sim(tmp_path, monkeypatch)
+
+  def _fake_run(cmd, capture_output, text, cwd):
+    captured["cmd"] = list(cmd)
+    captured["cwd"] = cwd
+    return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+  monkeypatch.setattr(vlog_sim_module, "task_status", lambda *args, **kwargs: nullcontext())
+  monkeypatch.setattr(vlog_sim_module.subprocess, "run", _fake_run)
+
+  assert sim.compile() == 0
+  assert captured["cwd"] == str(tmp_path / "artefacts" / "basic")
+  assert captured["cmd"][-2:] == ["-f", str(tmp_path / "artefacts" / "basic" / "run.f")]
+  assert (tmp_path / "artefacts" / "basic" / "run.f").is_file()
+
+
+def test_vlog_sim_execute_runs_in_artifact_dir_and_updates_symlinks(tmp_path, monkeypatch):
+  captured = {}
+  sim = _make_sim(tmp_path, monkeypatch, builder_cfg=DummyBuilderCfg(simv="bin/simv"))
+
+  class FakeProcess:
+    def __enter__(self):
+      return self
+
+    def __exit__(self, exc_type, exc, tb):
+      return False
+
+    def wait(self, timeout):
+      captured["timeout"] = timeout
+      return 0
+
+    def send_signal(self, _signal):
+      captured["signal_sent"] = True
+
+  def _fake_popen(cmd, preexec_fn, cwd, stdout, stderr):
+    captured["cmd"] = list(cmd)
+    captured["cwd"] = cwd
+    stdout.write("PASS basic\n")
+    stderr.write("")
+    return FakeProcess()
+
+  monkeypatch.setattr(vlog_sim_module, "task_status", lambda *args, **kwargs: nullcontext())
+  monkeypatch.setattr(vlog_sim_module.subprocess, "Popen", _fake_popen)
+
+  assert sim.execute(run_id=1) == 0
+  assert captured["cmd"][0] == str(tmp_path / "artefacts" / "basic" / "bin" / "simv")
+  assert captured["cwd"] == str(tmp_path / "artefacts" / "basic" / "run-0001")
+  assert Path(tmp_path / "test.log").resolve() == Path(sim._get_log_path(run_id=1)).resolve()
+  assert Path(tmp_path / "test.err").resolve() == Path(sim._get_err_path(run_id=1)).resolve()
+  assert Path(tmp_path / "test.randseed").resolve() == Path(sim._get_randseed_path(run_id=1)).resolve()
+
+
+def test_vlog_sim_execute_reads_replay_seed_from_nested_run_dir(tmp_path, monkeypatch):
+  captured = {}
+  sim = _make_sim(tmp_path, monkeypatch)
+  Path(sim._ensure_artifact_dir(run_id=3)).mkdir(parents=True, exist_ok=True)
+  Path(sim._get_randseed_path(run_id=3)).write_text("4242\n")
+
+  class FakeProcess:
+    def __enter__(self):
+      return self
+
+    def __exit__(self, exc_type, exc, tb):
+      return False
+
+    def wait(self, timeout):
+      return 0
+
+    def send_signal(self, _signal):
+      captured["signal_sent"] = True
+
+  def _fake_popen(cmd, preexec_fn, cwd, stdout, stderr):
+    captured["cmd"] = list(cmd)
+    return FakeProcess()
+
+  monkeypatch.setattr(vlog_sim_module, "task_status", lambda *args, **kwargs: nullcontext())
+  monkeypatch.setattr(vlog_sim_module.subprocess, "Popen", _fake_popen)
+
+  assert sim.execute(run_id=5, seed_mode=SeedMode.REPLAY, replay_run_id=3) == 0
+  assert "+seed=4242" in captured["cmd"]
+
+
+def test_vlog_sim_execute_reads_hier_seed_from_artifact_dir(tmp_path, monkeypatch):
+  sim = _make_sim(tmp_path, monkeypatch, builder_cfg=DummyBuilderCfg(run_opts=["hier_inst_seed"]))
+
+  class FakeProcess:
+    def __init__(self, cwd):
+      self.cwd = Path(cwd)
+
+    def __enter__(self):
+      (self.cwd / "HierInstanceSeed.txt").write_text("instance_seed=99\n")
+      return self
+
+    def __exit__(self, exc_type, exc, tb):
+      return False
+
+    def wait(self, timeout):
+      return 0
+
+    def send_signal(self, _signal):
+      pass
+
+  def _fake_popen(cmd, preexec_fn, cwd, stdout, stderr):
+    return FakeProcess(cwd)
+
+  monkeypatch.setattr(vlog_sim_module, "task_status", lambda *args, **kwargs: nullcontext())
+  monkeypatch.setattr(vlog_sim_module.subprocess, "Popen", _fake_popen)
+
+  assert sim.execute(run_id=1) == 0
+  randseed_text = Path(sim._get_randseed_path(run_id=1)).read_text()
+  assert "1234" in randseed_text
+  assert "instance_seed=99" in randseed_text
+
+
+def test_vlog_sim_multiple_runs_keep_runtime_side_files_separate(tmp_path, monkeypatch):
+  sim = _make_sim(tmp_path, monkeypatch)
+  counter = {"value": 0}
+
+  class FakeProcess:
+    def __init__(self, cwd):
+      self.cwd = Path(cwd)
+
+    def __enter__(self):
+      counter["value"] += 1
+      (self.cwd / "wave.vcd").write_text(f"run={counter['value']}\n")
+      return self
+
+    def __exit__(self, exc_type, exc, tb):
+      return False
+
+    def wait(self, timeout):
+      return 0
+
+    def send_signal(self, _signal):
+      pass
+
+  def _fake_popen(cmd, preexec_fn, cwd, stdout, stderr):
+    return FakeProcess(cwd)
+
+  monkeypatch.setattr(vlog_sim_module, "task_status", lambda *args, **kwargs: nullcontext())
+  monkeypatch.setattr(vlog_sim_module.subprocess, "Popen", _fake_popen)
+
+  assert sim.execute(run_id=1) == 0
+  assert sim.execute(run_id=2) == 0
+
+  assert (tmp_path / "artefacts" / "basic" / "run-0001" / "wave.vcd").read_text() == "run=1\n"
+  assert (tmp_path / "artefacts" / "basic" / "run-0002" / "wave.vcd").read_text() == "run=2\n"

--- a/tests/test_vlog_sim_paths.py
+++ b/tests/test_vlog_sim_paths.py
@@ -123,7 +123,7 @@ def test_vlog_sim_paths_are_nested_under_suite_logs(tmp_path, monkeypatch):
   assert sim._get_cov_path(run_id=1) == str(tmp_path / "artefacts" / "basic" / "run-0001" / "coverage.dat")
 
 
-def test_vlog_sim_resolves_relative_simv_paths_against_suite_work_dir(tmp_path, monkeypatch):
+def test_vlog_sim_resolves_relative_simv_paths_against_compile_work_dir(tmp_path, monkeypatch):
   sim = _make_sim(
     tmp_path,
     monkeypatch,


### PR DESCRIPTION
Currently, the only test outputs that `rtl_buddy` cares about renaming and relocating are the stdout/stderr logs and random seeds. The rest of the test artefacts remain in place and get successively overwritten with each test run. This is problematic; especially when it comes to coverage reports we want to combine.

@claude please review this PR, thank you.