### PR TITLE
Publish release docs from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,6 +174,74 @@ jobs:
           name: dist
           path: dist/
 
+  publish_docs:
+    needs: release
+    if: needs.release.outputs.new_tag != ''
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.release.outputs.new_tag }}
+          persist-credentials: false
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      - name: Install dependencies
+        run: uv sync --group docs
+
+      - name: Configure git remote
+        env:
+          GH_PAGES_TOKEN: ${{ secrets.GH_PAGES_TOKEN }}
+        run: |
+          test -n "$GH_PAGES_TOKEN" || {
+            echo "GH_PAGES_TOKEN is required to publish release docs to the gh-pages branch."
+            exit 1
+          }
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin "https://x-access-token:${GH_PAGES_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
+      - name: Fetch gh-pages branch if it exists
+        run: git fetch origin gh-pages --depth=1 || true
+
+      - name: Compute docs target
+        id: target
+        shell: bash
+        run: |
+          tag="${{ needs.release.outputs.new_tag }}"
+          major="${tag#v}"
+          major="${major%%.*}"
+          version="v${major}"
+          highest_major="$(git tag --list 'v*.*.*' | sed -E 's/^v([0-9]+)\..*/\1/' | sort -n | tail -1)"
+          update_latest=false
+          if [[ -n "${highest_major}" && "${major}" == "${highest_major}" ]]; then
+            update_latest=true
+          fi
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "update_latest=${update_latest}" >> "$GITHUB_OUTPUT"
+
+      - name: Deploy docs version
+        run: |
+          if [[ "${{ steps.target.outputs.update_latest }}" == "true" ]]; then
+            uv run mike deploy --branch gh-pages --update-aliases "${{ steps.target.outputs.version }}" latest
+          else
+            uv run mike deploy --branch gh-pages --update-aliases "${{ steps.target.outputs.version }}"
+          fi
+
+      - name: Set default docs version
+        if: steps.target.outputs.update_latest == 'true'
+        run: uv run mike set-default --branch gh-pages latest
+
+      - name: Push gh-pages
+        run: git push origin gh-pages
+
   publish:
     needs: build
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,6 +119,6 @@ The rtl_buddy agent skill ships inside this wheel at `src/rtl_buddy/skill/` and 
 ## Release Workflow
 
 1. Merge to `main` in this repo and tag (e.g. `v2.0.0`).
-2. The docs workflow publishes versioned MkDocs output to the `gh-pages` branch with `mike`: `main` updates the `dev` docs, release tags update the matching `v<major>` docs line, and the newest released major also moves the `latest` alias.
-3. GitHub Pages must be configured to publish from the `gh-pages` branch, and the repo must provide a `GH_PAGES_TOKEN` secret because pushes made with the default `GITHUB_TOKEN` do not trigger branch-based Pages publishing or downstream workflows from release-created tags.
+2. The docs workflow publishes versioned MkDocs output to the `gh-pages` branch with `mike`: `main` updates the `dev` docs, and the release workflow publishes the matching `v<major>` docs line for official releases while also moving the `latest` alias for the newest released major.
+3. GitHub Pages must be configured to publish from the `gh-pages` branch, and the repo must provide a `GH_PAGES_TOKEN` secret because pushes made with the default `GITHUB_TOKEN` do not trigger branch-based Pages publishing or reliable downstream docs publishing from automation-created tags.
 4. Update and tag any downstream integrations that track this repo.


### PR DESCRIPTION
## Summary
- publish versioned docs directly from release.yml after a new release tag is created
- stop relying on automation-created tag pushes to trigger the separate Docs workflow
- keep the existing Docs workflow for main/dev docs while making official releases publish /v<major>/ and latest reliably

## Validation
- reviewed the release/docs workflow interaction after v2.5.1 still failed to publish /v2/
- checked the updated workflow structure for the tag checkout and mike deployment path
