### PR TITLE
fix: handle Verilator ≥5.048 per-metric coverage summary format (#46)

### DIFF
--- a/src/rtl_buddy/tools/vlog_cov.py
+++ b/src/rtl_buddy/tools/vlog_cov.py
@@ -1006,7 +1006,23 @@ class VlogCov:
         )
         return None
 
-      match = re.search(r"Total coverage \((\d+)/(\d+)\)\s+([0-9.]+)%", output)
+      # Verilator ≤5.042: "Total coverage (hit/total) X.XX%"
+      # Verilator ≥5.048: per-metric table "  toggle    : 63.1% ( 82/130)"
+      hit, total = None, None
+      legacy = re.search(r"Total coverage \((\d+)/(\d+)\)\s+([0-9.]+)%", output)
+      if legacy is not None:
+        hit = int(legacy.group(1))
+        total = int(legacy.group(2))
+      else:
+        per_metric = re.search(
+          r"^\s+" + re.escape(filter_type) + r"\s*:\s*[0-9.]+%\s*\(\s*(\d+)/(\d+)\)",
+          output,
+          re.MULTILINE,
+        )
+        if per_metric is not None:
+          hit = int(per_metric.group(1))
+          total = int(per_metric.group(2))
+
       if metric_name == "functional":
         manual_value = self._parse_user_annotated_summary(annotate_cwd)
         if manual_value is not None:
@@ -1021,7 +1037,7 @@ class VlogCov:
             method="annotated_user_lines",
           )
           return manual_value
-      if match is None:
+      if hit is None or total is None:
         if metric_name == "functional":
           log_event(
             logger,
@@ -1043,9 +1059,6 @@ class VlogCov:
           output=output.strip(),
         )
         return None
-
-      total = int(match.group(2))
-      hit = int(match.group(1))
       if total == 0:
         return None
       value = hit / total

--- a/tests/test_vlog_cov_metric_parsing.py
+++ b/tests/test_vlog_cov_metric_parsing.py
@@ -1,0 +1,92 @@
+"""
+Unit tests for _parse_verilator_metric output format handling.
+
+Verilator ≤5.042 emits:  "Total coverage (hit/total) X.XX%"
+Verilator ≥5.048 emits:  "  toggle    : 63.1% ( 82/130)"
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from rtl_buddy.tools.vlog_cov import VlogCov
+
+
+def _make_cov():
+  return VlogCov(simulator_name="verilator", use_lcov=True)
+
+
+def _run_parse(output_text, metric_name="toggle"):
+  """Drive _parse_verilator_metric with a fake subprocess result."""
+  cov = _make_cov()
+  fake_result = MagicMock()
+  fake_result.returncode = 0
+  fake_result.stdout = output_text
+  fake_result.stderr = ""
+
+  # _build_annotate_cwd needs a real-ish dat file; stub it out
+  with (
+    patch.object(cov, "_build_annotate_cwd", return_value="/tmp/fake_cwd"),
+    patch("subprocess.run", return_value=fake_result),
+    patch("tempfile.TemporaryDirectory") as mock_td,
+  ):
+    mock_td.return_value.__enter__ = MagicMock(return_value="/tmp/fake_tmpdir")
+    mock_td.return_value.__exit__ = MagicMock(return_value=False)
+    return cov._parse_verilator_metric("/fake/coverage.dat", metric_name)
+
+
+def test_legacy_format_total_coverage_line():
+  output = (
+    "Coverage Summary:\n"
+    "  toggle    : 63.1% ( 82/130)\n"
+    "Total coverage (82/130) 63.10%\n"
+  )
+  result = _run_parse(output)
+  assert result == pytest.approx(82 / 130)
+
+
+def test_new_format_per_metric_table():
+  output = (
+    "Coverage Summary:\n"
+    "  line      : 0.0% (  0/  0)\n"
+    "  toggle    : 63.1% ( 82/130)\n"
+    "  branch    : 0.0% (  0/  0)\n"
+    "  expr      : 0.0% (  0/  0)\n"
+  )
+  result = _run_parse(output)
+  assert result == pytest.approx(82 / 130)
+
+
+def test_new_format_fully_covered():
+  output = (
+    "Coverage Summary:\n"
+    "  toggle    : 100.0% (130/130)\n"
+  )
+  result = _run_parse(output)
+  assert result == pytest.approx(1.0)
+
+
+def test_new_format_zero_hit():
+  output = (
+    "Coverage Summary:\n"
+    "  toggle    : 0.0% (  0/130)\n"
+  )
+  result = _run_parse(output)
+  assert result == pytest.approx(0.0)
+
+
+def test_new_format_zero_total_returns_none():
+  output = (
+    "Coverage Summary:\n"
+    "  toggle    : 0.0% (  0/  0)\n"
+  )
+  result = _run_parse(output)
+  assert result is None
+
+
+def test_missing_metric_returns_none_with_warning(caplog):
+  import logging
+  output = "Coverage Summary:\n  line      : 75.0% ( 15/ 20)\n"
+  with caplog.at_level(logging.WARNING):
+    result = _run_parse(output, metric_name="toggle")
+  assert result is None
+  assert any("summary_missing" in r.message or "toggle" in r.message for r in caplog.records)


### PR DESCRIPTION
Verilator ≤5.042 reported aggregate toggle/user coverage as:
  Total coverage (82/130) 63.10%

Verilator ≥5.048 replaced this with a per-metric summary table:
  Coverage Summary:
    toggle    : 63.1% ( 82/130)
    ...

_parse_verilator_metric relied solely on the legacy regex, causing coverage.metric.summary_missing warnings and T:UNSP in the results table even though toggle data was fully collected in the .dat file and processed correctly into .info / coverview outputs.

Fix: try the legacy pattern first; if absent, match the per-metric table line using the filter_type key (e.g. "toggle", "user"). Both paths extract (hit, total) directly so the percentage precision difference between versions is irrelevant.

Adds test_vlog_cov_metric_parsing.py covering:
- legacy "Total coverage" format
- new per-metric table (full, partial, zero-hit, zero-total)
- missing metric → summary_missing warning

Verified end-to-end on Verilator 5.048 in rtl-buddy-ai-project sandbox suite: toggle column now shows T:0.63 instead of T:UNSP.