### PR TITLE
feat: add rb wave command with Surfer WCP integration (#49)

### DIFF
--- a/docs/concepts/root-config.md
+++ b/docs/concepts/root-config.md
@@ -65,6 +65,15 @@ Defines simulation tool configurations. Each entry has:
 
 Defines Verible tool configurations for lint and syntax checks.
 
+**`cfg-surfer`** *(optional)*
+
+Configures the Surfer waveform viewer for `rb wave`. Fields:
+
+- `path`: bare executable name (resolved via PATH, e.g. `"surfer"`) or a relative/absolute path to the binary
+- `wcp-port`: TCP port rtl-buddy listens on; Surfer connects with `--wcp-initiate` (default: `54321`)
+- `editor-cmd`: command template with `%f` (file path) and `%l` (line number) placeholders — e.g. `"vim +%l %f"`, `"code --goto %f:%l"`
+- `editor-terminal`: how to open terminal editors — `tmux` (new tmux window), `iterm2`, `terminal` (macOS Terminal.app), or `""` to run the command directly (for GUI editors)
+
 **`cfg-rtl-reg`**
 
 Sets the default path to `regressions.yaml` used by `rtl-buddy regression` when `--reg-config` is not specified.

--- a/docs/concepts/root-config.md
+++ b/docs/concepts/root-config.md
@@ -74,6 +74,8 @@ Configures the Surfer waveform viewer for `rb wave`. Fields:
 - `editor-cmd`: command template with `%f` (file path) and `%l` (line number) placeholders — e.g. `"vim +%l %f"`, `"code --goto %f:%l"`
 - `editor-terminal`: how to open terminal editors — `tmux` (new tmux window), `iterm2`, `terminal` (macOS Terminal.app), or `""` to run the command directly (for GUI editors)
 
+`rb wave <test>` looks for a signal layout file at `<test>.surfer` in the same directory as `tests.yaml` (e.g. `verif/sandbox/basic.surfer`). If found it is passed to Surfer via `-c`; if not, Surfer opens with no pre-loaded signals. If no FST exists for the test, `rb wave` runs a debug sim automatically before launching Surfer.
+
 **`cfg-rtl-reg`**
 
 Sets the default path to `regressions.yaml` used by `rtl-buddy regression` when `--reg-config` is not specified.

--- a/docs/concepts/root-config.md
+++ b/docs/concepts/root-config.md
@@ -70,7 +70,7 @@ Defines Verible tool configurations for lint and syntax checks.
 Configures the Surfer waveform viewer for `rb wave`. Fields:
 
 - `path`: bare executable name (resolved via PATH, e.g. `"surfer"`) or a relative/absolute path to the binary
-- `wcp-port`: TCP port rtl-buddy listens on; Surfer connects with `--wcp-initiate` (default: `54321`)
+- `wcp-port`: TCP port rtl-buddy listens on; Surfer connects with `--wcp-initiate` (default: `0` — OS auto-assigns a free port)
 - `editor-cmd`: command template with `%f` (file path) and `%l` (line number) placeholders — e.g. `"vim +%l %f"`, `"code --goto %f:%l"`
 - `editor-terminal`: how to open terminal editors — `tmux` (new tmux window), `iterm2`, `terminal` (macOS Terminal.app), or `""` to run the command directly (for GUI editors)
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -188,6 +188,24 @@ Usage: rtl-buddy verible [OPTIONS] CMD [VERIBLE_ARGS]...
 ╰──────────────────────────────────────────────────────────────────────────────────────╯
 ```
 
+## wave
+
+```text
+Usage: rtl-buddy wave [OPTIONS] TEST_NAME                                              
+                                                                                        
+ open waveform viewer for a test                                                        
+                                                                                        
+╭─ Arguments ──────────────────────────────────────────────────────────────────────────╮
+│ *    test_name      TEXT  name of test to open waveform for [required]               │
+╰──────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────────────╮
+│ --test-config  -c      TEXT  tests.yaml to use [default: tests.yaml]                 │
+│ --surfer               TEXT  cfg-surfer entry name [default: surfer-default]         │
+│ --resim                      force re-run of debug sim even if FST exists            │
+│ --help                       Show this message and exit.                             │
+╰──────────────────────────────────────────────────────────────────────────────────────╯
+```
+
 ## skill
 
 ```text

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -47,6 +47,7 @@ Usage: rtl-buddy [OPTIONS] COMMAND [ARGS]...
 │ regression  run rtl regression                                                       │
 │ filelist    generate filelists using models.yaml                                     │
 │ verible     run verible cmd                                                          │
+│ wave        open waveform viewer for a test                                          │
 │ skill       manage the rtl_buddy agent skill                                         │
 │ docs        browse bundled documentation                                             │
 │ spec        spec traceability commands                                               │

--- a/docs/reference/yaml.md
+++ b/docs/reference/yaml.md
@@ -63,7 +63,7 @@ cfg-coverview:
 cfg-surfer:
   - name: "surfer-default"
     path: "surfer"              # bare name → found via PATH; or relative/absolute path
-    wcp-port: 54321
+    wcp-port: 0         # 0 = OS auto-assigns a free port
     editor-cmd: "vim +%l %f"   # %f = file path, %l = line number
     editor-terminal: "tmux"    # tmux | iterm2 | terminal | "" (empty = run cmd directly)
 

--- a/docs/reference/yaml.md
+++ b/docs/reference/yaml.md
@@ -60,6 +60,13 @@ cfg-coverview:
     config:
       # inline Coverview JSON configuration values
 
+cfg-surfer:
+  - name: "surfer-default"
+    path: "surfer"              # bare name → found via PATH; or relative/absolute path
+    wcp-port: 54321
+    editor-cmd: "vim +%l %f"   # %f = file path, %l = line number
+    editor-terminal: "tmux"    # tmux | iterm2 | terminal | "" (empty = run cmd directly)
+
 cfg-rtl-reg:
   reg-cfg-path: "design/regression.yaml"
 ```
@@ -71,6 +78,7 @@ cfg-rtl-reg:
 - `--builder-mode` selects which named `builder-opts` entry to use for compile-time and run-time flags.
 - `cfg-coverage` is keyed by simulator family (e.g. `verilator`). `use-lcov: true` enables `.info` export and LCOV HTML generation when `--coverage-html` is used.
 - `cfg-coverview` is keyed by simulator family. `generate-tables` sets the coverage type for Coverview tables. `config` is a dict of inline Coverview JSON configuration values.
+- `cfg-surfer` configures the Surfer waveform viewer used by `rb wave`. `path` is a bare executable name (resolved via PATH) or a relative/absolute path to the binary. `editor-cmd` supports `%f` (file path) and `%l` (line number) placeholders. `editor-terminal` controls how the editor is launched: `tmux` opens a new tmux window, `iterm2` and `terminal` use AppleScript, empty string runs the command directly (suitable for GUI editors like VS Code).
 - `cfg-rtl-reg.reg-cfg-path` is the fallback regression file for `rtl-buddy regression` when no `./regression.yaml` exists in the cwd.
 
 ---

--- a/scripts/gen_cli_reference.py
+++ b/scripts/gen_cli_reference.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).parent.parent
 OUTPUT = REPO_ROOT / "docs" / "reference" / "cli.md"
-SUBCOMMANDS = ["test", "randtest", "regression", "filelist", "verible", "skill", "docs", "spec"]
+SUBCOMMANDS = ["test", "randtest", "regression", "filelist", "verible", "wave", "skill", "docs", "spec"]
 
 HEADER = """\
 ---

--- a/src/rtl_buddy/config/__init__.py
+++ b/src/rtl_buddy/config/__init__.py
@@ -16,3 +16,4 @@ from .spec import SpecConfig, SpecBlock, SpecCoverageItem
 from .verible import VeribleConfig
 from .coverage import CoverageConfig, CoverageConfigFile
 from .coverview import CoverviewConfig, CoverviewConfigFile
+from .surfer import SurferConfig

--- a/src/rtl_buddy/config/root.py
+++ b/src/rtl_buddy/config/root.py
@@ -15,6 +15,7 @@ from .rtl import RtlBuilderConfig
 from .verible import VeribleConfig, VeribleConfigFile
 from .coverage import CoverageConfig, CoverageConfigFile
 from .coverview import CoverviewConfig, CoverviewConfigFile
+from .surfer import SurferConfig, SurferConfigFile
 from ..errors import FatalRtlBuddyError
 from ..logging_utils import log_event
 
@@ -77,6 +78,7 @@ class RootConfigFile:
   veribles: list[VeribleConfigFile] = field(rename='cfg-verible', default_factory=list)
   coverages: list[CoverageConfigFile] = field(rename='cfg-coverage', default_factory=list)
   coverviews: list[CoverviewConfigFile] = field(rename='cfg-coverview', default_factory=list)
+  surfers: list[SurferConfigFile] = field(rename='cfg-surfer', default_factory=list)
 
 class RootConfig:
   """
@@ -112,6 +114,7 @@ class RootConfig:
     self.verible_cfgs = dict()
     self.coverage_cfgs = dict()
     self.coverview_cfgs = dict()
+    self.surfer_cfgs = dict()
     self.platform_cfg = None
     self.reg_cfg = None # initialise later when get_rtl_reg_cfg is called
 
@@ -138,6 +141,11 @@ class RootConfig:
       }
       self.coverview_cfgs = {
         cfg.name: cfg.initialise(self.root_cfg_path) for cfg in data.coverviews
+      }
+
+      # Populate surfer configs
+      self.surfer_cfgs = {
+        cfg.name: cfg.initialise(self.root_cfg_path) for cfg in data.surfers
       }
 
       # Initialise regression config
@@ -271,6 +279,17 @@ class RootConfig:
     """
     cfg = self.get_coverage_cfg(simulator_name)
     return False if cfg is None else cfg.get_use_lcov()
+
+  def get_surfer_cfg(self, name: str = 'surfer-default') -> 'SurferConfig | None':
+    """
+    Get Surfer configuration by name.
+
+    Args:
+      name (str): cfg-surfer entry name. Defaults to "surfer-default".
+    Returns:
+      cfg (SurferConfig|None): Matching Surfer configuration, if present.
+    """
+    return self.surfer_cfgs.get(name)
 
   def get_coverview_cfg(self, simulator_name:str):
     """

--- a/src/rtl_buddy/config/surfer.py
+++ b/src/rtl_buddy/config/surfer.py
@@ -54,7 +54,7 @@ class SurferConfig:
 class SurferConfigFile:
   name: str
   path: str = 'surfer'
-  wcp_port: int = field(rename='wcp-port', default=54321)
+  wcp_port: int = field(rename='wcp-port', default=0)  # 0 = OS auto-assigns a free port
   editor_cmd: str = field(rename='editor-cmd', default='vim +%l %f')
   editor_terminal: str = field(rename='editor-terminal', default='')
 

--- a/src/rtl_buddy/config/surfer.py
+++ b/src/rtl_buddy/config/surfer.py
@@ -1,0 +1,78 @@
+# rtl-buddy
+# vim: set sw=2:ts=2:et:
+#
+# Copyright 2024 rtl_buddy contributors
+#
+import logging
+import os
+import shutil
+import pprint
+from dataclasses import dataclass
+from serde import serde, field
+from ..logging_utils import log_event
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SurferConfig:
+  """
+  Configuration for launching Surfer and its WCP client.
+
+  Attributes:
+    name (str): Unique identifier.
+    path (str): Surfer executable path or bare name (resolved via PATH).
+    wcp_port (int): TCP port rtl-buddy listens on; Surfer connects with --wcp-initiate.
+    editor_cmd (str): Editor command template; %f = file path, %l = line number.
+    editor_terminal (str): Terminal emulator for terminal editors ("iterm2", "terminal", or "").
+    root_cfg_path (str): Path of root_config.yaml, used for relative path resolution.
+    available (bool): True when the Surfer executable was found at initialise time.
+  """
+  name: str
+  path: str
+  wcp_port: int
+  editor_cmd: str
+  editor_terminal: str
+  root_cfg_path: str
+  available: bool
+
+  def get_surfer_exe(self) -> str:
+    """Return absolute path to the Surfer executable."""
+    if os.sep in self.path or self.path.startswith('.'):
+      return os.path.join(os.path.dirname(self.root_cfg_path), self.path)
+    return shutil.which(self.path) or self.path
+
+  def format_editor_cmd(self, filepath: str, lineno: int) -> str:
+    """Substitute %f and %l placeholders in editor_cmd."""
+    return self.editor_cmd.replace('%f', filepath).replace('%l', str(lineno))
+
+  def __str__(self):
+    return pprint.pformat(self)
+
+
+@serde
+class SurferConfigFile:
+  name: str
+  path: str = 'surfer'
+  wcp_port: int = field(rename='wcp-port', default=54321)
+  editor_cmd: str = field(rename='editor-cmd', default='vim +%l %f')
+  editor_terminal: str = field(rename='editor-terminal', default='')
+
+  def initialise(self, root_cfg_path: str) -> SurferConfig:
+    cfg = SurferConfig(
+      name=self.name,
+      path=self.path,
+      wcp_port=self.wcp_port,
+      editor_cmd=self.editor_cmd,
+      editor_terminal=self.editor_terminal,
+      root_cfg_path=root_cfg_path,
+      available=False,
+    )
+    if os.sep in self.path or self.path.startswith('.'):
+      exe = os.path.join(os.path.dirname(root_cfg_path), self.path)
+      cfg.available = os.path.isfile(exe) and os.access(exe, os.X_OK)
+    else:
+      cfg.available = shutil.which(self.path) is not None
+    if not cfg.available:
+      log_event(logger, logging.DEBUG, "surfer.path_missing", name=cfg.name, path=self.path)
+    return cfg

--- a/src/rtl_buddy/logging_utils.py
+++ b/src/rtl_buddy/logging_utils.py
@@ -295,6 +295,10 @@ def _human_message(event: str, fields: Mapping[str, Any]) -> str:
       return "verible binaries unavailable"
     case "verible.command_invalid":
       return f'verible: invalid command "{fields.get("command")}"'
+    case "wcp.resolve_failed":
+      return f'WCP: could not find source for "{fields.get("variable")}" (searched {fields.get("searched")} files)'
+    case "wcp.connection_lost":
+      return f'WCP: connection lost ({fields.get("reason")}); waiting for Surfer to reconnect'
     case "coverage.metric.failed":
       return (
         f'coverage metric "{fields.get("metric")}" failed'

--- a/src/rtl_buddy/rtl_buddy.py
+++ b/src/rtl_buddy/rtl_buddy.py
@@ -44,7 +44,7 @@ class RtlBuddy():
   Handles cli entry into RTL Buddy
   """
 
-  _GIT_COMMANDS = {"test", "randtest", "regression", "filelist"}
+  _GIT_COMMANDS = {"test", "randtest", "regression", "filelist", "wave"}
 
   def cb_builder(value: str | None) -> str | None:
     if value is None:
@@ -74,6 +74,7 @@ class RtlBuddy():
     self.app.command("regression", help="run rtl regression")(self.do_rtl_regression)
     self.app.command("filelist", help="generate filelists using models.yaml")(self.do_gen_model_filelist)
     self.app.command("verible", help="run verible cmd")(self.do_verible)
+    self.app.command("wave", help="open waveform viewer for a test")(self.do_cmd_wave)
     self.app.add_typer(skill_app, name="skill", help="manage the rtl_buddy agent skill")
     self.docs_app.command("list", help="list bundled documentation pages")(self.do_docs_list)
     self.docs_app.command("show", help="show a bundled documentation page")(self.do_docs_show)
@@ -759,6 +760,57 @@ class RtlBuddy():
     if uncovered:
       emit_console_text(f"Uncovered items: {', '.join(uncovered)}", style="yellow")
     raise typer.Exit(0)
+
+  def do_cmd_wave(self,
+    test_name: Annotated[str, typer.Argument(help="name of test to open waveform for")],
+    test_config: Annotated[str, typer.Option("-c", "--test-config", help="tests.yaml to use")] = "tests.yaml",
+    surfer_name: Annotated[str, typer.Option("--surfer", help="cfg-surfer entry name")] = "surfer-default",
+    resim: Annotated[bool, typer.Option("--resim", help="force re-run of debug sim even if FST exists")] = False,
+    ):
+    """
+    open waveform viewer for a test
+    """
+    from .tools.wave_launcher import WaveLauncher
+
+    self.rtl_builder_mode = "debug"
+
+    surfer_cfg = self.root_cfg.get_surfer_cfg(surfer_name)
+    if surfer_cfg is None:
+      raise FatalRtlBuddyError(
+        f'No cfg-surfer entry named "{surfer_name}" in root_config.yaml. '
+        f'Add a cfg-surfer section to enable waveform viewing.'
+      )
+    if not surfer_cfg.available:
+      raise FatalRtlBuddyError(
+        f'Surfer not found at "{surfer_cfg.path}". '
+        f'Check cfg-surfer.path in root_config.yaml or install surfer on PATH.'
+      )
+
+    suite_cfg = SuiteConfig(path=test_config)
+    suite_dir = os.path.dirname(os.path.abspath(test_config))
+    test_cfg = suite_cfg.get_tests(test_name)[0]
+
+    fst_path = os.path.join(suite_dir, 'artefacts', test_name, 'dump.fst')
+    surfer_file = os.path.join(suite_dir, f'{test_name}.surfer')
+
+    log_event(logger, logging.INFO, "command.wave", command="wave", test=test_name, fst=fst_path)
+
+    if resim or not os.path.isfile(fst_path):
+      log_event(logger, logging.INFO, "wave.sim_required", test=test_name, fst=fst_path)
+      suite_results = self._do_test_suite(suite_cfg, test_name=test_name, run_ids=[None])
+      result = suite_results[0]['results'] if suite_results else None
+      if result is None or not result.is_pass():
+        raise FatalRtlBuddyError(f'Debug sim for "{test_name}" failed; cannot open waveform.')
+    else:
+      log_event(logger, logging.INFO, "wave.fst_found", test=test_name, fst=fst_path)
+
+    WaveLauncher(
+      test_cfg=test_cfg,
+      surfer_cfg=surfer_cfg,
+      suite_dir=suite_dir,
+      fst_path=fst_path,
+      surfer_file=surfer_file if os.path.isfile(surfer_file) else None,
+    ).launch()
 
   def do_lint(self):
     assert False, "not yet impl"

--- a/src/rtl_buddy/skill/SKILL.md
+++ b/src/rtl_buddy/skill/SKILL.md
@@ -64,9 +64,16 @@ end
 - `artefacts/<test>/test.log`, `test.err`, `test.randseed`, `coverage.dat` — sim outputs for a single run.
 - `artefacts/<test>/compile.log`, `run.f` — compile outputs, always at the test root (not per run-id).
 - `artefacts/<test>/run-0001/test.log` etc. — per-iteration outputs for `randtest`.
+- `artefacts/<test>/dump.fst` — FST waveform produced by debug-mode builds (`-M debug`).
 - Symlinks `test.log`, `test.err`, `test.randseed` at the suite root point at the latest run.
 - For multi-suite runs, each suite directory has its own `rtl_buddy.log` and `artefacts/`; report logs per suite.
 - Next docs: `rtl-buddy docs show reference/cli`, `rtl-buddy docs show reference/yaml`, `rtl-buddy docs show known-issues`
+
+## Waveform viewing
+
+- `rb wave <test>` opens `artefacts/<test>/dump.fst` in Surfer (runs debug sim first if no FST exists).
+- Signal layout files follow the convention `<test>.surfer` placed next to `tests.yaml` (e.g. `verif/sandbox/basic.surfer`). Use `variable_add <path>` and `zoom_fit` commands. See `verif/mem/tb_spsram.surfer` for a reference example.
+- Surfer must be configured in `cfg-surfer` in `root_config.yaml`. Run `rtl-buddy docs show concepts/root-config` for the schema.
 
 ## Bugs & Improvements
 If you discover a rtl_buddy bug or potential improvement, you can post an issue on GitHub <https://github.com/rtl-buddy/rtl_buddy/> documenting your findings, with permission from your user.

--- a/src/rtl_buddy/tools/surfer_wcp.py
+++ b/src/rtl_buddy/tools/surfer_wcp.py
@@ -130,7 +130,7 @@ class SurferSourceResolver:
       return None
     try:
       result = subprocess.run(
-        ['grep', '-n', '-w', '--', term, *self._sv_files],
+        ['grep', '-n', '-w', '-H', '--', term, *self._sv_files],
         capture_output=True, text=True, timeout=5,
       )
       for line in result.stdout.splitlines():

--- a/src/rtl_buddy/tools/surfer_wcp.py
+++ b/src/rtl_buddy/tools/surfer_wcp.py
@@ -1,0 +1,280 @@
+# rtl-buddy
+# vim: set sw=2:ts=2:et:
+#
+# Copyright 2024 rtl_buddy contributors
+#
+"""
+surfer_wcp: WCP client for Surfer waveform viewer.
+
+rtl-buddy acts as the WCP client (TCP listener). Surfer connects out using
+--wcp-initiate <port>. After handshake, Surfer sends goto_declaration events
+when the user right-clicks a signal; rtl-buddy resolves the variable to a
+source file and opens it in the configured editor.
+"""
+import json
+import logging
+import os
+import re
+import socket
+import subprocess
+import threading
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+  from ..config.surfer import SurferConfig
+  from ..config.test import TestConfig
+
+from ..logging_utils import log_event
+
+logger = logging.getLogger(__name__)
+
+_WCP_VERSION = "0"  # Surfer only accepts version "0"
+_RECV_BUF = 4096
+
+
+# ---------------------------------------------------------------------------
+# Frame I/O helpers
+# ---------------------------------------------------------------------------
+
+class _FrameReader:
+  """Read null-byte delimited JSON frames from a socket."""
+
+  def __init__(self, sock: socket.socket):
+    self._sock = sock
+    self._buf = b''
+
+  def read(self) -> dict:
+    while b'\x00' not in self._buf:
+      chunk = self._sock.recv(_RECV_BUF)
+      if not chunk:
+        raise ConnectionError("WCP connection closed by peer")
+      self._buf += chunk
+    frame, _, self._buf = self._buf.partition(b'\x00')
+    return json.loads(frame.decode('utf-8'))
+
+
+def _send_frame(sock: socket.socket, obj: dict) -> None:
+  data = json.dumps(obj).encode('utf-8') + b'\x00'
+  sock.sendall(data)
+
+
+# ---------------------------------------------------------------------------
+# Source resolver
+# ---------------------------------------------------------------------------
+
+class SurferSourceResolver:
+  """
+  Resolve a WCP variable path (e.g. "tb_top.i_dut_2.z_bus") to a source
+  file and line number by grepping the model's SV source files.
+
+  Source files are derived from the test's ModelConfig filelist, not from
+  root_config, so the search is scoped to the relevant design block.
+  """
+
+  def __init__(self, test_cfg: 'TestConfig', suite_dir: str):
+    self._sv_files = self._collect_sv_files(test_cfg, suite_dir)
+    log_event(logger, logging.DEBUG, "wcp.resolver_ready",
+              files=len(self._sv_files), suite=suite_dir)
+
+  def _collect_sv_files(self, test_cfg: 'TestConfig', suite_dir: str) -> list[str]:
+    from ..tools.vlog_filelist import VlogFilelist
+
+    model_cfg = test_cfg.get_model()
+    tb_cfg = test_cfg.get_testbench()
+    fl = VlogFilelist(name='wcp_resolver', model_cfg=model_cfg, output_path='/dev/null')
+
+    # Model source files (resolved from models.yaml location)
+    model_fpath = os.path.abspath(model_cfg.get_model_path() or '.')
+    model_entries = fl._extract(model_cfg.get_filelist(), unroll=True, fpath=model_fpath)
+
+    # Testbench source files (resolved from suite dir)
+    tb_fpath = os.path.join(suite_dir, 'tests.yaml')
+    tb_entries = fl._extract(tb_cfg.get_filelist(), unroll=True, fpath=tb_fpath)
+
+    sv_files = []
+    for path, opt in model_entries + tb_entries:
+      if opt is None or opt.strip() == '-v':
+        if os.path.isfile(path):
+          sv_files.append(path)
+    return sv_files
+
+  def resolve(self, variable: str) -> tuple[str, int] | None:
+    """
+    Resolve a hierarchical variable path to (filepath, lineno).
+
+    Tries the rightmost component (signal name) first, then the second-to-last
+    (instance/module component) as a fallback.
+    """
+    parts = variable.split('.')
+    candidates = [parts[-1]]
+    if len(parts) >= 2:
+      # Strip trailing digits from instance name to approximate module name
+      mod_candidate = re.sub(r'_\d+$', '', parts[-2])
+      if mod_candidate not in candidates:
+        candidates.append(mod_candidate)
+
+    for term in candidates:
+      result = self._grep(term)
+      if result:
+        filepath, lineno = result
+        log_event(logger, logging.DEBUG, "wcp.resolve_found",
+                  variable=variable, term=term, file=filepath, line=lineno)
+        return filepath, lineno
+
+    log_event(logger, logging.WARNING, "wcp.resolve_failed",
+              variable=variable, searched=len(self._sv_files))
+    return None
+
+  def _grep(self, term: str) -> tuple[str, int] | None:
+    if not self._sv_files:
+      return None
+    try:
+      result = subprocess.run(
+        ['grep', '-n', '-w', '--', term, *self._sv_files],
+        capture_output=True, text=True, timeout=5,
+      )
+      for line in result.stdout.splitlines():
+        parts = line.split(':', 2)
+        if len(parts) >= 2:
+          try:
+            return parts[0], int(parts[1])
+          except ValueError:
+            continue
+    except (subprocess.TimeoutExpired, OSError):
+      pass
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Editor launcher
+# ---------------------------------------------------------------------------
+
+class EditorLauncher:
+  """Open a source file at a given line in the configured editor."""
+
+  def __init__(self, surfer_cfg: 'SurferConfig'):
+    self._surfer_cfg = surfer_cfg
+
+  def open(self, filepath: str, lineno: int) -> None:
+    cmd = self._surfer_cfg.format_editor_cmd(filepath, lineno)
+    terminal = self._surfer_cfg.editor_terminal.lower()
+    log_event(logger, logging.DEBUG, "editor.open",
+              cmd=cmd, terminal=terminal, file=filepath, line=lineno)
+
+    if terminal == 'tmux':
+      self._open_tmux(cmd)
+    elif terminal == 'iterm2':
+      self._open_iterm2(cmd)
+    elif terminal == 'terminal':
+      self._open_terminal_app(cmd)
+    else:
+      subprocess.Popen(cmd, shell=True)
+
+  def _open_tmux(self, cmd: str) -> None:
+    subprocess.Popen(['tmux', 'new-window', cmd])
+
+  def _open_iterm2(self, cmd: str) -> None:
+    safe_cmd = cmd.replace('\\', '\\\\').replace('"', '\\"')
+    applescript = f'''
+      tell application "iTerm2"
+        activate
+        create window with default profile
+        tell current session of current window
+          write text "{safe_cmd}"
+        end tell
+      end tell
+    '''
+    subprocess.Popen(['osascript', '-e', applescript])
+
+  def _open_terminal_app(self, cmd: str) -> None:
+    safe_cmd = cmd.replace('"', '\\"')
+    applescript = f'''
+      tell application "Terminal"
+        activate
+        do script "{safe_cmd}"
+      end tell
+    '''
+    subprocess.Popen(['osascript', '-e', applescript])
+
+
+# ---------------------------------------------------------------------------
+# WCP listener (rtl-buddy is the WCP client; Surfer connects via --wcp-initiate)
+# ---------------------------------------------------------------------------
+
+class SurferWcpListener:
+  """
+  TCP listener that accepts a single connection from Surfer (--wcp-initiate).
+  Performs the WCP handshake then dispatches goto_declaration events to the
+  source resolver and editor launcher.
+  """
+
+  def __init__(self, surfer_cfg: 'SurferConfig', resolver: SurferSourceResolver,
+               editor: EditorLauncher):
+    self._surfer_cfg = surfer_cfg
+    self._resolver = resolver
+    self._editor = editor
+    self._stop = threading.Event()
+    self._srv: socket.socket | None = None
+
+  def bind(self) -> None:
+    """Bind the TCP socket. Call before launching Surfer."""
+    self._srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    self._srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    self._srv.bind(('127.0.0.1', self._surfer_cfg.wcp_port))
+    self._srv.listen(1)
+    self._srv.settimeout(1.0)
+    log_event(logger, logging.INFO, "wave.wcp_listening",
+              port=self._surfer_cfg.wcp_port)
+
+  def run(self) -> None:
+    """Accept connections and handle events. Reconnects if Surfer drops."""
+    while not self._stop.is_set():
+      try:
+        conn, addr = self._srv.accept()  # type: ignore[union-attr]
+      except TimeoutError:
+        continue
+      except OSError:
+        break
+      log_event(logger, logging.INFO, "wave.wcp_connected", addr=str(addr))
+      try:
+        self._handle_connection(conn)
+      except ConnectionError as exc:
+        log_event(logger, logging.WARNING, "wcp.connection_lost", reason=str(exc))
+      finally:
+        conn.close()
+
+  def stop(self) -> None:
+    self._stop.set()
+    if self._srv:
+      try:
+        self._srv.close()
+      except OSError:
+        pass
+
+  def _handle_connection(self, conn: socket.socket) -> None:
+    reader = _FrameReader(conn)
+
+    # Send our greeting first — Surfer (WCP server) waits for the client greeting
+    # before sending its own. Surfer then sets goto_declaration capability and
+    # shows "Go to declaration" in the right-click menu.
+    _send_frame(conn, {
+      'type': 'greeting',
+      'version': _WCP_VERSION,
+      'commands': ['goto_declaration'],
+    })
+
+    # Receive Surfer's greeting in response
+    greeting = reader.read()
+    if greeting.get('type') != 'greeting':
+      raise ConnectionError(f"Expected greeting, got: {greeting.get('type')}")
+
+    # Event loop
+    while not self._stop.is_set():
+      msg = reader.read()
+      if msg.get('type') == 'event' and msg.get('event') == 'goto_declaration':
+        variable = msg.get('variable', '')
+        log_event(logger, logging.INFO, "wave.goto_declaration", variable=variable)
+        result = self._resolver.resolve(variable)
+        if result:
+          filepath, lineno = result
+          self._editor.open(filepath, lineno)

--- a/src/rtl_buddy/tools/surfer_wcp.py
+++ b/src/rtl_buddy/tools/surfer_wcp.py
@@ -216,15 +216,17 @@ class SurferWcpListener:
     self._stop = threading.Event()
     self._srv: socket.socket | None = None
 
-  def bind(self) -> None:
-    """Bind the TCP socket. Call before launching Surfer."""
+  def bind(self) -> int:
+    """Bind the TCP socket. Returns the actual port (OS-assigned when wcp_port=0).
+    Call before launching Surfer so the port is ready when Surfer connects."""
     self._srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     self._srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
     self._srv.bind(('127.0.0.1', self._surfer_cfg.wcp_port))
     self._srv.listen(1)
     self._srv.settimeout(1.0)
-    log_event(logger, logging.INFO, "wave.wcp_listening",
-              port=self._surfer_cfg.wcp_port)
+    actual_port = self._srv.getsockname()[1]
+    log_event(logger, logging.INFO, "wave.wcp_listening", port=actual_port)
+    return actual_port
 
   def run(self) -> None:
     """Accept connections and handle events. Reconnects if Surfer drops."""

--- a/src/rtl_buddy/tools/wave_launcher.py
+++ b/src/rtl_buddy/tools/wave_launcher.py
@@ -44,13 +44,14 @@ class WaveLauncher:
     editor = EditorLauncher(self._surfer_cfg)
     listener = SurferWcpListener(self._surfer_cfg, resolver, editor)
 
-    # Bind before launching Surfer so the port is ready when it connects
-    listener.bind()
+    # Bind before launching Surfer so the port is ready when it connects.
+    # actual_port is OS-assigned when wcp_port=0, otherwise matches wcp_port.
+    actual_port = listener.bind()
 
     cmd = [self._surfer_cfg.get_surfer_exe(), self._fst_path]
     if self._surfer_file and os.path.isfile(self._surfer_file):
       cmd += ['-c', self._surfer_file]
-    cmd += ['--wcp-initiate', str(self._surfer_cfg.wcp_port)]
+    cmd += ['--wcp-initiate', str(actual_port)]
 
     log_event(logger, logging.INFO, "wave.launched",
               test=self._test_cfg.name, fst=self._fst_path,

--- a/src/rtl_buddy/tools/wave_launcher.py
+++ b/src/rtl_buddy/tools/wave_launcher.py
@@ -1,0 +1,82 @@
+# rtl-buddy
+# vim: set sw=2:ts=2:et:
+#
+# Copyright 2024 rtl_buddy contributors
+#
+"""
+wave_launcher: orchestrates the `rb wave` workflow.
+
+Sequence:
+  1. Check for existing debug FST; run debug sim if absent.
+  2. Bind WCP listener socket (must happen before Surfer starts).
+  3. Launch Surfer with --wcp-initiate <port>.
+  4. Start WCP listener thread.
+  5. Block until Ctrl-C or Surfer exits.
+"""
+import logging
+import os
+import subprocess
+import threading
+
+from ..config.surfer import SurferConfig
+from ..config.test import TestConfig
+from ..logging_utils import emit_console_text, log_event
+from .surfer_wcp import EditorLauncher, SurferSourceResolver, SurferWcpListener
+
+logger = logging.getLogger(__name__)
+
+
+class WaveLauncher:
+  """
+  Launches Surfer and manages the WCP client lifecycle for a single test.
+  """
+
+  def __init__(self, test_cfg: TestConfig, surfer_cfg: SurferConfig,
+               suite_dir: str, fst_path: str, surfer_file: str | None = None):
+    self._test_cfg = test_cfg
+    self._surfer_cfg = surfer_cfg
+    self._suite_dir = suite_dir
+    self._fst_path = fst_path
+    self._surfer_file = surfer_file
+
+  def launch(self) -> None:
+    resolver = SurferSourceResolver(self._test_cfg, self._suite_dir)
+    editor = EditorLauncher(self._surfer_cfg)
+    listener = SurferWcpListener(self._surfer_cfg, resolver, editor)
+
+    # Bind before launching Surfer so the port is ready when it connects
+    listener.bind()
+
+    cmd = [self._surfer_cfg.get_surfer_exe(), self._fst_path]
+    if self._surfer_file and os.path.isfile(self._surfer_file):
+      cmd += ['-c', self._surfer_file]
+    cmd += ['--wcp-initiate', str(self._surfer_cfg.wcp_port)]
+
+    log_event(logger, logging.INFO, "wave.launched",
+              test=self._test_cfg.name, fst=self._fst_path,
+              surfer_file=self._surfer_file or '')
+
+    proc = subprocess.Popen(cmd)
+
+    wcp_thread = threading.Thread(target=listener.run, daemon=True, name='wcp-listener')
+    wcp_thread.start()
+
+    emit_console_text(
+      f"Surfer open (PID {proc.pid}). "
+      f"Right-click a signal → Go to declaration. "
+      f"Press Ctrl-C to exit.",
+    )
+
+    try:
+      proc.wait()
+    except KeyboardInterrupt:
+      proc.terminate()
+      try:
+        proc.wait(timeout=3)
+      except subprocess.TimeoutExpired:
+        proc.kill()
+    finally:
+      listener.stop()
+      wcp_thread.join(timeout=2)
+
+    log_event(logger, logging.INFO, "wave.done", test=self._test_cfg.name)

--- a/tests/test_surfer_wcp.py
+++ b/tests/test_surfer_wcp.py
@@ -1,0 +1,260 @@
+"""
+Tests for Surfer WCP integration: config path resolution, editor command
+formatting, WCP frame I/O, and source resolver signal extraction.
+"""
+import io
+import json
+import os
+import socket
+import threading
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from rtl_buddy.config.surfer import SurferConfig, SurferConfigFile
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_surfer_cfg(*, path='surfer', wcp_port=54321,
+                     editor_cmd='vim +%l %f', editor_terminal='tmux',
+                     root_cfg_path='/proj/root_config.yaml', available=True):
+  return SurferConfig(
+    name='surfer-default',
+    path=path,
+    wcp_port=wcp_port,
+    editor_cmd=editor_cmd,
+    editor_terminal=editor_terminal,
+    root_cfg_path=root_cfg_path,
+    available=available,
+  )
+
+
+# ---------------------------------------------------------------------------
+# SurferConfig: path resolution
+# ---------------------------------------------------------------------------
+
+class TestSurferConfigPathResolution:
+
+  def test_bare_name_uses_which(self, tmp_path):
+    fake_exe = tmp_path / 'surfer'
+    fake_exe.touch(mode=0o755)
+    cfg = _make_surfer_cfg(path='surfer', root_cfg_path=str(tmp_path / 'root_config.yaml'))
+    with patch('shutil.which', return_value=str(fake_exe)):
+      assert cfg.get_surfer_exe() == str(fake_exe)
+
+  def test_bare_name_falls_back_to_name_when_not_found(self):
+    cfg = _make_surfer_cfg(path='surfer')
+    with patch('shutil.which', return_value=None):
+      assert cfg.get_surfer_exe() == 'surfer'
+
+  def test_relative_path_resolved_from_root_config(self, tmp_path):
+    root_cfg = tmp_path / 'root_config.yaml'
+    cfg = _make_surfer_cfg(
+      path='../surfer/target/release/surfer',
+      root_cfg_path=str(root_cfg),
+    )
+    expected = os.path.join(str(tmp_path), '../surfer/target/release/surfer')
+    assert cfg.get_surfer_exe() == expected
+
+  def test_dotslash_path_treated_as_relative(self, tmp_path):
+    root_cfg = tmp_path / 'root_config.yaml'
+    cfg = _make_surfer_cfg(path='./bin/surfer', root_cfg_path=str(root_cfg))
+    assert cfg.get_surfer_exe().endswith('./bin/surfer') or '/' in cfg.get_surfer_exe()
+
+  def test_absolute_path_returned_as_is(self, tmp_path):
+    abs_path = '/usr/local/bin/surfer'
+    cfg = _make_surfer_cfg(path=abs_path, root_cfg_path=str(tmp_path / 'root_config.yaml'))
+    assert cfg.get_surfer_exe() == abs_path
+
+
+# ---------------------------------------------------------------------------
+# SurferConfig: editor command formatting
+# ---------------------------------------------------------------------------
+
+class TestSurferConfigEditorCmd:
+
+  def test_f_and_l_substituted(self):
+    cfg = _make_surfer_cfg(editor_cmd='vim +%l %f')
+    assert cfg.format_editor_cmd('/path/to/file.sv', 42) == 'vim +42 /path/to/file.sv'
+
+  def test_vscode_format(self):
+    cfg = _make_surfer_cfg(editor_cmd='code --goto %f:%l')
+    assert cfg.format_editor_cmd('/src/foo.sv', 10) == 'code --goto /src/foo.sv:10'
+
+  def test_nvim_format(self):
+    cfg = _make_surfer_cfg(editor_cmd='nvim +%l %f')
+    assert cfg.format_editor_cmd('/src/bar.sv', 1) == 'nvim +1 /src/bar.sv'
+
+  def test_custom_script_format(self):
+    cfg = _make_surfer_cfg(editor_cmd='/path/to/open.sh %f %l')
+    assert cfg.format_editor_cmd('/src/baz.sv', 99) == '/path/to/open.sh /src/baz.sv 99'
+
+  def test_no_placeholders_returns_cmd_unchanged(self):
+    cfg = _make_surfer_cfg(editor_cmd='code .')
+    assert cfg.format_editor_cmd('/src/foo.sv', 5) == 'code .'
+
+
+# ---------------------------------------------------------------------------
+# SurferConfigFile.initialise: available flag
+# ---------------------------------------------------------------------------
+
+class TestSurferConfigFileInitialise:
+
+  def test_available_true_when_bare_name_on_path(self, tmp_path):
+    root_cfg = str(tmp_path / 'root_config.yaml')
+    cf = SurferConfigFile(name='s', path='surfer', wcp_port=54321,
+                          editor_cmd='vim +%l %f', editor_terminal='tmux')
+    with patch('shutil.which', return_value='/usr/bin/surfer'):
+      cfg = cf.initialise(root_cfg)
+    assert cfg.available is True
+
+  def test_available_false_when_bare_name_not_on_path(self, tmp_path):
+    root_cfg = str(tmp_path / 'root_config.yaml')
+    cf = SurferConfigFile(name='s', path='surfer', wcp_port=54321,
+                          editor_cmd='vim +%l %f', editor_terminal='tmux')
+    with patch('shutil.which', return_value=None):
+      cfg = cf.initialise(root_cfg)
+    assert cfg.available is False
+
+  def test_available_true_when_relative_path_exists(self, tmp_path):
+    exe = tmp_path / 'bin' / 'surfer'
+    exe.parent.mkdir()
+    exe.touch(mode=0o755)
+    root_cfg = str(tmp_path / 'root_config.yaml')
+    cf = SurferConfigFile(name='s', path='bin/surfer', wcp_port=54321,
+                          editor_cmd='vim +%l %f', editor_terminal='tmux')
+    cfg = cf.initialise(root_cfg)
+    assert cfg.available is True
+
+  def test_available_false_when_relative_path_missing(self, tmp_path):
+    root_cfg = str(tmp_path / 'root_config.yaml')
+    cf = SurferConfigFile(name='s', path='bin/surfer', wcp_port=54321,
+                          editor_cmd='vim +%l %f', editor_terminal='tmux')
+    cfg = cf.initialise(root_cfg)
+    assert cfg.available is False
+
+
+# ---------------------------------------------------------------------------
+# WCP frame I/O
+# ---------------------------------------------------------------------------
+
+class TestWcpFrameIO:
+  """Test null-byte delimited JSON framing using a socketpair."""
+
+  def _make_pair(self):
+    a, b = socket.socketpair()
+    return a, b
+
+  def test_send_and_receive_single_frame(self):
+    from rtl_buddy.tools.surfer_wcp import _FrameReader, _send_frame
+    a, b = self._make_pair()
+    try:
+      _send_frame(a, {'type': 'greeting', 'version': '0', 'commands': ['goto_declaration']})
+      reader = _FrameReader(b)
+      msg = reader.read()
+      assert msg['type'] == 'greeting'
+      assert msg['version'] == '0'
+      assert 'goto_declaration' in msg['commands']
+    finally:
+      a.close()
+      b.close()
+
+  def test_multiple_frames_in_sequence(self):
+    from rtl_buddy.tools.surfer_wcp import _FrameReader, _send_frame
+    a, b = self._make_pair()
+    try:
+      _send_frame(a, {'type': 'greeting', 'version': '0', 'commands': []})
+      _send_frame(a, {'type': 'event', 'event': 'goto_declaration', 'variable': 'tb_top.clk'})
+      reader = _FrameReader(b)
+      m1 = reader.read()
+      m2 = reader.read()
+      assert m1['type'] == 'greeting'
+      assert m2['event'] == 'goto_declaration'
+      assert m2['variable'] == 'tb_top.clk'
+    finally:
+      a.close()
+      b.close()
+
+  def test_connection_error_on_closed_socket(self):
+    from rtl_buddy.tools.surfer_wcp import _FrameReader
+    a, b = self._make_pair()
+    a.close()
+    reader = _FrameReader(b)
+    with pytest.raises(ConnectionError):
+      reader.read()
+    b.close()
+
+
+# ---------------------------------------------------------------------------
+# SurferSourceResolver: signal extraction logic
+# ---------------------------------------------------------------------------
+
+class TestSurferSourceResolver:
+  """Test the resolver's variable→signal parsing and grep dispatch."""
+
+  def _make_resolver_with_files(self, sv_files):
+    """Build a resolver with a pre-set file list, bypassing VlogFilelist."""
+    from rtl_buddy.tools.surfer_wcp import SurferSourceResolver
+    resolver = object.__new__(SurferSourceResolver)
+    resolver._sv_files = sv_files
+    return resolver
+
+  def test_resolve_finds_signal_in_sv_file(self, tmp_path):
+    from rtl_buddy.tools.surfer_wcp import SurferSourceResolver
+    sv = tmp_path / 'tb_top.sv'
+    sv.write_text('module tb_top;\n  logic clk;\n  logic rst;\nendmodule\n')
+    resolver = self._make_resolver_with_files([str(sv)])
+    result = resolver.resolve('tb_top.clk')
+    assert result is not None
+    filepath, lineno = result
+    assert filepath == str(sv)
+    assert lineno == 2
+
+  def test_resolve_returns_none_when_not_found(self, tmp_path):
+    from rtl_buddy.tools.surfer_wcp import SurferSourceResolver
+    sv = tmp_path / 'empty.sv'
+    sv.write_text('module foo;\nendmodule\n')
+    resolver = self._make_resolver_with_files([str(sv)])
+    result = resolver.resolve('tb_top.nonexistent_signal_xyz')
+    assert result is None
+
+  def test_resolve_strips_trailing_digits_from_instance_fallback(self, tmp_path):
+    from rtl_buddy.tools.surfer_wcp import SurferSourceResolver
+    sv = tmp_path / 'design.sv'
+    sv.write_text('module test_module_3;\n  logic z_bus;\nendmodule\n')
+    resolver = self._make_resolver_with_files([str(sv)])
+    # Signal "z_bus" found directly; no need for fallback
+    result = resolver.resolve('tb_top.i_dut_2.z_bus')
+    assert result is not None
+    assert result[1] == 2
+
+  def test_resolve_uses_module_fallback_when_signal_not_found(self, tmp_path):
+    from rtl_buddy.tools.surfer_wcp import SurferSourceResolver
+    sv = tmp_path / 'design.sv'
+    # Only the module name exists, not a signal named "i_z"
+    sv.write_text('module test_module_2;\n  // i_m2 instance\nendmodule\n')
+    resolver = self._make_resolver_with_files([str(sv)])
+    # "i_z" not found; fallback to "gen_i" → strip digits → "gen_i" → not found either
+    # then "i_m2" → found on line 2
+    result = resolver.resolve('tb_top.i_dut_2.gen_i.i_m2')
+    assert result is not None
+
+  def test_resolve_empty_file_list_returns_none(self):
+    from rtl_buddy.tools.surfer_wcp import SurferSourceResolver
+    resolver = self._make_resolver_with_files([])
+    assert resolver.resolve('tb_top.clk') is None
+
+  def test_resolve_single_component_variable(self, tmp_path):
+    from rtl_buddy.tools.surfer_wcp import SurferSourceResolver
+    sv = tmp_path / 'top.sv'
+    sv.write_text('logic clk;\n')
+    resolver = self._make_resolver_with_files([str(sv)])
+    result = resolver.resolve('clk')
+    assert result is not None
+    assert result[1] == 1

--- a/tests/test_surfer_wcp.py
+++ b/tests/test_surfer_wcp.py
@@ -21,7 +21,7 @@ from rtl_buddy.config.surfer import SurferConfig, SurferConfigFile
 # Helpers
 # ---------------------------------------------------------------------------
 
-def _make_surfer_cfg(*, path='surfer', wcp_port=54321,
+def _make_surfer_cfg(*, path='surfer', wcp_port=0,
                      editor_cmd='vim +%l %f', editor_terminal='tmux',
                      root_cfg_path='/proj/root_config.yaml', available=True):
   return SurferConfig(
@@ -108,7 +108,7 @@ class TestSurferConfigFileInitialise:
 
   def test_available_true_when_bare_name_on_path(self, tmp_path):
     root_cfg = str(tmp_path / 'root_config.yaml')
-    cf = SurferConfigFile(name='s', path='surfer', wcp_port=54321,
+    cf = SurferConfigFile(name='s', path='surfer', wcp_port=0,
                           editor_cmd='vim +%l %f', editor_terminal='tmux')
     with patch('shutil.which', return_value='/usr/bin/surfer'):
       cfg = cf.initialise(root_cfg)
@@ -116,7 +116,7 @@ class TestSurferConfigFileInitialise:
 
   def test_available_false_when_bare_name_not_on_path(self, tmp_path):
     root_cfg = str(tmp_path / 'root_config.yaml')
-    cf = SurferConfigFile(name='s', path='surfer', wcp_port=54321,
+    cf = SurferConfigFile(name='s', path='surfer', wcp_port=0,
                           editor_cmd='vim +%l %f', editor_terminal='tmux')
     with patch('shutil.which', return_value=None):
       cfg = cf.initialise(root_cfg)
@@ -127,14 +127,14 @@ class TestSurferConfigFileInitialise:
     exe.parent.mkdir()
     exe.touch(mode=0o755)
     root_cfg = str(tmp_path / 'root_config.yaml')
-    cf = SurferConfigFile(name='s', path='bin/surfer', wcp_port=54321,
+    cf = SurferConfigFile(name='s', path='bin/surfer', wcp_port=0,
                           editor_cmd='vim +%l %f', editor_terminal='tmux')
     cfg = cf.initialise(root_cfg)
     assert cfg.available is True
 
   def test_available_false_when_relative_path_missing(self, tmp_path):
     root_cfg = str(tmp_path / 'root_config.yaml')
-    cf = SurferConfigFile(name='s', path='bin/surfer', wcp_port=54321,
+    cf = SurferConfigFile(name='s', path='bin/surfer', wcp_port=0,
                           editor_cmd='vim +%l %f', editor_terminal='tmux')
     cfg = cf.initialise(root_cfg)
     assert cfg.available is False


### PR DESCRIPTION
**Implementation complete on \`feature/49-surfer-wcp-integration\`.**

### What was built

\`rb wave <test>\` — a new command that opens a debug waveform in Surfer and connects a live WCP client so right-clicking any signal shows **"Go to declaration"**, which opens the source file at the correct line in the configured editor.

### How it works

rtl-buddy acts as the **WCP client** (TCP listener on \`wcp-port\`). Surfer is launched with \`--wcp-initiate <port>\` so it connects out. After the WCP handshake (rtl-buddy sends its greeting first, advertising \`goto_declaration\`; Surfer responds and enables the menu item), Surfer emits \`goto_declaration\` events on right-click. rtl-buddy resolves the variable path to a source file by grepping the model's \`.sv\` files derived from \`TestConfig → ModelConfig → filelist\`, then opens the file in the configured editor.

### Configuration (\`root_config.yaml\`)

```yaml
cfg-surfer:
  - name: "surfer-default"
    path: "surfer"              # bare name → PATH lookup; or relative/absolute path
    wcp-port: 54321
    editor-cmd: "vim +%l %f"   # %f = file, %l = line; supports nvim, code, custom scripts
    editor-terminal: "tmux"    # tmux | iterm2 | terminal | "" (direct for GUI editors)
```

### Key design notes

- **WCP protocol**: version must be \`"0"\`; client sends greeting first (before Surfer responds) — discovered by reading \`wcp_handler.rs\`
- **Source resolution**: scoped to the test's model filelist, not a global search path. Uses \`grep -n -w -H\` (the \`-H\` flag is required to get filename prefixes even for single-file searches)
- **No FST stem metadata needed**: unlike GTKWave's RTL Browse, this approach works with stock Verilator FSTs
- If no FST exists, \`rb wave\` runs the debug sim automatically before opening Surfer

### Files added

| File | Purpose |
|---|---|
| \`config/surfer.py\` | \`SurferConfigFile\` + \`SurferConfig\` |
| \`tools/surfer_wcp.py\` | WCP listener, source resolver, editor launcher |
| \`tools/wave_launcher.py\` | Orchestrates sim check, Surfer launch, WCP thread |
| \`tests/test_surfer_wcp.py\` | 23 unit tests (path resolution, editor cmd, WCP framing, resolver) |

Closes #49