### PR TITLE
Expose suite_dir and artifact_dir to hook scripts

### DIFF
--- a/docs/concepts/plugins.md
+++ b/docs/concepts/plugins.md
@@ -31,6 +31,8 @@ The sweep hook runs before the test flow and expands a single test entry into mu
 | `logger` | Logger | Use this for all logging so output goes through `rtl_buddy`'s log system |
 | `test_cfg` | TestConfig (immutable) | The original test entry from `tests.yaml` |
 | `root_cfg` | RootConfig (mutable) | The loaded root config |
+| `suite_dir` | string | Absolute path to the directory containing `tests.yaml` |
+| `artifact_dir` | string | Artifact root for the incoming test name under `suite_dir/artefacts/` |
 | `out_test_cfgs` | list | **Assign** the expanded list of `TestConfig` objects here |
 | `__file__` | string | Absolute path to the current sweep script |
 
@@ -74,14 +76,21 @@ The pre-processing hook runs after sweep expansion but before the compilation st
 | `logger` | Logger | Use for all logging |
 | `test_cfg` | TestConfig (mutable) | Modify this to change compile/sim parameters |
 | `root_cfg` | RootConfig (mutable) | The loaded root config |
+| `suite_dir` | string | Absolute path to the directory containing `tests.yaml` |
+| `artifact_dir` | string | Artifact root for this test under `suite_dir/artefacts/` |
 | `__file__` | string | Absolute path to the current pre-processing script |
+
+Plusargs are still passed through verbatim. If a plusarg value should reference a suite-local file, resolve it explicitly against `suite_dir` in preproc. Output filenames that should land in the per-test artefact tree can remain relative to `artifact_dir`.
 
 **Example:**
 
 ```python
 # my_preproc.py
 import os
+from pathlib import Path
+
 test_cfg.plusargs["BUILD_ID"] = os.environ.get("CI_BUILD_ID", "local")
+test_cfg.plusargs["stimulus"] = str(Path(suite_dir) / "vectors" / "streaming_contract.txt")
 ```
 
 If a pre-processing script raises an exception, the affected test is marked as a setup failure and the rest of the run continues.

