### PR TITLE
fix: switch to hatchling to fix v3.1.0 wheel build

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,7 +106,7 @@ The rtl_buddy agent skill ships inside this wheel at `src/rtl_buddy/skill/` and 
 - Agent-facing local docs access goes through `rtl-buddy docs ...`. The wheel ships `docs/**/*.md` directly (via a symlink at `src/rtl_buddy/docs`) so docs are always in sync with the installed version.
 - Any edit to `SKILL.md` takes effect for users only after they re-run `rtl-buddy skill install`. `rtl-buddy skill status` surfaces stale installs via the `.rtl_buddy_skill_version` marker.
 - `src/rtl_buddy/skill/gitignore_snippet.txt` is printed by project-level installs and by `rtl-buddy skill print-gitignore`.
-- Package-data for the skill dir is declared in `pyproject.toml` under `[tool.setuptools.package-data]`. Adding new files to `src/rtl_buddy/skill/` requires updating that glob.
+- Files in `src/rtl_buddy/skill/` are included in the wheel automatically via hatchling's `packages = ["src/rtl_buddy"]`. Adding new files to the skill dir requires no extra config. The `docs/` directory ships via `force-include` in `pyproject.toml` and is excluded from package discovery to avoid double-inclusion.
 
 ### Install scope policy
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["setuptools>=80.9.0", "setuptools-scm[simple]>=9.2.0"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling", "hatch-vcs"]
+build-backend = "hatchling.build"
 
 [project]
 name = "rtl_buddy"
@@ -41,11 +41,15 @@ Source = "https://github.com/rtl-buddy/rtl_buddy"
 Documentation = "https://rtl-buddy.github.io/rtl_buddy/"
 Tracker = "https://github.com/rtl-buddy/rtl_buddy/issues"
 
-[tool.setuptools_scm]
+[tool.hatch.version]
+source = "vcs"
 
-[tool.setuptools.package-data]
-"rtl_buddy.skill" = ["SKILL.md", "gitignore_snippet.txt"]
-"rtl_buddy" = ["docs/**/*.md"]
+[tool.hatch.build.targets.wheel]
+packages = ["src/rtl_buddy"]
+exclude = ["src/rtl_buddy/docs"]
+
+[tool.hatch.build.targets.wheel.force-include]
+"docs" = "rtl_buddy/docs"
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
## Root cause

PR #34 introduced `src/rtl_buddy/docs` as a git symlink → `../../docs`. setuptools preserves symlinks literally in the sdist tarball. When the release workflow then built the wheel from that sdist, the symlink target (`../../docs`) pointed outside the extracted sdist directory, causing:

```
error: can't copy 'src/rtl_buddy/docs': doesn't exist or not a regular file
```

The v3.1.0 tag and GitHub release exist but the wheel never reached PyPI.

## Fix

Switch build backend from setuptools + setuptools-scm to **hatchling + hatch-vcs**.

- `packages = ["src/rtl_buddy"]` — includes all package files
- `exclude = ["src/rtl_buddy/docs"]` — excludes the symlink from package discovery
- `force-include = {"docs" = "rtl_buddy/docs"}` — explicitly maps `docs/` from the project root into the wheel as `rtl_buddy/docs/`, independent of symlink semantics

`hatch-vcs` is a drop-in replacement for setuptools-scm (same git tag convention).

## Verified locally

- `uv build` succeeds — builds both sdist and wheel without errors
- `unzip -l dist/*.whl | grep docs/` — `rtl_buddy/docs/**/*.md` present in wheel
- `tar tzf dist/*.tar.gz | grep docs/concepts` — real files in sdist
- `uv sync && uv run rb docs list` — editable install resolves docs via symlink correctly

## Note on v3.1.0

PyPI won't accept a re-upload of v3.1.0. This PR releases as **v3.1.1** (version/patch label).

🤖 Generated with [Claude Code](https://claude.com/claude-code)