### PR TITLE
feat: warn when no PASS/FAIL markers found in test log

### DIFF
--- a/src/rtl_buddy/logging_utils.py
+++ b/src/rtl_buddy/logging_utils.py
@@ -273,6 +273,8 @@ def _human_message(event: str, fields: Mapping[str, Any]) -> str:
       return f'{target or "sim"}: using timeout override {fields.get("timeout_sec")}s'
     case "postproc.completed":
       return f'{target or "postproc"}: post-processing completed with result {fields.get("result")} ({fields.get("desc")})'
+    case "postproc.no_markers":
+      return f'{fields.get("test")}: no PASS/FAIL markers found in {fields.get("log")}; result is NA'
     case "filelist.malformed_line":
       return f'{fields.get("file")}: malformed filelist line "{fields.get("line")}"'
     case "filelist.include_missing":

--- a/src/rtl_buddy/tools/vlog_post.py
+++ b/src/rtl_buddy/tools/vlog_post.py
@@ -10,6 +10,7 @@ import logging
 logger = logging.getLogger(__name__)
 import re
 from ..runner.test_results import TestResults,TestPassResults
+from ..logging_utils import log_event
 
 class VlogPost:
   """
@@ -41,7 +42,9 @@ class VlogPost:
       results={'result':'FAIL', 'desc':f'{match_fail.group(1)} {match_err.group(2).strip()}'}
     if match_pass is not None:
       results={'result':'PASS', 'desc':match_pass.group(1)}
-    
+    if match_pass is None and match_fail is None:
+      log_event(logger, logging.WARNING, "postproc.no_markers", test=self.name, log=str(self.path))
+
     return TestResults(name=self.name, results=results)
 
 


### PR DESCRIPTION
## Summary

- Emits a `postproc.no_markers` WARNING in `vlog_post.get_results()` when neither `^PASS` nor `^FAIL` is found in the simulation log
- Adds the matching human-readable case to `_human_message()` in `logging_utils.py`
- In machine mode the event appears as a structured JSON WARNING with `test` and `log` fields, so agents can grep for `"event": "postproc.no_markers"` to diagnose NA results without opening the log file

Previously a missing marker silently produced `result=NA, desc="test result unknown"` with no indication of why. Now users and agents see:
```
smoke: no PASS/FAIL markers found in artefacts/smoke/run-0001/test.log; result is NA
```

## Test plan

- [x] Validated locally in `rtl-buddy-project-template` dev worktree with a minimal testbench that calls `$finish` without emitting any markers — `postproc.no_markers` WARNING fires before `postproc.completed`, and the machine-mode log contains the structured JSON event

🤖 Generated with [Claude Code](https://claude.com/claude-code)