--- a/docs/concepts/tests.md
+++ b/docs/concepts/tests.md
@@ -167,6 +167,8 @@ For machine-readable logs (JSON Lines), use `--machine`. See [For Agents](../age
 
 Paths in `tests.yaml` (such as `model_path`) are resolved relative to the suite file's directory, not the invocation directory.
 
+Plusargs are passed to the simulator verbatim. If a plusarg should reference a suite-local file, resolve it explicitly in preproc using `suite_dir`. Bare output filenames can remain artifact-relative so they land under `artefacts/{test_name}/`.
+
 ## Full schema
 
 See [YAML Formats: tests.yaml](../reference/yaml.md#testsyaml) for the complete field reference.

--- a/docs/migrations/v2-to-v3.md
+++ b/docs/migrations/v2-to-v3.md
@@ -31,6 +31,8 @@ artefacts/{test_name}/run-0001/coverage.dat
 
 Compile outputs (`compile.log`, `run.f`) remain at `artefacts/{test_name}/` — they are shared across all iterations of the same test.
 
+Hook scripts that previously relied on suite-relative file paths resolving from the simulator working directory must now resolve those paths explicitly. Use the preproc hook's `suite_dir` variable for suite-local inputs; keep output filenames artifact-relative when they should land under `artefacts/{test_name}/`.
+
 ### Symlinks
 
 The convenience symlinks `test.log`, `test.err`, and `test.randseed` at the suite root still exist and still point to the latest run.

--- a/docs/reference/yaml.md
+++ b/docs/reference/yaml.md
@@ -247,7 +247,7 @@ cocotb writes a JUnit XML results file (`cocotb_results.xml`) instead of `PASS`/
 - `plusargs`: converted to `+KEY` (no value) or `+KEY=VALUE`.
 - `sim_timeout`: applies per test run, not per iteration in `randtest`.
 - `sweep.path`: Python script that expands one test entry into a list of `TestConfig` objects. See [Plugins](../concepts/plugins.md).
-- `preproc.path`: Python script executed before compile; can mutate `test_cfg` and `root_cfg`. See [Plugins](../concepts/plugins.md).
+- `preproc.path`: Python script executed before compile; can mutate `test_cfg` and `root_cfg`, and receives `suite_dir` plus `artifact_dir` in its execution namespace. See [Plugins](../concepts/plugins.md).
 
 ## Path semantics and cwd
 
@@ -255,6 +255,7 @@ cocotb writes a JUnit XML results file (`cocotb_results.xml`) instead of `PASS`/
 - Per-test artifacts are written to `artefacts/{test_name}/` under the suite root. Single runs write `test.log`, `test.err`, `test.randseed`, `compile.log`, `run.f`, and (if enabled) `coverage.dat` there directly. Repeated runs (`randtest`) write sim outputs into numbered subdirectories: `artefacts/{test_name}/run-0001/`, etc.
 - `test` and `randtest` do **not** automatically change into the suite directory. Run from the suite directory, or use `--test-config` with a full path.
 - `regression` does `chdir` into each suite directory before executing.
+- Preproc plusargs are passed to the simulator verbatim. Resolve suite-local input paths explicitly against `suite_dir`; keep output filenames artifact-relative when they should land under `artefacts/{test_name}/`.
 - For portable configs in multi-suite repos, make paths in `tests.yaml` explicit and verify they resolve correctly from the intended invocation directory.
 
 ---

--- a/src/rtl_buddy/rtl_buddy.py
+++ b/src/rtl_buddy/rtl_buddy.py
@@ -8,6 +8,7 @@ import os
 import subprocess
 import sys
 import json
+from pathlib import Path
 import typer
 from importlib.metadata import version
 from typing_extensions import Annotated
@@ -23,6 +24,7 @@ from .runner.test_runner import RunDepth, TestRunner
 from .seed_mode import SeedMode
 from .skill_install import app as skill_app
 from .tools.coverage import CoverageReporter
+from .tools.artifact_paths import test_artifact_dir
 from .tools.spec_trace import (
   all_spec_blocks,
   build_coverage_map,
@@ -343,7 +345,7 @@ class RtlBuddy():
     for run_id in run_ids:
       suite_results.append({'test_name': test_name, 'randmode_i': run_id, 'results': test_results})
 
-  def _expand_tests_with_sweep(self, test_cfg):
+  def _expand_tests_with_sweep(self, test_cfg, suite_dir):
     script_path = test_cfg.get_sweep_path()
     if script_path is None:
       return [test_cfg], None
@@ -356,6 +358,8 @@ class RtlBuddy():
       "TestConfig": TestConfig,
       "test_cfg": test_cfg,
       "root_cfg": self.root_cfg,
+      "suite_dir": suite_dir,
+      "artifact_dir": str(test_artifact_dir(suite_dir, test_cfg.get_name())),
       "out_test_cfgs": [],
       "__file__": os.path.abspath(script_path),
     }
@@ -369,7 +373,7 @@ class RtlBuddy():
     log_event(logger, logging.INFO, "sweep.completed", test=test_cfg.name, script=script_path, expanded=len(ns["out_test_cfgs"]))
     return ns["out_test_cfgs"], None
 
-  def _run_test_cfg_for_run_ids(self, test_cfg, run_ids, seed_mode: SeedMode, replay_run_id, test_runner_mode):
+  def _run_test_cfg_for_run_ids(self, test_cfg, run_ids, seed_mode: SeedMode, replay_run_id, test_runner_mode, suite_dir):
     test_runner = TestRunner(
       name=self.name+"/testrunner",
       root_cfg=self.root_cfg,
@@ -379,7 +383,8 @@ class RtlBuddy():
       seed_mode=seed_mode,
       replay_run_id=replay_run_id,
       rtl_builder_mode=self.rtl_builder_mode,
-      run_depth=self.run_depth)
+      run_depth=self.run_depth,
+      suite_dir=suite_dir)
 
     if len(run_ids) == 1:
       return [test_runner.run()]
@@ -406,6 +411,7 @@ class RtlBuddy():
       run_ids = [None]
 
     tests = suite_cfg.get_tests(test_name)
+    suite_dir = str(Path(suite_cfg.get_path()).resolve().parent)
     suite_results = []
     for t in tests:
       t_lvl = t.get_reglvl(self.builder)
@@ -419,7 +425,7 @@ class RtlBuddy():
         self._append_skip_results(t.name, f'lvl {t_lvl} < cmd start_level {start_level}', run_ids, suite_results)
         continue
 
-      expanded_tests, sweep_error = self._expand_tests_with_sweep(t)
+      expanded_tests, sweep_error = self._expand_tests_with_sweep(t, suite_dir=suite_dir)
       if sweep_error is not None:
         self._append_setup_results(t.name, sweep_error, run_ids, suite_results)
         continue
@@ -430,7 +436,8 @@ class RtlBuddy():
           run_ids=run_ids,
           seed_mode=seed_mode,
           replay_run_id=replay_run_id,
-          test_runner_mode=test_runner_mode)
+          test_runner_mode=test_runner_mode,
+          suite_dir=suite_dir)
         self._append_results(expanded_test_cfg.name, run_ids, run_results, suite_results)
     return suite_results
 

