### PR TITLE
[codex] Define __file__ in hook scripts

### DIFF
--- a/docs/concepts/plugins.md
+++ b/docs/concepts/plugins.md
@@ -28,6 +28,7 @@ The sweep hook runs before the test flow and expands a single test entry into mu
 | `test_cfg` | TestConfig (immutable) | The original test entry from `tests.yaml` |
 | `root_cfg` | RootConfig (mutable) | The loaded root config |
 | `out_test_cfgs` | list | **Assign** the expanded list of `TestConfig` objects here |
+| `__file__` | string | Absolute path to the current sweep script |
 
 Everything in `TestConfig` except `reglvl` can be mutated in the generated tests (e.g. change `name`, `plusargs`, `plusdefines`).
 
@@ -69,6 +70,7 @@ The pre-processing hook runs after sweep expansion but before the compilation st
 | `logger` | Logger | Use for all logging |
 | `test_cfg` | TestConfig (mutable) | Modify this to change compile/sim parameters |
 | `root_cfg` | RootConfig (mutable) | The loaded root config |
+| `__file__` | string | Absolute path to the current pre-processing script |
 
 **Example:**
 

--- a/src/rtl_buddy/rtl_buddy.py
+++ b/src/rtl_buddy/rtl_buddy.py
@@ -331,10 +331,11 @@ class RtlBuddy():
       suite_results.append({'test_name': test_name, 'randmode_i': run_id, 'results': test_results})
 
   def _expand_tests_with_sweep(self, test_cfg):
-    if test_cfg.get_sweep_path() is None:
+    script_path = test_cfg.get_sweep_path()
+    if script_path is None:
       return [test_cfg], None
 
-    with open(test_cfg.get_sweep_path(), 'r') as file:
+    with open(script_path, 'r') as file:
       code = file.read()
 
     ns = {
@@ -343,15 +344,16 @@ class RtlBuddy():
       "test_cfg": test_cfg,
       "root_cfg": self.root_cfg,
       "out_test_cfgs": [],
+      "__file__": os.path.abspath(script_path),
     }
     try:
       exec(code, ns)
     except Exception as e:
-      log_event(logger, logging.ERROR, "sweep.failed", test=test_cfg.name, script=test_cfg.get_sweep_path(), error=e)
+      log_event(logger, logging.ERROR, "sweep.failed", test=test_cfg.name, script=script_path, error=e)
       logger.debug("sweep traceback", exc_info=True)
       return [], f"Setup failed in sweep: {e}"
 
-    log_event(logger, logging.INFO, "sweep.completed", test=test_cfg.name, script=test_cfg.get_sweep_path(), expanded=len(ns["out_test_cfgs"]))
+    log_event(logger, logging.INFO, "sweep.completed", test=test_cfg.name, script=script_path, expanded=len(ns["out_test_cfgs"]))
     return ns["out_test_cfgs"], None
 
   def _run_test_cfg_for_run_ids(self, test_cfg, run_ids, seed_mode: SeedMode, replay_run_id, test_runner_mode):

--- a/src/rtl_buddy/tools/vlog_sim.py
+++ b/src/rtl_buddy/tools/vlog_sim.py
@@ -161,11 +161,12 @@ class VlogSim:
     return pd_list
     
   def pre(self):
-    if self.test_cfg.get_preproc_path() is None:
+    script_path = self.test_cfg.get_preproc_path()
+    if script_path is None:
       log_event(logger, logging.DEBUG, "preproc.skipped", test=self.test_name)
       return None
 
-    with open(self.test_cfg.get_preproc_path(), 'r') as file:
+    with open(script_path, 'r') as file:
       code = file.read()
 
     # Pass self.test_cfg to the preproc script as root_cfg
@@ -173,16 +174,17 @@ class VlogSim:
     ns = {
       "logger"   : logger, 
       "test_cfg" : self.test_cfg,
-      "root_cfg" : self.root_cfg
+      "root_cfg" : self.root_cfg,
+      "__file__" : os.path.abspath(script_path),
     }
     try:
       exec(code, ns)
     except Exception as e:
-      log_event(logger, logging.ERROR, "preproc.failed", test=self.test_name, script=self.test_cfg.get_preproc_path(), error=e)
+      log_event(logger, logging.ERROR, "preproc.failed", test=self.test_name, script=script_path, error=e)
       logger.debug("preproc traceback", exc_info=True)
       return f"Setup failed in preproc: {e}"
 
-    log_event(logger, logging.INFO, "preproc.completed", test=self.test_name, script=self.test_cfg.get_preproc_path())
+    log_event(logger, logging.INFO, "preproc.completed", test=self.test_name, script=script_path)
     return None
 
   def compile(self):

--- a/tests/test_setup_failures.py
+++ b/tests/test_setup_failures.py
@@ -235,6 +235,14 @@ class DummyExecuteTestCfg:
     return None
 
 
+class DummyPreprocTestCfg(DummyExecuteTestCfg):
+  def __init__(self, script_path):
+    self._script_path = script_path
+
+  def get_preproc_path(self):
+    return self._script_path
+
+
 class DummyProcess:
   def __enter__(self):
     return self
@@ -271,3 +279,50 @@ def test_vlog_sim_missing_hier_seed_file_is_nonfatal(tmp_path, monkeypatch):
   assert returncode == 0
   assert (tmp_path / "logs" / "basic.randseed").read_text() == "31310\n"
   assert "hierarchical seed file missing at HierInstanceSeed.txt" in log_path.read_text()
+
+
+def test_preproc_script_receives___file__(tmp_path, monkeypatch):
+  setup_logging(color=False, log_path=tmp_path / "rtl_buddy.log")
+  monkeypatch.chdir(tmp_path)
+
+  script_path = tmp_path / "my_preproc.py"
+  sentinel = tmp_path / "preproc_file.txt"
+  script_path.write_text(
+    "from pathlib import Path\n"
+    "Path('preproc_file.txt').write_text(str(Path(__file__).resolve().name))\n"
+  )
+
+  sim = VlogSim(
+    name="rtl_buddy/vlog_sim",
+    root_cfg=DummyRootCfg(),
+    test_cfg=DummyPreprocTestCfg(str(script_path)),
+    rtl_builder_mode="reg",
+    sim_mode={"sim_to_stdout": False},
+  )
+
+  error = sim.pre()
+
+  assert error is None
+  assert sentinel.read_text() == "my_preproc.py"
+
+
+def test_sweep_script_receives___file__(tmp_path):
+  setup_logging(color=False, log_path=tmp_path / "rtl_buddy.log")
+  sweep_script = tmp_path / "sweep.py"
+  sweep_script.write_text(
+    "from pathlib import Path\n"
+    "assert Path(__file__).resolve().name == 'sweep.py'\n"
+    "out_test_cfgs = [test_cfg]\n"
+  )
+
+  rb = RtlBuddy(name="rtl_buddy")
+  rb.builder = "vcs"
+  rb.root_cfg = object()
+  rb.run_depth = RunDepth.POST
+  rb.rtl_builder_mode = "debug"
+
+  test_cfgs, error = rb._expand_tests_with_sweep(DummySweepTest(str(sweep_script)))
+
+  assert error is None
+  assert len(test_cfgs) == 1
+  assert test_cfgs[0] is not None


### PR DESCRIPTION
## Summary
- define `__file__` in the exec namespace for preproc and sweep hook scripts
- add regression coverage for hook scripts that resolve their own path via `__file__`
- document the supported hook context in the plugin docs

## Why
Users reported that `__file__` was missing in the preproc exec context, which breaks hook scripts that use file-relative logic. The same dynamic exec pattern existed in sweep, so this makes both hook entry points consistent.

## Impact
Hook authors can now use `Path(__file__)` or equivalent path-relative logic inside preproc and sweep scripts without hitting a setup failure.

## Validation
- `uv run --with pytest pytest tests/test_setup_failures.py`