### PR TITLE
Trigger docs publishing from release-created tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,11 +81,28 @@ jobs:
           echo "new_tag=${NEW_TAG}" >> "$GITHUB_OUTPUT"
           echo "Bumping ${LATEST} -> ${NEW_TAG}"
 
-      - name: Create and push tag
+      - name: Require release token
         if: steps.version.outputs.new_tag != ''
+        env:
+          GH_PAGES_TOKEN: ${{ secrets.GH_PAGES_TOKEN }}
+        run: |
+          test -n "$GH_PAGES_TOKEN" || {
+            echo "GH_PAGES_TOKEN is required so release-created tags trigger downstream docs publishing."
+            exit 1
+          }
+
+      - name: Configure git remote
+        if: steps.version.outputs.new_tag != ''
+        env:
+          GH_PAGES_TOKEN: ${{ secrets.GH_PAGES_TOKEN }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin "https://x-access-token:${GH_PAGES_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
+      - name: Create and push tag
+        if: steps.version.outputs.new_tag != ''
+        run: |
           TAG="${{ steps.version.outputs.new_tag }}"
           if git tag -l "$TAG" | grep -q "$TAG"; then
             echo "Tag $TAG already exists, skipping tag creation."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,5 +120,5 @@ The rtl_buddy agent skill ships inside this wheel at `src/rtl_buddy/skill/` and 
 
 1. Merge to `main` in this repo and tag (e.g. `v2.0.0`).
 2. The docs workflow publishes versioned MkDocs output to the `gh-pages` branch with `mike`: `main` updates the `dev` docs, release tags update the matching `v<major>` docs line, and the newest released major also moves the `latest` alias.
-3. GitHub Pages must be configured to publish from the `gh-pages` branch, and the repo must provide a `GH_PAGES_TOKEN` secret because pushes made with the default `GITHUB_TOKEN` do not trigger branch-based Pages publishing.
+3. GitHub Pages must be configured to publish from the `gh-pages` branch, and the repo must provide a `GH_PAGES_TOKEN` secret because pushes made with the default `GITHUB_TOKEN` do not trigger branch-based Pages publishing or downstream workflows from release-created tags.
 4. Update and tag any downstream integrations that track this repo.


### PR DESCRIPTION
## Summary
- make release.yml push tags using the existing GH_PAGES_TOKEN-backed remote instead of the default GITHUB_TOKEN
- ensure release-created tags trigger the tag-based Docs workflow that publishes versioned docs
- document that GH_PAGES_TOKEN is required for both gh-pages publishing and downstream workflow triggering

## Validation
- reviewed release and docs workflow interaction after v2.5.0 did not trigger a Docs run