--- a/src/rtl_buddy/runner/test_runner.py
+++ b/src/rtl_buddy/runner/test_runner.py
@@ -22,7 +22,7 @@ class RunDepth(Enum):
 
 class TestRunner:
 
-  def __init__(self, name, root_cfg, test_cfg, rtl_builder_mode, test_runner_mode, run_id=None, seed_mode:SeedMode=SeedMode.DEFAULT, replay_run_id=None, run_depth=None):
+  def __init__(self, name, root_cfg, test_cfg, rtl_builder_mode, test_runner_mode, run_id=None, seed_mode:SeedMode=SeedMode.DEFAULT, replay_run_id=None, run_depth=None, suite_dir=None):
     """
     Run tests based on config
     Handles Verilog compilation
@@ -37,6 +37,7 @@ class TestRunner:
     self.run_depth = run_depth
     self.rtl_builder_mode = rtl_builder_mode
     self.test_runner_mode = test_runner_mode
+    self.suite_dir = suite_dir
 
   def _create_vlog_sim(self):
     sim_mode = {'sim_to_stdout': True}
@@ -50,7 +51,8 @@ class TestRunner:
       rtl_builder_mode=self.rtl_builder_mode,
       sim_mode=sim_mode,
       run_id=self.run_id,
-      replay_run_id=self.replay_run_id)
+      replay_run_id=self.replay_run_id,
+      suite_dir=self.suite_dir)
 
   def run(self):
     # compile simulation exe

--- a/src/rtl_buddy/tools/artifact_paths.py
+++ b/src/rtl_buddy/tools/artifact_paths.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+import re
+
+
+def sanitize_artifact_component(name: str) -> str:
+  """
+  Return a filesystem-safe artifact path component.
+  """
+  return re.sub(r"[^A-Za-z0-9_.-]", "_", name)
+
+
+def test_artifact_dir(suite_dir: str | Path, test_name: str, run_id: int | None = None) -> Path:
+  """
+  Return the per-test artifact directory rooted under the suite directory.
+  """
+  artifact_dir = Path(suite_dir) / "artefacts" / sanitize_artifact_component(test_name)
+  if run_id is not None:
+    artifact_dir /= f"run-{run_id:04d}"
+  return artifact_dir
+
+
+def test_build_dir_name(test_name: str) -> str:
+  """
+  Return the simulator build directory name for a test.
+  """
+  return f"obj_dir_{sanitize_artifact_component(test_name)}"
+
+
+test_artifact_dir.__test__ = False
+test_build_dir_name.__test__ = False

--- a/src/rtl_buddy/tools/vlog_cov.py
+++ b/src/rtl_buddy/tools/vlog_cov.py
@@ -20,6 +20,7 @@ from collections import defaultdict
 
 from ..config.root import RootConfig
 from ..logging_utils import log_event
+from .artifact_paths import sanitize_artifact_component
 
 
 def _fmt_cov(value):
@@ -102,7 +103,7 @@ class VlogCov:
     """
     Return a filesystem-safe coverage artifact name.
     """
-    return re.sub(r"[^A-Za-z0-9_.-]", "_", name)
+    return sanitize_artifact_component(name)
 
   def _extract_raw_source_paths(self, raw_path):
     """

--- a/src/rtl_buddy/tools/vlog_sim.py
+++ b/src/rtl_buddy/tools/vlog_sim.py
@@ -12,13 +12,13 @@ import random
 import signal
 import logging
 logger = logging.getLogger(__name__)
-import re
 from ..seed_mode import SeedMode
 
 from .vlog_filelist import VlogFilelist
 from .vlog_post import VlogPost
 from .vlog_post import UvmVlogPost
 from .vlog_cov import VlogCov
+from .artifact_paths import test_artifact_dir, test_build_dir_name
 
 import time
 import pprint
