### PR TITLE
Improve SEO metadata and docs discoverability

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,18 @@
 [![License](https://img.shields.io/badge/license-BSD--3--Clause-blue)](LICENSE)
 [![Docs](https://img.shields.io/badge/docs-rtl--buddy.github.io-blue)](https://rtl-buddy.github.io/rtl_buddy/)
 
-`rtl_buddy` is a CLI for running RTL tests, regressions, filelist generation, and adjacent workflow automation in Verilog and SystemVerilog projects. It is designed to work well for both humans and AI agents.
+`rtl_buddy` is a Python CLI for running Verilog and SystemVerilog RTL tests, randomized regressions, filelist generation, Verilator/VCS simulator workflows, and adjacent verification automation. It is designed to work well for both humans and AI agents.
 
 It is built to sit on top of the tools your project already uses, while giving you a cleaner, more repeatable interface for day-to-day verification work. The primary supported flows are Verilator and VCS-based compile, simulation, and regression workflows. Basic Verible command integration exists, while broader first-class Verible and PeakRDL workflows are on the roadmap.
+
+Typical commands look like:
+
+```bash
+uv run rb test basic
+uv run rb test smoke --repeat 20
+uv run rb regression
+uv run rb regression --coverage-merge
+```
 
 ## Why `rtl_buddy`
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,23 +1,32 @@
 ---
-description: RTL Buddy is a CLI tool for automating tests, regressions, and RTL workflows for Verilog/SystemVerilog codebases.
+description: RTL Buddy is a Python CLI for Verilog and SystemVerilog regression testing, Verilator and VCS simulation workflows, coverage, and YAML-based RTL verification automation.
 ---
 
 # RTL Buddy
 
-RTL Buddy is a CLI tool for automating tests, regressions, and RTL workflows for Verilog/SystemVerilog codebases.
+RTL Buddy is a Python CLI for Verilog and SystemVerilog RTL verification workflows, including test execution, randomized regression testing, Verilator and VCS simulation, coverage collection, and YAML-based automation.
 
-It wraps simulation tools (primarily Verilator on macOS/Linux and VCS on Linux) and provides a structured, config-driven test and regression system for ASIC and FPGA projects.
+It wraps simulation tools and project scripts to provide a structured, config-driven test and regression system for ASIC and FPGA projects. The primary supported flows are Verilator on macOS/Linux and VCS on Linux.
 
 ## Features
 
-- Run individual tests or full regressions from YAML config files
-- Randomized seed testing with repeat support
+- Run individual Verilog/SystemVerilog tests or full regressions from YAML config files
+- Randomized seed testing with repeat and replay support
 - Plugin hooks for sweep generation, test pre-processing, and post-processing
 - Filelist generation from `models.yaml`
+- Verilator coverage collection, merge, summary, and export workflows
 - Basic Verible command integration for lint, syntax, formatting, and preprocessing
 - Machine-readable JSONL logging for use with AI agents and CI pipelines
 
 `rtl_buddy` can be adapted to different project toolchains, but the primary supported flows are Verilator and VCS. Broader first-class Verible and PeakRDL workflows are on the roadmap.
+
+## SystemVerilog Regression Testing
+
+RTL Buddy keeps simulator invocation, seeds, logs, result handling, and regression selection consistent across repeated verification runs. Projects describe suites, tests, platforms, builders, and models in readable YAML files instead of scattering that logic across ad hoc shell scripts.
+
+## Verilator and VCS Simulation Workflows
+
+The CLI gives RTL projects one command surface for open-source Verilator flows and Linux VCS flows, with optional hooks for project-specific compile, simulation, sweep, and post-processing behavior.
 
 ## Getting Started
 

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://rtl-buddy.github.io/rtl_buddy/sitemap.xml

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,8 @@
 site_name: RTL Buddy
-site_description: CLI tool for automating tests, regressions, and RTL workflows for Verilog/SystemVerilog codebases.
+site_description: Python CLI for Verilog and SystemVerilog regression testing, Verilator and VCS simulation workflows, RTL test automation, coverage, and YAML-based verification flows.
+site_author: RTL Buddy contributors
+repo_url: https://github.com/rtl-buddy/rtl_buddy
+repo_name: rtl-buddy/rtl_buddy
 docs_dir: docs
 site_url: https://rtl-buddy.github.io/rtl_buddy/
 remote_name: origin

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,11 +19,23 @@ authors = [
   { name = "Xie Jiacheng"}
 ]
 
-description = "RTL Buddy is a build-system with testplan, regression, workflow support for Verilog RTL codebases."
+description = "Python CLI for Verilog and SystemVerilog RTL testing, randomized regressions, coverage, and simulator workflow automation."
 readme = "README.md"
 license = "BSD-3-Clause"
 license-files = ["LICENSE"]
-keywords = [ "SystemVerilog", "Verilog", "ASIC", "FPGA" ]
+keywords = [
+  "SystemVerilog",
+  "Verilog",
+  "RTL",
+  "ASIC",
+  "FPGA",
+  "EDA",
+  "Verilator",
+  "VCS",
+  "regression testing",
+  "verification",
+  "coverage",
+]
 
 classifiers = [
   "Development Status :: 4 - Beta",


### PR DESCRIPTION
## Summary

- strengthen search-facing MkDocs and PyPI metadata for Verilog/SystemVerilog RTL verification queries
- tune the docs homepage and README opening copy toward regression, simulator, coverage, and YAML workflow search intent
- add a crawlable robots.txt that points at the generated sitemap

Closes #53.

## Validation

- uv run python scripts/check_docs_frontmatter.py --check
- uv run --group docs mkdocs build