### PR TITLE
docs: normalize skill install commands

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -66,7 +66,7 @@ This works without any `--pre` flag because the exact version is specified.
 `rtl_buddy` ships an agent skill for Claude Code and Codex. After installing `rtl_buddy`, run once per machine:
 
 ```bash
-uv run rtl-buddy skill install
+uv run rb skill install
 ```
 
 This writes `SKILL.md` to `~/.claude/skills/rtl_buddy/` and `~/.codex/skills/rtl_buddy/`. Agents pick it up automatically. Re-run after upgrading `rtl_buddy` to refresh the content.
@@ -74,7 +74,7 @@ This writes `SKILL.md` to `~/.claude/skills/rtl_buddy/` and `~/.codex/skills/rtl
 To install at project scope instead (overrides the user-level copy for that project):
 
 ```bash
-uv run rtl-buddy skill install --project
+uv run rb skill install --project
 ```
 
 See [For Agents](agents.md) for scope semantics and `.gitignore` guidance.

--- a/src/rtl_buddy/skill/SKILL.md
+++ b/src/rtl_buddy/skill/SKILL.md
@@ -1,47 +1,32 @@
 ---
 name: rtl-buddy
-description: Use rtl_buddy to orchestrate SystemVerilog compile/sim workflows, randomized tests, regressions, filelist generation, and verible checks. Trigger this skill when asked to run or debug rtl_buddy commands or interpret root_config.yaml, tests.yaml, models.yaml, and regression.yaml.
+description: Use rtl_buddy to run SystemVerilog tests, regressions, filelists, coverage, and Verible checks. Trigger this skill when asked to run or debug rtl_buddy commands or interpret root_config.yaml, tests.yaml, models.yaml, regression.yaml, or specs.yaml.
 ---
 
 # rtl_buddy
 
-You are running rtl_buddy a Verilog/SV build and regression helper configured with YAML.
+You are running rtl_buddy, a Verilog/SystemVerilog build and regression helper configured with YAML.
 
-This skill covers agent-specific conventions. Use local docs if you need help:
+Start every run by reporting `rtl-buddy --version`.
 
+Use bundled docs before external references:
 - `rtl-buddy docs list`
 - `rtl-buddy docs show agents`
 - `rtl-buddy --machine docs show reference/yaml`
 
-Use GitHub Pages at <https://rtl-buddy.github.io/rtl_buddy/> as a fallback reference.
+Run all agent invocations with `--machine`. This makes `rtl_buddy.log` JSONL and keeps console output plain text.
 
-## Always use `--machine`
+Working-directory rules:
+- Run `test` and `randtest` from the suite directory that contains `tests.yaml`.
+- Run `regression` from the project root.
+- Discover suites with `rg --files -g '**/tests.yaml'`.
 
-All agent invocations must use `--machine` so `rtl_buddy.log` is JSONL and console output is plain text.
-
-See `rtl-buddy docs show agents` or <https://rtl-buddy.github.io/rtl_buddy/latest/agents/> for the JSONL schema and exit codes (0 pass, 1 test failures, 2 fatal).
-
-## Version check
-
-Report `rtl-buddy --version` at the top of every run summary.
-This skill ships with the CLI, so its content matches the installed major. Surface any observed behavior differences in your summary.
-
-## YAML types
-
-rtl_buddy reads four YAML file types. See `rtl-buddy docs show reference/yaml` for exact schemas.
-
-- **`root_config.yaml`** — project root. Selects platform, builders, builder modes, verible path, coverage config, and the default `regression.yaml` path. Discovered by walking up from the invocation directory.
-- **`regression.yaml`** — lists the suite `tests.yaml` paths and reg-levels that `regression` iterates over.
-- **`tests.yaml`** — per-suite. Declares `testbenches` (TB filelists) and `tests` that map test names to a model, model_path, and testbench. Lives in each verification suite dir.
-- **`models.yaml`** — per-design. Maps model names to source/include filelists; consumed by `filelist` and referenced from `tests.yaml`.
-
-## Test Pass/fail detection
-- If `tests.yaml` sets `uvm:`, `rtl_buddy` parses the UVM Report Summary and applies the configured thresholds.
-- If the testbench has a `cocotb:` block, `rtl_buddy` parses JUnit XML written by cocotb — no `PASS`/`FAIL` line needed. Run `rtl-buddy docs show concepts/cocotb` for setup.
-- Otherwise, `rtl_buddy` parses `artefacts/<test>/test.log` and expects one stdout line starting with `PASS` or `FAIL`.
-- When emitting `FAIL`, also print an `ERR:` or `FAT:` line because the default failure parser expects it.
-- Always use the `PASS` or `FAIL` markers as otherwise the result is ambiguous and shows `NA`.
-- Do not rely on simulator exit code alone for non-UVM pass/fail signalling.
+Pass/fail rules:
+- With `uvm:`, rtl_buddy parses the UVM Report Summary.
+- With a `cocotb:` testbench, it parses `cocotb_results.xml`.
+- Otherwise, `artefacts/<test>/test.log` must contain one stdout line starting with `PASS` or `FAIL`.
+- On `FAIL`, also print an `ERR:` or `FAT:` line.
+- If no PASS/FAIL marker appears, the result is `NA`; grep `rtl_buddy.log` for `postproc.no_markers`.
 
 ```systemverilog
 if (test_passed) $display("PASS smoke completed");
