### PR TITLE
fix: pre-releases via workflow_dispatch on branch only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,9 +77,6 @@ jobs:
               echo "new_tag=" >> "$GITHUB_OUTPUT"
               exit 0
             fi
-            if echo "$LABELS" | grep -qi '"pre-release"'; then
-              IS_PRERELEASE=true
-            fi
           fi
 
           if [ "$BUMP_TYPE" = "major" ]; then

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,14 +133,17 @@ Apply one of `version/patch`, `version/minor`, or `version/major` to the PR. On 
 
 ### Pre-release
 
-Apply both a `version/` label **and** `pre-release` to the PR. On merge:
+Pre-releases are cut from a **feature branch** via `workflow_dispatch` — never by merging to `main`. Merging to `main` with a `version/` label always produces a stable release.
 
-1. The workflow appends `rcN` to the computed base tag (PEP 440). If `v2.3.0rc1` already exists, the next is `v2.3.0rc2`.
-2. A GitHub release is created and marked **pre-release**.
-3. The wheel is published to PyPI as a pre-release version (e.g. `2.3.0rc1`). Unqualified version ranges (`>=2.2.0`) will not resolve to it.
-4. Docs are **not** published — the `latest` alias is not updated.
+To cut a pre-release:
 
-The same options are available via `workflow_dispatch` (`pre_release` boolean checkbox).
+1. Run the Release workflow on your feature branch with the desired bump type and the **Mark as pre-release** checkbox enabled.
+2. The workflow appends `rcN` to the computed base tag (PEP 440). If `v2.3.0rc1` already exists, the next is `v2.3.0rc2`.
+3. A GitHub release is created and marked **pre-release**.
+4. The wheel is published to PyPI as a pre-release version (e.g. `2.3.0rc1`). Unqualified version ranges (`>=2.2.0`) will not resolve to it.
+5. Docs are **not** published — the `latest` alias is not updated.
+
+The version is computed from the latest stable tag at dispatch time. If `main` advances and releases the same bump tier before your branch merges, the next RC will shift to the following version — that is expected and acceptable.
 
 ### Infrastructure notes
 


### PR DESCRIPTION
Fixes a design flaw introduced in #39.

## Problem

#39 added a `pre-release` PR label that, when combined with a `version/` label, would cut a pre-release on merge to `main`. This is wrong: merging to `main` is permanent, so the feature is now on `main` and will be included in every subsequent stable release — even if it wasn't ready.

## Fix

Remove the `pre-release` label from the PR merge path entirely. Pre-releases are now only triggered via `workflow_dispatch` on a feature branch, before it merges to `main`.

The developer flow:
1. Work on a feature branch
2. Run the Release workflow on that branch with the desired bump type + **Mark as pre-release** checked → publishes `v2.3.0rc1` from the branch tip
3. Iterate (`rc2`, `rc3` …) as needed via further dispatches
4. When ready, open a PR to `main` with a `version/` label → stable release

The version is computed from the latest stable tag at dispatch time. If `main` advances and releases the same bump tier first, the RC version shifts — that is expected and acceptable.

Also updates `AGENTS.md` to document the correct flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)