@@ -40,7 +40,7 @@ class VlogSim:
   """
 
   # TODO: Replace suite_cfg, test_name with test_info and testbench
-  def __init__(self, name, root_cfg, test_cfg, rtl_builder_mode, sim_mode, run_id=None, replay_run_id=None):
+  def __init__(self, name, root_cfg, test_cfg, rtl_builder_mode, sim_mode, run_id=None, replay_run_id=None, suite_dir=None):
     """
     compile and execute sim for given test
     """
@@ -56,7 +56,7 @@ class VlogSim:
     self.replay_run_id = replay_run_id
     self.testbench = self.test_cfg.get_testbench()
     self.vlog_post = None
-    self.suite_work_dir = os.path.abspath(os.getcwd())
+    self.suite_work_dir = os.path.abspath(suite_dir) if suite_dir is not None else os.path.abspath(os.getcwd())
 
     output_dir = Path(self.suite_work_dir) / "artefacts"
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -67,13 +67,13 @@ class VlogSim:
     """
     Return a filesystem-safe tag derived from the test name.
     """
-    return re.sub(r"[^A-Za-z0-9_.-]", "_", self.test_name)
+    return test_artifact_dir(self.suite_work_dir, self.test_name).name
 
   def _get_build_dir(self):
     """
     Return the simulator build directory for this test.
     """
-    return f"obj_dir_{self._get_build_tag()}"
+    return test_build_dir_name(self.test_name)
 
   def _get_compile_work_dir(self):
     return self._get_artifact_dir()
@@ -91,10 +91,7 @@ class VlogSim:
     return str(Path(self._get_compile_work_dir()) / simv_path)
 
   def _get_artifact_dir(self, run_id=None):
-    artifact_dir = Path(self.output_dir) / self._get_build_tag()
-    if run_id is not None:
-      artifact_dir /= f"run-{run_id:04d}"
-    return str(artifact_dir)
+    return str(test_artifact_dir(self.suite_work_dir, self.test_name, run_id=run_id))
 
   def _ensure_artifact_dir(self, run_id=None):
     artifact_dir = Path(self._get_artifact_dir(run_id=run_id))
@@ -210,6 +207,8 @@ class VlogSim:
       "logger"   : logger, 
       "test_cfg" : self.test_cfg,
       "root_cfg" : self.root_cfg,
+      "suite_dir": self.suite_work_dir,
+      "artifact_dir": self._get_artifact_dir(),
       "__file__" : os.path.abspath(script_path),
     }
     try:

--- a/tests/test_setup_failures.py
+++ b/tests/test_setup_failures.py
@@ -1,4 +1,5 @@
 from contextlib import nullcontext
+from pathlib import Path
 
 from rtl_buddy.errors import FilelistError
 from rtl_buddy.logging_utils import setup_logging
@@ -58,13 +59,20 @@ class DummySweepTest:
   def get_sweep_path(self):
     return self._script_path
 
+  def get_name(self):
+    return self.name
+
 
 class DummySuiteCfg:
-  def __init__(self, tests):
+  def __init__(self, tests, path="tests.yaml"):
     self._tests = tests
+    self._path = path
 
   def get_tests(self, _test_name=None):
     return self._tests
+
+  def get_path(self):
+    return self._path
 
 
 def test_test_runner_returns_setup_fail_on_preproc_error(tmp_path, monkeypatch):
@@ -117,7 +125,10 @@ def test_sweep_failure_becomes_setup_fail_result(tmp_path):
   rb.run_depth = RunDepth.POST
   rb.rtl_builder_mode = "debug"
 
-  suite_results = rb._do_test_suite(DummySuiteCfg([DummySweepTest(str(sweep_script))]), run_ids=[None])
+  suite_results = rb._do_test_suite(
+    DummySuiteCfg([DummySweepTest(str(sweep_script))], path=str(tmp_path / "tests.yaml")),
+    run_ids=[None],
+  )
 
   assert len(suite_results) == 1
   result = suite_results[0]["results"]
@@ -277,8 +288,8 @@ def test_vlog_sim_missing_hier_seed_file_is_nonfatal(tmp_path, monkeypatch):
   returncode = sim.execute()
 
   assert returncode == 0
-  assert (tmp_path / "logs" / "basic.randseed").read_text() == "31310\n"
-  assert "hierarchical seed file missing at HierInstanceSeed.txt" in log_path.read_text()
+  assert (tmp_path / "artefacts" / "basic" / "test.randseed").read_text() == "31310\n"
+  assert "hierarchical seed file missing at" in log_path.read_text()
 
 
 def test_preproc_script_receives___file__(tmp_path, monkeypatch):
@@ -306,6 +317,33 @@ def test_preproc_script_receives___file__(tmp_path, monkeypatch):
   assert sentinel.read_text() == "my_preproc.py"
 
 
+def test_preproc_script_receives_suite_dir_and_artifact_dir(tmp_path):
+  setup_logging(color=False, log_path=tmp_path / "rtl_buddy.log")
+
+  suite_dir = tmp_path / "suite dir"
+  suite_dir.mkdir()
+  script_path = suite_dir / "my_preproc.py"
+  sentinel = tmp_path / "preproc_ctx.txt"
+  script_path.write_text(
+    "from pathlib import Path\n"
+    f"Path({str(sentinel)!r}).write_text(suite_dir + '\\n' + artifact_dir)\n"
+  )
+
+  sim = VlogSim(
+    name="rtl_buddy/vlog_sim",
+    root_cfg=DummyRootCfg(),
+    test_cfg=DummyPreprocTestCfg(str(script_path)),
+    rtl_builder_mode="reg",
+    sim_mode={"sim_to_stdout": False},
+    suite_dir=str(suite_dir),
+  )
+
+  error = sim.pre()
+
+  assert error is None
+  assert sentinel.read_text() == f"{suite_dir}\n{suite_dir / 'artefacts' / 'basic'}"
+
+
 def test_sweep_script_receives___file__(tmp_path):
   setup_logging(color=False, log_path=tmp_path / "rtl_buddy.log")
   sweep_script = tmp_path / "sweep.py"
@@ -321,8 +359,67 @@ def test_sweep_script_receives___file__(tmp_path):
   rb.run_depth = RunDepth.POST
   rb.rtl_builder_mode = "debug"
 
-  test_cfgs, error = rb._expand_tests_with_sweep(DummySweepTest(str(sweep_script)))
+  test_cfgs, error = rb._expand_tests_with_sweep(DummySweepTest(str(sweep_script)), suite_dir=str(tmp_path))
 
   assert error is None
   assert len(test_cfgs) == 1
   assert test_cfgs[0] is not None
+
+
+def test_sweep_script_receives_suite_dir_and_artifact_dir(tmp_path):
+  setup_logging(color=False, log_path=tmp_path / "rtl_buddy.log")
+  suite_dir = tmp_path / "suite dir"
+  suite_dir.mkdir()
+  sweep_script = tmp_path / "sweep.py"
+  sentinel = tmp_path / "sweep_ctx.txt"
+  sweep_script.write_text(
+    "from pathlib import Path\n"
+    f"Path({str(sentinel)!r}).write_text(suite_dir + '\\n' + artifact_dir)\n"
+    "out_test_cfgs = [test_cfg]\n"
+  )
+
+  rb = RtlBuddy(name="rtl_buddy")
+  rb.builder = "vcs"
+  rb.root_cfg = object()
+  rb.run_depth = RunDepth.POST
+  rb.rtl_builder_mode = "debug"
+
+  test_cfgs, error = rb._expand_tests_with_sweep(DummySweepTest(str(sweep_script)), suite_dir=str(suite_dir))
+
+  assert error is None
+  assert len(test_cfgs) == 1
+  assert sentinel.read_text() == f"{suite_dir}\n{suite_dir / 'artefacts' / 'basic'}"
+
+
+def test_suite_dir_for_test_runner_comes_from_suite_cfg_path(tmp_path, monkeypatch):
+  setup_logging(color=False, log_path=tmp_path / "rtl_buddy.log")
+  suite_dir = tmp_path / "suite-dir"
+  suite_dir.mkdir()
+  invocation_dir = tmp_path / "invocation"
+  invocation_dir.mkdir()
+
+  captured = {}
+
+  class CapturingRunner:
+    def __init__(self, **kwargs):
+      captured["suite_dir"] = kwargs["suite_dir"]
+
+    def run(self):
+      return SetupFailResults(name="dummy", desc="captured")
+
+  monkeypatch.chdir(invocation_dir)
+  monkeypatch.setattr("rtl_buddy.rtl_buddy.TestRunner", CapturingRunner)
+
+  rb = RtlBuddy(name="rtl_buddy")
+  rb.builder = "vcs"
+  rb.root_cfg = object()
+  rb.run_depth = RunDepth.POST
+  rb.rtl_builder_mode = "debug"
+
+  suite_results = rb._do_test_suite(
+    DummySuiteCfg([DummySweepTest(None)], path=str(suite_dir / "tests.yaml")),
+    run_ids=[None],
+  )
+
+  assert len(suite_results) == 1
+  assert captured["suite_dir"] == str(suite_dir.resolve())

--- a/tests/test_vlog_sim_paths.py
+++ b/tests/test_vlog_sim_paths.py
@@ -3,6 +3,8 @@ from pathlib import Path
 from types import SimpleNamespace
 
 from rtl_buddy.seed_mode import SeedMode
+from rtl_buddy.tools.artifact_paths import sanitize_artifact_component, test_artifact_dir, test_build_dir_name
+from rtl_buddy.tools.vlog_cov import VlogCov
 from rtl_buddy.tools import vlog_sim as vlog_sim_module
 
 
@@ -295,3 +297,12 @@ def test_vlog_sim_multiple_runs_keep_runtime_side_files_separate(tmp_path, monke
 
   assert (tmp_path / "artefacts" / "basic" / "run-0001" / "wave.vcd").read_text() == "run=1\n"
   assert (tmp_path / "artefacts" / "basic" / "run-0002" / "wave.vcd").read_text() == "run=2\n"
+
+
+def test_artifact_path_helpers_match_existing_sanitization():
+  assert sanitize_artifact_component("basic") == "basic"
+  assert sanitize_artifact_component("with spaces/slash:punct") == "with_spaces_slash_punct"
+  assert test_artifact_dir("/tmp/suite", "with spaces/slash:punct") == Path("/tmp/suite/artefacts/with_spaces_slash_punct")
+  assert test_artifact_dir("/tmp/suite", "basic", run_id=7) == Path("/tmp/suite/artefacts/basic/run-0007")
+  assert test_build_dir_name("with spaces/slash:punct") == "obj_dir_with_spaces_slash_punct"
+  assert VlogCov(simulator_name="vcs")._sanitize_artifact_name("with spaces/slash:punct") == "with_spaces_slash_punct"


### PR DESCRIPTION
## Summary

Fixes #42.

This change makes suite-relative path handling explicit for hook scripts instead of relying on the simulator working directory.

## What changed

- Added `src/rtl_buddy/tools/artifact_paths.py` as the shared home for:
  - artifact-path sanitization
  - per-test artefact root construction
  - simulator build directory naming
- Threaded canonical `suite_dir` from `SuiteConfig.get_path()` through `RtlBuddy`, `TestRunner`, and `VlogSim` so hook execution does not depend on the invocation cwd.
- Exposed `suite_dir` and `artifact_dir` in both hook namespaces:
  - `preproc` now receives the suite directory and per-test artefact root
  - `sweep` now receives the suite directory and the incoming test's artefact root
- Refactored `VlogSim` to use the shared helper for sanitized artefact paths and build directory names.
- Refactored `VlogCov` to delegate artifact-name sanitization to the same shared helper so the regex logic lives in one place.

## Why this solves issue #42

Issue #42 comes from preproc scripts generating suite-local files and then storing suite-relative plusarg paths such as `vectors/generated.txt`. Simulation now runs from `artefacts/<test>/`, so those relative paths break even though the generated file exists under the suite directory.

With this change, hook scripts are given the correct runtime context directly:

- use `suite_dir` to resolve suite-local input paths before putting them into plusargs
- use `artifact_dir` for outputs that should land in the test artefact tree

That preserves the current artefact-isolated execution model while removing the need for hook authors to guess the simulator cwd.

## Docs and tests

- Updated hook docs, test behavior docs, migration notes, and the YAML reference to describe when to use `suite_dir` vs `artifact_dir`.
- Added regression coverage for:
  - `suite_dir` / `artifact_dir` injection into preproc and sweep
  - deriving `suite_dir` from the suite config path rather than invocation cwd
  - shared artefact-path sanitization behavior
  - unchanged coverage sanitization behavior

## Verification

```bash
uv run pytest tests/test_vlog_sim_paths.py tests/test_setup_failures.py tests/test_coverage_paths.py -q
```

Focused manual repro in the template suite:

```bash
cd rtl-buddy-project-template/verif/issue42_repro
../../.venv/bin/python -m rtl_buddy test preproc_path_bug
```

The repro fails with a suite-relative `stimulus=vectors/generated.txt` plusarg and passes once the preproc script resolves the generated file against `suite_dir`.