@@ -51,22 +36,10 @@ else begin
 end
 ```
 
-## Multi-suite discovery and CWD rules
+Artefacts:
+- `rtl_buddy.log` lives in the invocation directory.
+- `artefacts/<test>/` holds `compile.log`, `run.f`, `test.log`, `test.err`, `test.randseed`, and optional `coverage.dat`.
+- `randtest` writes per-iteration logs under `artefacts/<test>/run-0001/` and later numbered dirs.
+- `test.log`, `test.err`, and `test.randseed` at the suite root point to the latest run.
 
-- Discover suites with `rg --files -g '**/tests.yaml'`.
-- Run `test` / `randtest` from each suite directory.
-- Run `regression` from the repo root.
-- Summarize results per suite, not just globally.
-
-## Artefact locations
-
-- `rtl_buddy.log` — JSONL in `--machine` mode; written to the suite root (CWD you invoked from).
-- `artefacts/<test>/test.log`, `test.err`, `test.randseed`, `coverage.dat` — sim outputs for a single run.
-- `artefacts/<test>/compile.log`, `run.f` — compile outputs, always at the test root (not per run-id).
-- `artefacts/<test>/run-0001/test.log` etc. — per-iteration outputs for `randtest`.
-- Symlinks `test.log`, `test.err`, `test.randseed` at the suite root point at the latest run.
-- For multi-suite runs, each suite directory has its own `rtl_buddy.log` and `artefacts/`; report logs per suite.
-- Next docs: `rtl-buddy docs show reference/cli`, `rtl-buddy docs show reference/yaml`, `rtl-buddy docs show known-issues`
-
-## Bugs & Improvements
-If you discover a rtl_buddy bug or potential improvement, you can post an issue on GitHub <https://github.com/rtl-buddy/rtl_buddy/> documenting your findings, with permission from your user.
+For YAML schema, plugins, spec traceability, and CLI details, cite the docs instead of restating them.

--- a/src/rtl_buddy/skill/SKILL.md
+++ b/src/rtl_buddy/skill/SKILL.md
@@ -1,32 +1,47 @@
 ---
 name: rtl-buddy
-description: Use rtl_buddy to run SystemVerilog tests, regressions, filelists, coverage, and Verible checks. Trigger this skill when asked to run or debug rtl_buddy commands or interpret root_config.yaml, tests.yaml, models.yaml, regression.yaml, or specs.yaml.
+description: Use rtl_buddy to orchestrate SystemVerilog compile/sim workflows, randomized tests, regressions, filelist generation, and verible checks. Trigger this skill when asked to run or debug rtl_buddy commands or interpret root_config.yaml, tests.yaml, models.yaml, and regression.yaml.
 ---
 
 # rtl_buddy
 
-You are running rtl_buddy, a Verilog/SystemVerilog build and regression helper configured with YAML.
+You are running rtl_buddy a Verilog/SV build and regression helper configured with YAML.
 
-Start every run by reporting `rtl-buddy --version`.
+This skill covers agent-specific conventions. Use local docs if you need help:
 
-Use bundled docs before external references:
 - `rtl-buddy docs list`
 - `rtl-buddy docs show agents`
 - `rtl-buddy --machine docs show reference/yaml`
 
-Run all agent invocations with `--machine`. This makes `rtl_buddy.log` JSONL and keeps console output plain text.
+Use GitHub Pages at <https://rtl-buddy.github.io/rtl_buddy/> as a fallback reference.
 
-Working-directory rules:
-- Run `test` and `randtest` from the suite directory that contains `tests.yaml`.
-- Run `regression` from the project root.
-- Discover suites with `rg --files -g '**/tests.yaml'`.
+## Always use `--machine`
 
-Pass/fail rules:
-- With `uvm:`, rtl_buddy parses the UVM Report Summary.
-- With a `cocotb:` testbench, it parses `cocotb_results.xml`.
-- Otherwise, `artefacts/<test>/test.log` must contain one stdout line starting with `PASS` or `FAIL`.
-- On `FAIL`, also print an `ERR:` or `FAT:` line.
-- If no PASS/FAIL marker appears, the result is `NA`; grep `rtl_buddy.log` for `postproc.no_markers`.
+All agent invocations must use `--machine` so `rtl_buddy.log` is JSONL and console output is plain text.
+
+See `rtl-buddy docs show agents` or <https://rtl-buddy.github.io/rtl_buddy/latest/agents/> for the JSONL schema and exit codes (0 pass, 1 test failures, 2 fatal).
+
+## Version check
+
+Report `rtl-buddy --version` at the top of every run summary.
+This skill ships with the CLI, so its content matches the installed major. Surface any observed behavior differences in your summary.
+
+## YAML types
+
+rtl_buddy reads four YAML file types. See `rtl-buddy docs show reference/yaml` for exact schemas.
+
+- **`root_config.yaml`** — project root. Selects platform, builders, builder modes, verible path, coverage config, and the default `regression.yaml` path. Discovered by walking up from the invocation directory.
+- **`regression.yaml`** — lists the suite `tests.yaml` paths and reg-levels that `regression` iterates over.
+- **`tests.yaml`** — per-suite. Declares `testbenches` (TB filelists) and `tests` that map test names to a model, model_path, and testbench. Lives in each verification suite dir.
+- **`models.yaml`** — per-design. Maps model names to source/include filelists; consumed by `filelist` and referenced from `tests.yaml`.
+
+## Test Pass/fail detection
+- If `tests.yaml` sets `uvm:`, `rtl_buddy` parses the UVM Report Summary and applies the configured thresholds.
+- If the testbench has a `cocotb:` block, `rtl_buddy` parses JUnit XML written by cocotb — no `PASS`/`FAIL` line needed. Run `rtl-buddy docs show concepts/cocotb` for setup.
+- Otherwise, `rtl_buddy` parses `artefacts/<test>/test.log` and expects one stdout line starting with `PASS` or `FAIL`.
+- When emitting `FAIL`, also print an `ERR:` or `FAT:` line because the default failure parser expects it.
+- Always use the `PASS` or `FAIL` markers as otherwise the result is ambiguous and shows `NA`.
+- Do not rely on simulator exit code alone for non-UVM pass/fail signalling.
 
 ```systemverilog
 if (test_passed) $display("PASS smoke completed");
