### PR TITLE
feat: pre-release label support in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,11 @@ on:
           - patch
           - minor
           - major
+      pre_release:
+        description: 'Mark as pre-release (appends rcN suffix, PEP 440)'
+        required: false
+        type: boolean
+        default: false
       description:
         description: 'Release description (optional)'
         required: false
@@ -31,6 +36,7 @@ jobs:
       contents: write
     outputs:
       new_tag: ${{ steps.version.outputs.new_tag }}
+      is_prerelease: ${{ steps.version.outputs.is_prerelease }}
 
     steps:
       - name: Checkout merged commit
@@ -52,8 +58,12 @@ jobs:
           MINOR=$(echo "$VERSION" | cut -d. -f2)
           PATCH=$(echo "$VERSION" | cut -d. -f3)
 
+          IS_PRERELEASE=false
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             BUMP_TYPE="${{ inputs.bump }}"
+            if [ "${{ inputs.pre_release }}" = "true" ]; then
+              IS_PRERELEASE=true
+            fi
           else
             LABELS='${{ toJson(github.event.pull_request.labels.*.name) }}'
             if echo "$LABELS" | grep -qi '"version/major"'; then
@@ -67,18 +77,30 @@ jobs:
               echo "new_tag=" >> "$GITHUB_OUTPUT"
               exit 0
             fi
+            if echo "$LABELS" | grep -qi '"pre-release"'; then
+              IS_PRERELEASE=true
+            fi
           fi
 
           if [ "$BUMP_TYPE" = "major" ]; then
-            NEW_TAG="v$((MAJOR + 1)).0.0"
+            BASE_TAG="v$((MAJOR + 1)).0.0"
           elif [ "$BUMP_TYPE" = "minor" ]; then
-            NEW_TAG="v${MAJOR}.$((MINOR + 1)).0"
+            BASE_TAG="v${MAJOR}.$((MINOR + 1)).0"
           else
-            NEW_TAG="v${MAJOR}.${MINOR}.$((PATCH + 1))"
+            BASE_TAG="v${MAJOR}.${MINOR}.$((PATCH + 1))"
+          fi
+
+          if [ "$IS_PRERELEASE" = "true" ]; then
+            RC_COUNT=$(git tag --list "${BASE_TAG}rc*" | wc -l | tr -d ' ')
+            RC_NUM=$((RC_COUNT + 1))
+            NEW_TAG="${BASE_TAG}rc${RC_NUM}"
+          else
+            NEW_TAG="${BASE_TAG}"
           fi
 
           echo "latest_tag=${LATEST}" >> "$GITHUB_OUTPUT"
           echo "new_tag=${NEW_TAG}" >> "$GITHUB_OUTPUT"
+          echo "is_prerelease=${IS_PRERELEASE}" >> "$GITHUB_OUTPUT"
           echo "Bumping ${LATEST} -> ${NEW_TAG}"
 
       - name: Require release token
@@ -117,6 +139,7 @@ jobs:
         env:
           TAG: ${{ steps.version.outputs.new_tag }}
           PREV_TAG: ${{ steps.version.outputs.latest_tag }}
+          IS_PRERELEASE: ${{ steps.version.outputs.is_prerelease }}
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_USER: ${{ github.event.pull_request.user.login }}
@@ -128,6 +151,7 @@ jobs:
           script: |
             const tag = process.env.TAG;
             const prevTag = process.env.PREV_TAG;
+            const isPrerelease = process.env.IS_PRERELEASE === 'true';
             let body;
             if (context.eventName === 'workflow_dispatch') {
               body = process.env.DESCRIPTION || `Manual release triggered by @${process.env.ACTOR}`;
@@ -146,7 +170,7 @@ jobs:
               name: `Release ${tag}`,
               body,
               draft: false,
-              prerelease: false,
+              prerelease: isPrerelease,
             });
 
   build:
@@ -176,7 +200,7 @@ jobs:
 
   publish_docs:
     needs: release
-    if: needs.release.outputs.new_tag != ''
+    if: needs.release.outputs.new_tag != '' && needs.release.outputs.is_prerelease != 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,7 +120,30 @@ The rtl_buddy agent skill ships inside this wheel at `src/rtl_buddy/skill/` and 
 
 ## Release Workflow
 