@@ -36,10 +51,22 @@ else begin
 end
 ```
 
-Artefacts:
-- `rtl_buddy.log` lives in the invocation directory.
-- `artefacts/<test>/` holds `compile.log`, `run.f`, `test.log`, `test.err`, `test.randseed`, and optional `coverage.dat`.
-- `randtest` writes per-iteration logs under `artefacts/<test>/run-0001/` and later numbered dirs.
-- `test.log`, `test.err`, and `test.randseed` at the suite root point to the latest run.
+## Multi-suite discovery and CWD rules
 
-For YAML schema, plugins, spec traceability, and CLI details, cite the docs instead of restating them.
+- Discover suites with `rg --files -g '**/tests.yaml'`.
+- Run `test` / `randtest` from each suite directory.
+- Run `regression` from the repo root.
+- Summarize results per suite, not just globally.
+
+## Artefact locations
+
+- `rtl_buddy.log` — JSONL in `--machine` mode; written to the suite root (CWD you invoked from).
+- `artefacts/<test>/test.log`, `test.err`, `test.randseed`, `coverage.dat` — sim outputs for a single run.
+- `artefacts/<test>/compile.log`, `run.f` — compile outputs, always at the test root (not per run-id).
+- `artefacts/<test>/run-0001/test.log` etc. — per-iteration outputs for `randtest`.
+- Symlinks `test.log`, `test.err`, `test.randseed` at the suite root point at the latest run.
+- For multi-suite runs, each suite directory has its own `rtl_buddy.log` and `artefacts/`; report logs per suite.
+- Next docs: `rtl-buddy docs show reference/cli`, `rtl-buddy docs show reference/yaml`, `rtl-buddy docs show known-issues`
+
+## Bugs & Improvements
+If you discover a rtl_buddy bug or potential improvement, you can post an issue on GitHub <https://github.com/rtl-buddy/rtl_buddy/> documenting your findings, with permission from your user.


### PR DESCRIPTION
## Summary

- normalize the install guide to use `uv run rb skill install` and `uv run rb skill install --project`, matching the rest of the docs and template examples
- keep the bundled skill content in its previous shape, including the requirement to use `--machine`

## Why

The docs had drifted on the command spelling for agent-skill install. This keeps the user-facing guidance consistent without changing the shipped skill content.

## Validation

- Not run in this environment