-1. Merge to `main` in this repo and tag (e.g. `v2.0.0`).
-2. The docs workflow publishes versioned MkDocs output to the `gh-pages` branch with `mike`: `main` updates the `dev` docs, and the release workflow publishes the matching `v<major>` docs line for official releases while also moving the `latest` alias for the newest released major.
-3. GitHub Pages must be configured to publish from the `gh-pages` branch, and the repo must provide a `GH_PAGES_TOKEN` secret because pushes made with the default `GITHUB_TOKEN` do not trigger branch-based Pages publishing or reliable downstream docs publishing from automation-created tags.
-4. Update and tag any downstream integrations that track this repo.
+Releases are triggered by merging a PR to `main` with a `version/` label, or via `workflow_dispatch`.
+
+### Stable release
+
+Apply one of `version/patch`, `version/minor`, or `version/major` to the PR. On merge:
+
+1. The workflow computes the next `vMAJOR.MINOR.PATCH` tag, creates it, and pushes it.
+2. A GitHub release is created (not marked pre-release).
+3. The wheel is built (hatch-vcs derives the version from the tag) and published to PyPI.
+4. Docs are deployed to `gh-pages` under the matching `v{major}` alias; `latest` is updated if this is the highest major.
+
+### Pre-release
+
+Apply both a `version/` label **and** `pre-release` to the PR. On merge:
+
+1. The workflow appends `rcN` to the computed base tag (PEP 440). If `v2.3.0rc1` already exists, the next is `v2.3.0rc2`.
+2. A GitHub release is created and marked **pre-release**.
+3. The wheel is published to PyPI as a pre-release version (e.g. `2.3.0rc1`). Unqualified version ranges (`>=2.2.0`) will not resolve to it.
+4. Docs are **not** published — the `latest` alias is not updated.
+
+The same options are available via `workflow_dispatch` (`pre_release` boolean checkbox).
+
+### Infrastructure notes
+
+- GitHub Pages must be configured to publish from the `gh-pages` branch.
+- A `GH_PAGES_TOKEN` secret is required because pushes made with the default `GITHUB_TOKEN` do not reliably trigger downstream docs publishing from automation-created tags.
+- Update and tag any downstream integrations that track this repo after a stable release.

--- a/docs/install.md
+++ b/docs/install.md
@@ -43,6 +43,24 @@ uv sync
 
 Commit the resulting lockfile change in your project repo.
 
+## Installing A Pre-release
+
+Pre-release versions follow PEP 440 (`2.3.0rc1`, `2.3.0rc2`, …). They are published to PyPI but excluded from the default resolver — an unqualified range like `>=2.2.0` will not pull one in.
+
+To install a specific pre-release, pin it exactly:
+
+```bash
+uv add "rtl_buddy==2.3.0rc1"
+```
+
+Or in `pyproject.toml`:
+
+```toml
+dependencies = ["rtl_buddy==2.3.0rc1"]
+```
+
+This works without any `--pre` flag because the exact version is specified.
+
 ## Set Up The Agent Skill
 
 `rtl_buddy` ships an agent skill for Claude Code and Codex. After installing `rtl_buddy`, run once per machine:


### PR DESCRIPTION
## Summary

- Adds a `pre-release` PR label that, when combined with a `version/*` label, produces a PEP 440 pre-release (`rcN`) instead of a stable release
- Adds a `pre_release` boolean input to the `workflow_dispatch` trigger for the same effect manually
- `publish_docs` is skipped for pre-releases so the `latest` docs alias is not updated
- Build and PyPI publish run unchanged — hatch-vcs derives the wheel version from the tag, so `v2.3.0rc1` produces `2.3.0rc1` on PyPI automatically

## How to use

For a PR: apply both `version/patch` (or `minor`/`major`) **and** `pre-release`. The tag will be `v{next}rc1`; if `v{next}rc1` already exists, it increments to `rc2`, and so on.

For `workflow_dispatch`: check the **Mark as pre-release** checkbox alongside the bump type.

## Install a pre-release

```toml
# pyproject.toml — exact pin works without --pre flag
dependencies = ["rtl_buddy==2.3.0rc1"]
```

```
# requirements.txt
rtl_buddy==2.3.0rc1
```

Unqualified ranges (`>=2.2.0`) will not pick up pre-releases unless `--prerelease=allow` is passed.

## Test plan

- [ ] Merge a PR with `version/patch` + `pre-release` labels; verify tag is `vX.Y.Zrc1`, GitHub release is marked pre-release, docs job is skipped
- [ ] Merge a second PR with the same labels targeting the same base; verify tag increments to `rc2`
- [ ] Merge a PR with only `version/patch`; verify tag is `vX.Y.Z`, docs job runs, release is not marked pre-release
- [ ] Trigger `workflow_dispatch` with `pre_release=true`; verify same pre-release behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)