### PR TITLE
Feature/57 synthesis flow support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,10 +19,14 @@ src/rtl_buddy/
 │   ├── root.py            # discover_project_root(), RootConfig
 │   ├── model.py           # ModelConfig (models.yaml)
 │   ├── test.py            # TestConfig / TestConfigFile (tests.yaml)
+│   ├── synth.py           # SynthConfig, SynthSuiteConfig, SynthRegConfig, SynthToolConfig (synth.yaml)
 │   ├── spec.py            # SpecConfig / SpecBlock / SpecCoverageItem (specs.yaml)
 │   └── ...                # platform, rtl, verible, coverage, coverview, reg
 ├── runner/test_runner.py  # PRE -> COMP -> SIM -> POST execution
+├── runner/synth_runner.py # synthesis dispatch; resolves tool config and invokes backend
+├── runner/synth_results.py # SynthResults / SynthPassResults / SynthFailResults / SynthSkipResults
 └── tools/
+    ├── synth_yosys.py     # Yosys backend: filelist → synth.ys script → yosys invocation
     ├── spec_trace.py      # discover_spec_configs, build_coverage_map, etc.
     └── ...                # filelist, sim, postproc, verible wrappers
 ```
@@ -44,6 +48,8 @@ src/rtl_buddy/
 - `VlogFilelist` handles `.f` parsing and transformations. It resolves model entries from the real `models.yaml` location, resolves testbench entries from the suite cwd, and writes paths relative to the directory containing the generated `run.f`.
 - Nested raw coverage paths such as `artefacts/<test>/run-0001/coverage.dat` must preserve the suite-root hint during LCOV/Coverview `SF:` rewriting. When updating coverage path logic, make sure duplicate basenames still resolve against the originating suite root instead of falling back to repo-wide basename matching.
 - Hook scripts (`sweep`, `preproc`, `postproc`) are executed dynamically and should be treated as compatibility-sensitive APIs.
+- `SynthRunner` resolves a `SynthToolConfig` from `root_cfg.get_synth_tool_cfg(tool_name)`, merges any `tool_overrides` from the `SynthConfig`, then dispatches to `YosysSynth`. Opts resolution: root-config `opts` are the baseline; per-run `tool_overrides.<tool>` keys overwrite matching fields.
+- `YosysSynth` writes `synth.f` via `VlogFilelist` (with `unroll=True, strip=True, deduplicate=True`), then generates `synth.ys`. Source files are emitted as individual `read_verilog -sv -defer` commands (not `-f filelist`) so Yosys only elaborates the top hierarchy. Pass/fail is determined by exit code then `ERROR:` line scan.
 
 ## Validation
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 [![License](https://img.shields.io/badge/license-BSD--3--Clause-blue)](LICENSE)
 [![Docs](https://img.shields.io/badge/docs-rtl--buddy.github.io-blue)](https://rtl-buddy.github.io/rtl_buddy/)
 
-`rtl_buddy` is a Python CLI for running Verilog and SystemVerilog RTL tests, randomized regressions, filelist generation, Verilator/VCS simulator workflows, and adjacent verification automation. It is designed to work well for both humans and AI agents.
+`rtl_buddy` is a Python CLI for running Verilog and SystemVerilog RTL tests, randomized regressions, filelist generation, Verilator/VCS simulator workflows, Yosys synthesis flows, coverage, and adjacent verification automation. It is designed to work well for both humans and AI agents.
 
-It is built to sit on top of the tools your project already uses, while giving you a cleaner, more repeatable interface for day-to-day verification work. The primary supported flows are Verilator and VCS-based compile, simulation, and regression workflows. Basic Verible command integration exists, while broader first-class Verible and PeakRDL workflows are on the roadmap.
+It is built to sit on top of the tools your project already uses, while giving you a cleaner, more repeatable interface for day-to-day verification work. The primary supported simulation flows are Verilator and VCS-based compile, simulation, test, regression, as well as Yosys-based synthesis. Basic Verible command integration exists, while broader first-class Verible and PeakRDL workflows are on the roadmap.
 
 Typical commands look like:
 
@@ -34,6 +34,7 @@ uv run rb regression --coverage-merge
 - **Randomized testing support**: create new seeds, repeat runs, and replay previous randomized iterations
 - **Structured config model**: describe suites, regressions, platforms, builders, and models in readable YAML
 - **Filelist generation**: build simulator-ready filelists from `models.yaml`
+- **Synthesis flows**: run Yosys synthesis from `synth.yaml`, including optional Liberty-mapped runs and synthesis regressions
 - **Coverage workflows**: collect, merge, summarize, and export Verilator coverage
 - **Hookable execution flow**: plug in your own sweep generation, test preprocessing, and postprocessing scripts
 - **Verible integration**: invoke lint, syntax, formatting, and preprocessing commands through the same project config
@@ -65,6 +66,7 @@ Prerequisites:
 - A simulator on `PATH`
   - Verilator is the recommended open-source starting point
   - VCS is also supported as a first-class flow
+- Optional: the [rtl-buddy fork of Yosys](https://github.com/rtl-buddy/yosys) if you want to use `uv run rb synth ...`
 - Optional: Verible if you want to use `uv run rb verible ...` — e.g. `brew tap chipsalliance/verible && brew install verible` on macOS, or see [Verible releases](https://github.com/chipsalliance/verible/releases) for other platforms
 - Optional system-level coverage tools:
   - `lcov` for LCOV and HTML coverage export
@@ -83,6 +85,7 @@ Once you have a project set up, the basic commands are:
 ```bash
 uv run rb test basic      # run a single test
 uv run rb regression      # run the full regression
+uv run rb synth -c synth/sandbox/synth.yaml
 ```
 
 For full usage, see the [Quick Start guide](https://rtl-buddy.github.io/rtl_buddy/latest/quickstart/).

--- a/docs/concepts/synthesis.md
+++ b/docs/concepts/synthesis.md
@@ -6,6 +6,37 @@ description: How to run synthesis flows with rtl_buddy using synth.yaml, cfg-syn
 
 `rtl_buddy` provides a tool-agnostic synthesis flow that mirrors the simulation workflow. Synthesis runs are described in `synth.yaml` files; tool-specific defaults live in `root_config.yaml` under `cfg-synth-tools`.
 
+## Installing Yosys
+
+`rtl_buddy` uses the [rtl-buddy fork of Yosys](https://github.com/rtl-buddy/yosys), which tracks upstream with rtl-buddy-specific patches. Build from source:
+
+```bash
+git clone https://github.com/rtl-buddy/yosys.git
+cd yosys
+make config-clang   # or config-gcc on Linux
+make -j$(nproc)
+sudo make install   # installs to /usr/local/bin/yosys
+```
+
+On macOS with Homebrew dependencies:
+
+```bash
+brew install cmake python tcl-tk libffi readline
+git clone https://github.com/rtl-buddy/yosys.git
+cd yosys
+make config-clang
+make -j$(sysctl -n hw.logicalcpu)
+sudo make install
+```
+
+Verify the install:
+
+```bash
+yosys --version
+```
+
+The `yosys` binary must be on `PATH` when `rb synth` is invoked.
+
 ## Synthesis config: `synth.yaml`
 
 A `synth.yaml` file defines one or more synthesis runs for a block.

--- a/docs/concepts/synthesis.md
+++ b/docs/concepts/synthesis.md
@@ -1,10 +1,10 @@
 ---
-description: How to run synthesis flows with rtl_buddy using synth.yaml, cfg-synth-tools, and the rb synth command.
+description: How to run synthesis flows with rtl_buddy using synth.yaml, cfg-synth-tools, cfg-synth-libs, and the rb synth command.
 ---
 
 # Synthesis
 
-`rtl_buddy` provides a tool-agnostic synthesis flow that mirrors the simulation workflow. Synthesis runs are described in `synth.yaml` files; tool-specific defaults live in `root_config.yaml` under `cfg-synth-tools`.
+`rtl_buddy` provides a tool-agnostic synthesis flow that mirrors the simulation workflow. Synthesis runs are described in `synth.yaml` files; tool-specific defaults and PDK library paths live in `root_config.yaml`.
 
 ## Installing Yosys
 
@@ -45,11 +45,22 @@ A `synth.yaml` file defines one or more synthesis runs for a block.
 rtl-buddy-filetype: synth_config
 
 syntheses:
+  # Technology-independent run
   - name: "sandbox_synth"
     desc: "Synthesize sandbox module with Yosys"
     model: "test_module"
     model_path: "../../design/sandbox/models.yaml"
     tool: "yosys"
+    reglvl: 0
+
+  # Technology-mapped run targeting SKY130
+  - name: "sandbox_sky130"
+    desc: "Synthesize sandbox module targeting SKY130 HD TT corner"
+    model: "test_module"
+    model_path: "../../design/sandbox/models.yaml"
+    tool: "yosys"
+    libraries:
+      - "sky130hd_tt"
     constraints: "constraints.sdc"
     params:
       WIDTH: 8
@@ -58,7 +69,7 @@ syntheses:
     reglvl: 0
     tool_overrides:
       yosys:
-        abc_args: "-fast"
+        synth_args: "-flatten"
 ```
 
 ### Synthesis fields
@@ -70,11 +81,24 @@ syntheses:
 | `model` | Model name from `models.yaml`; also used as the synthesis top module |
 | `model_path` | Path to `models.yaml`, resolved relative to the `synth.yaml` directory |
 | `tool` | Synthesis tool name — must match a `cfg-synth-tools` entry in `root_config.yaml` |
+| `libraries` | Optional list of library names from `cfg-synth-libs`; enables technology mapping |
 | `constraints` | Optional SDC constraints file, resolved relative to `synth.yaml` |
 | `params` | Optional key-value pairs passed as top-level parameter overrides (`chparam` in Yosys) |
 | `defines` | Optional compile-time Verilog defines passed via `-D KEY=VALUE` |
 | `reglvl` | Regression level (int or per-tool dict); same semantics as simulation `reglvl` |
 | `tool_overrides` | Optional per-tool option overrides — keyed by tool name, merges over `cfg-synth-tools` defaults |
+
+### SDC constraints
+
+When `constraints` points to an SDC file, the Yosys backend extracts the `create_clock` period and passes it to ABC as `-D <period_ps>` for timing-driven technology mapping. The critical path delay is then used to compute WNS in the results table.
+
+```sdc
+create_clock -period 10.0 [get_ports clk]
+set_input_delay  2.0 -clock clk [all_inputs]
+set_output_delay 2.0 -clock clk [all_outputs]
+```
+
+**Multi-clock designs:** ABC's `-D` flag takes a single timing window. When multiple `create_clock` entries are present, `rtl_buddy` uses the minimum period as a workaround and emits a warning. For proper multi-clock synthesis, create separate `synth.yaml` entries per clock domain, each with its own SDC.
 
 ### Regression levels
 
@@ -92,7 +116,7 @@ reglvl:
 
 ### Per-tool overrides
 
-`tool_overrides` is an escape hatch for tool-specific options that don't have a tool-agnostic equivalent. Keys within each tool entry match the `opts` fields defined in `cfg-synth-tools`:
+`tool_overrides` is an escape hatch for tool-specific options that don't have a tool-agnostic equivalent. Keys match the `opts` fields in `cfg-synth-tools`:
 
 ```yaml
 tool_overrides:
@@ -101,11 +125,11 @@ tool_overrides:
     abc_args: "-fast"
 ```
 
-Overrides merge over the root-config defaults for that tool.
+## Root config: `root_config.yaml`
 
-## Tool configuration: `root_config.yaml`
+### Synthesis tool configuration
 
-Synthesis tool defaults are defined under `cfg-synth-tools` in `root_config.yaml`:
+Synthesis tool defaults live under `cfg-synth-tools`:
 
 ```yaml
 cfg-synth-tools:
@@ -117,6 +141,27 @@ cfg-synth-tools:
 ```
 
 Multiple tools can be listed. The `tool` field in `synth.yaml` selects which entry to use.
+
+### PDK library configuration
+
+Liberty files for technology mapping are registered under `cfg-synth-libs`. Paths are resolved relative to `root_config.yaml`:
+
+```yaml
+cfg-synth-libs:
+  - name: "sky130hd_tt"
+    path: "pdk/sky130hd/lib/sky130_fd_sc_hd__tt_025C_1v80.lib"
+  - name: "sky130hd_ss"
+    path: "pdk/sky130hd/lib/sky130_fd_sc_hd__ss_100C_1v60.lib"
+```
+
+The `libraries` list in `synth.yaml` references entries by name. When libraries are specified, the Yosys backend switches to a technology-mapped flow: `read_liberty` → `synth` → `dfflibmap` → `abc -liberty` → `write_verilog`.
+
+Liberty files are typically large and should be gitignored. Provide a download script in your project:
+
+```bash
+# pdk/download_pdk.sh
+curl -fL <liberty-url> -o pdk/sky130hd/lib/sky130_fd_sc_hd__tt_025C_1v80.lib
+```
 
 ## Synthesis regression: `synth_regression.yaml`
 
@@ -141,7 +186,7 @@ rtl-buddy synth -c synth/sandbox/synth.yaml
 
 Run a named synthesis:
 ```bash
-rtl-buddy synth sandbox_synth -c synth/sandbox/synth.yaml
+rtl-buddy synth sandbox_sky130 -c synth/sandbox/synth.yaml
 ```
 
 List syntheses without running:
@@ -159,6 +204,27 @@ Run only up to regression level 0:
 rtl-buddy synth-regression -c synth_regression.yaml --reg-level 0
 ```
 
+## Results table
+
+`rb synth` prints a results table after each run. Columns appear conditionally:
+
+```
+┏━━━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━┓
+┃ Synthesis      ┃ Result ┃ Description      ┃ Gates ┃ Area       ┃ WNS       ┃
+┡━━━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━┩
+│ sandbox_synth  │ PASS   │ Synthesis passed │ 18    │ -          │ -         │
+│ sandbox_sky130 │ PASS   │ Synthesis passed │ 18    │ 178.92 µm² │ +8.882 ns │
+└────────────────┴────────┴──────────────────┴───────┴────────────┴───────────┘
+```
+
+| Column | Source | When shown |
+|--------|--------|-----------|
+| **Gates** | `stat` cell count | Always (all Yosys flows) |
+| **Area** | `stat -liberty` chip area | Lib-mapped flows only |
+| **WNS** | Clock period − critical path (`stime -p`) | Lib-mapped flows with SDC clock constraint |
+
+WNS (Worst Negative Slack) is positive when timing is met and negative when violated.
+
 ## Artefacts
 
 Synthesis artefacts land under `artefacts/<synth_name>/` relative to the `synth.yaml` directory:
@@ -168,7 +234,8 @@ Synthesis artefacts land under `artefacts/<synth_name>/` relative to the `synth.
 | `synth.f` | Generated source filelist (resolved from `models.yaml`) |
 | `synth.ys` | Generated Yosys script |
 | `synth.log` | Captured tool stdout and stderr |
-| `synth.rtlil` | Output netlist (RTLIL format) |
+| `synth.rtlil` | Output netlist, technology-independent flow (RTLIL format) |
+| `synth_netlist.v` | Output netlist, technology-mapped flow (Verilog) |
 
 ## Pass/fail detection
 

--- a/docs/concepts/synthesis.md
+++ b/docs/concepts/synthesis.md
@@ -1,0 +1,153 @@
+---
+description: How to run synthesis flows with rtl_buddy using synth.yaml, cfg-synth-tools, and the rb synth command.
+---
+
+# Synthesis
+
+`rtl_buddy` provides a tool-agnostic synthesis flow that mirrors the simulation workflow. Synthesis runs are described in `synth.yaml` files; tool-specific defaults live in `root_config.yaml` under `cfg-synth-tools`.
+
+## Synthesis config: `synth.yaml`
+
+A `synth.yaml` file defines one or more synthesis runs for a block.
+
+```yaml
+rtl-buddy-filetype: synth_config
+
+syntheses:
+  - name: "sandbox_synth"
+    desc: "Synthesize sandbox module with Yosys"
+    model: "test_module"
+    model_path: "../../design/sandbox/models.yaml"
+    tool: "yosys"
+    constraints: "constraints.sdc"
+    params:
+      WIDTH: 8
+    defines:
+      TARGET_SYNTH: 1
+    reglvl: 0
+    tool_overrides:
+      yosys:
+        abc_args: "-fast"
+```
+
+### Synthesis fields
+
+| Field | Description |
+|-------|-------------|
+| `name` | Run identifier used on the command line and in artefact paths |
+| `desc` | Human-readable description |
+| `model` | Model name from `models.yaml`; also used as the synthesis top module |
+| `model_path` | Path to `models.yaml`, resolved relative to the `synth.yaml` directory |
+| `tool` | Synthesis tool name — must match a `cfg-synth-tools` entry in `root_config.yaml` |
+| `constraints` | Optional SDC constraints file, resolved relative to `synth.yaml` |
+| `params` | Optional key-value pairs passed as top-level parameter overrides (`chparam` in Yosys) |
+| `defines` | Optional compile-time Verilog defines passed via `-D KEY=VALUE` |
+| `reglvl` | Regression level (int or per-tool dict); same semantics as simulation `reglvl` |
+| `tool_overrides` | Optional per-tool option overrides — keyed by tool name, merges over `cfg-synth-tools` defaults |
+
+### Regression levels
+
+`reglvl` works the same way as for simulation tests. Use `--reg-level` on `synth-regression` to filter by level.
+
+```yaml
+# Same level for all tools
+reglvl: 0
+
+# Tool-specific with fallback
+reglvl:
+  default: 0
+  dc: 1000
+```
+
+### Per-tool overrides
+
+`tool_overrides` is an escape hatch for tool-specific options that don't have a tool-agnostic equivalent. Keys within each tool entry match the `opts` fields defined in `cfg-synth-tools`:
+
+```yaml
+tool_overrides:
+  yosys:
+    synth_args: "-flatten -nordff"
+    abc_args: "-fast"
+```
+
+Overrides merge over the root-config defaults for that tool.
+
+## Tool configuration: `root_config.yaml`
+
+Synthesis tool defaults are defined under `cfg-synth-tools` in `root_config.yaml`:
+
+```yaml
+cfg-synth-tools:
+  - name: "yosys"
+    tool: "yosys"        # executable name (must be on PATH)
+    opts:
+      synth-args: ""
+      abc-args: ""
+```
+
+Multiple tools can be listed. The `tool` field in `synth.yaml` selects which entry to use.
+
+## Synthesis regression: `synth_regression.yaml`
+
+`synth_regression.yaml` lists the `synth.yaml` files to include in a synthesis regression:
+
+```yaml
+rtl-buddy-filetype: synth_reg_config
+
+synth-configs:
+  - "synth/sandbox/synth.yaml"
+  - "synth/dma/synth.yaml"
+```
+
+Paths are resolved relative to `synth_regression.yaml`.
+
+## Running synthesis
+
+Run all syntheses in a config:
+```bash
+rtl-buddy synth -c synth/sandbox/synth.yaml
+```
+
+Run a named synthesis:
+```bash
+rtl-buddy synth sandbox_synth -c synth/sandbox/synth.yaml
+```
+
+List syntheses without running:
+```bash
+rtl-buddy synth --list -c synth/sandbox/synth.yaml
+```
+
+Run a synthesis regression:
+```bash
+rtl-buddy synth-regression -c synth_regression.yaml
+```
+
+Run only up to regression level 0:
+```bash
+rtl-buddy synth-regression -c synth_regression.yaml --reg-level 0
+```
+
+## Artefacts
+
+Synthesis artefacts land under `artefacts/<synth_name>/` relative to the `synth.yaml` directory:
+
+| File | Contents |
+|------|----------|
+| `synth.f` | Generated source filelist (resolved from `models.yaml`) |
+| `synth.ys` | Generated Yosys script |
+| `synth.log` | Captured tool stdout and stderr |
+| `synth.rtlil` | Output netlist (RTLIL format) |
+
+## Pass/fail detection
+
+A synthesis run is marked **PASS** when:
+
+1. The tool exits with code 0, **and**
+2. No lines starting with `ERROR:` appear in `synth.log`.
+
+Any other outcome is **FAIL** with a description in the results table.
+
+## Full schema
+
+See [YAML Formats: synth.yaml](../reference/yaml.md#synthyaml) for the complete field reference.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,12 +1,12 @@
 ---
-description: RTL Buddy is a Python CLI for Verilog and SystemVerilog regression testing, Verilator and VCS simulation workflows, coverage, and YAML-based RTL verification automation.
+description: RTL Buddy is a Python CLI for Verilog and SystemVerilog regression testing, Verilator and VCS simulation workflows, Yosys synthesis flows, coverage, and YAML-based RTL automation.
 ---
 
 # RTL Buddy
 
-RTL Buddy is a Python CLI for Verilog and SystemVerilog RTL verification workflows, including test execution, randomized regression testing, Verilator and VCS simulation, coverage collection, and YAML-based automation.
+RTL Buddy is a Python CLI for Verilog and SystemVerilog RTL workflows, including test execution, randomized regression testing, Verilator and VCS simulation, Yosys synthesis, coverage collection, and YAML-based automation.
 
-It wraps simulation tools and project scripts to provide a structured, config-driven test and regression system for ASIC and FPGA projects. The primary supported flows are Verilator on macOS/Linux and VCS on Linux.
+It wraps simulation, synthesis, and project scripts to provide a structured, config-driven test, regression, and synthesis system for ASIC and FPGA projects. The primary supported simulation flows are Verilator on macOS/Linux and VCS on Linux.
 
 ## Features
 
@@ -14,11 +14,12 @@ It wraps simulation tools and project scripts to provide a structured, config-dr
 - Randomized seed testing with repeat and replay support
 - Plugin hooks for sweep generation, test pre-processing, and post-processing
 - Filelist generation from `models.yaml`
+- Yosys synthesis runs and synthesis regressions from `synth.yaml`
 - Verilator coverage collection, merge, summary, and export workflows
 - Basic Verible command integration for lint, syntax, formatting, and preprocessing
 - Machine-readable JSONL logging for use with AI agents and CI pipelines
 
-`rtl_buddy` can be adapted to different project toolchains, but the primary supported flows are Verilator and VCS. Broader first-class Verible and PeakRDL workflows are on the roadmap.
+`rtl_buddy` can be adapted to different project toolchains, but the primary supported simulation flows are Verilator and VCS, and synthesis through Yosys. Broader first-class Verible and PeakRDL workflows are on the roadmap.
 
 ## SystemVerilog Regression Testing
 
@@ -27,6 +28,10 @@ RTL Buddy keeps simulator invocation, seeds, logs, result handling, and regressi
 ## Verilator and VCS Simulation Workflows
 
 The CLI gives RTL projects one command surface for open-source Verilator flows and Linux VCS flows, with optional hooks for project-specific compile, simulation, sweep, and post-processing behavior.
+
+## Yosys Synthesis Workflows
+
+Synthesis configs use the same YAML-driven style as tests and regressions. Projects can define technology-independent or Liberty-mapped Yosys runs, capture synthesis artefacts, and run synthesis regressions from one command surface.
 
 ## Getting Started
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,10 +1,10 @@
 ---
-description: Run your first rtl_buddy test, regression, and supporting commands in an already-installed project.
+description: Run your first rtl_buddy test, regression, synthesis, and supporting commands in an already-installed project.
 ---
 
 # Quick Start
 
-Use this guide to run your first `rtl_buddy` test, regression, and supporting commands in an already-installed project.
+Use this guide to run your first `rtl_buddy` test, regression, synthesis, and supporting commands in an already-installed project.
 
 ## Run a test
 
@@ -44,6 +44,22 @@ This uses the regression config path from `root_config.yaml`. To specify a diffe
 uv run rb regression --reg-config path/to/regressions.yaml
 ```
 
+## Run synthesis
+
+List synthesis entries in a config:
+
+```bash
+uv run rb synth --list --synth-config path/to/synth.yaml
+```
+
+Run a synthesis entry:
+
+```bash
+uv run rb synth smoke_synth --synth-config path/to/synth.yaml
+```
+
+See [Synthesis](concepts/synthesis.md) for `synth.yaml`, tool, and library configuration.
+
 ## Run with randomization
 
 Run a test once with a new random seed:
@@ -82,4 +98,5 @@ In machine mode, `rtl_buddy.log` is written as JSON Lines and console output is 
 
 - [Concepts: Tests](concepts/tests.md) — understand the test config model
 - [Concepts: Regressions](concepts/regressions.md) — run multi-suite regressions
+- [Concepts: Synthesis](concepts/synthesis.md) — run Yosys synthesis flows
 - [YAML Formats](reference/yaml.md) — full config file reference

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -42,14 +42,16 @@ Usage: rtl-buddy [OPTIONS] COMMAND [ARGS]...
 │                                                              exit.                   │
 ╰──────────────────────────────────────────────────────────────────────────────────────╯
 ╭─ Commands ───────────────────────────────────────────────────────────────────────────╮
-│ test        run a simple test                                                        │
-│ randtest    repeat a test with multiple random seeds                                 │
-│ regression  run rtl regression                                                       │
-│ filelist    generate filelists using models.yaml                                     │
-│ verible     run verible cmd                                                          │
-│ skill       manage the rtl_buddy agent skill                                         │
-│ docs        browse bundled documentation                                             │
-│ spec        spec traceability commands                                               │
+│ test              run a simple test                                                  │
+│ randtest          repeat a test with multiple random seeds                           │
+│ regression        run rtl regression                                                 │
+│ filelist          generate filelists using models.yaml                               │
+│ verible           run verible cmd                                                    │
+│ synth             run synthesis                                                      │
+│ synth-regression  run synthesis regression                                           │
+│ skill             manage the rtl_buddy agent skill                                   │
+│ docs              browse bundled documentation                                       │
+│ spec              spec traceability commands                                         │
 ╰──────────────────────────────────────────────────────────────────────────────────────╯
 ```
 

--- a/docs/reference/yaml.md
+++ b/docs/reference/yaml.md
@@ -1,5 +1,5 @@
 ---
-description: Canonical reference for all rtl_buddy YAML configuration files: root_config.yaml, regression.yaml, tests.yaml, and models.yaml.
+description: Canonical reference for rtl_buddy YAML configuration files, including root_config.yaml, regression.yaml, tests.yaml, models.yaml, synth.yaml, and synth_regression.yaml.
 ---
 
 # YAML Formats
@@ -8,7 +8,7 @@ This page is the canonical reference for all `rtl_buddy` configuration files. Us
 
 ## root_config.yaml
 
-The root config lives at the project root. It defines platforms, builders, Verible, and the default regression config path.
+The root config lives at the project root. It defines platforms, builders, Verible, coverage, synthesis tools, synthesis libraries, and the default regression config path.
 
 **Required keys:**
 
@@ -60,6 +60,17 @@ cfg-coverview:
     config:
       # inline Coverview JSON configuration values
 
+cfg-synth-tools:
+  - name: "yosys"
+    tool: "yosys"
+    opts:
+      synth-args: ""
+      abc-args: ""
+
+cfg-synth-libs:
+  - name: "sky130hd_tt"
+    path: "pdk/sky130hd/lib/sky130_fd_sc_hd__tt_025C_1v80.lib"
+
 cfg-rtl-reg:
   reg-cfg-path: "design/regression.yaml"
 ```
@@ -71,6 +82,8 @@ cfg-rtl-reg:
 - `--builder-mode` selects which named `builder-opts` entry to use for compile-time and run-time flags.
 - `cfg-coverage` is keyed by simulator family (e.g. `verilator`). `use-lcov: true` enables `.info` export and LCOV HTML generation when `--coverage-html` is used.
 - `cfg-coverview` is keyed by simulator family. `generate-tables` sets the coverage type for Coverview tables. `config` is a dict of inline Coverview JSON configuration values.
+- `cfg-synth-tools` defines synthesis tool entries selected by `synth.yaml` `tool` fields. `tool` is the executable name on `PATH`; `opts.synth-args` are appended to the Yosys `synth` command, and `opts.abc-args` are used by the unmapped ABC step.
+- `cfg-synth-libs` defines named Liberty files for technology-mapped synthesis. Relative paths are resolved from the directory containing `root_config.yaml`.
 - `cfg-rtl-reg.reg-cfg-path` is the fallback regression file for `rtl-buddy regression` when no `./regression.yaml` exists in the cwd.
 - `cfg-verible[].path` is the directory containing Verible executables. Absolute paths are used as-is; relative paths are resolved from the directory containing `root_config.yaml`.
 
@@ -258,6 +271,97 @@ cocotb writes a JUnit XML results file (`cocotb_results.xml`) instead of `PASS`/
 - `regression` does `chdir` into each suite directory before executing.
 - Preproc plusargs are passed to the simulator verbatim. Resolve suite-local input paths explicitly against `suite_dir`; keep output filenames artifact-relative when they should land under `artefacts/{test_name}/`.
 - For portable configs in multi-suite repos, make paths in `tests.yaml` explicit and verify they resolve correctly from the intended invocation directory.
+
+---
+
+## synth.yaml
+
+**Required keys:**
+
+- `rtl-buddy-filetype: synth_config`
+- `syntheses`
+
+**Example:**
+
+```yaml
+rtl-buddy-filetype: synth_config
+
+syntheses:
+  - name: "smoke_synth"
+    desc: "Synthesize my_design with the default Yosys flow"
+    model: "my_design"
+    model_path: "../src/models.yaml"
+    tool: "yosys"
+    reglvl: 0
+
+  - name: "sky130_synth"
+    desc: "Technology-mapped synthesis for SKY130"
+    model: "my_design"
+    model_path: "../src/models.yaml"
+    tool: "yosys"
+    constraints: "constraints.sdc"
+    libraries:
+      - "sky130hd_tt"
+    params:
+      WIDTH: 32
+    defines:
+      TARGET_SYNTH: 1
+    reglvl:
+      default: 0
+      dc: 1000
+    tool_overrides:
+      yosys:
+        synth_args: "-flatten"
+```
+
+**Field reference:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Synthesis identifier; used on the CLI and in `artefacts/{name}/` |
+| `desc` | string | Human-readable synthesis description |
+| `model` | string | Model name from `models.yaml`; also used as the Yosys top module |
+| `model_path` | string | Path to `models.yaml`, resolved relative to the `synth.yaml` file |
+| `tool` | string | Synthesis tool name from `root_config.yaml` `cfg-synth-tools` |
+| `constraints` | string | Optional SDC file path, resolved relative to the `synth.yaml` file |
+| `params` | dict | Optional top-level parameter overrides passed through Yosys `chparam -set` |
+| `defines` | dict | Optional Verilog defines passed to `read_verilog` as `-D KEY=VALUE` |
+| `libraries` | list of strings | Optional Liberty library names from `cfg-synth-libs`; enables technology mapping |
+| `reglvl` | int or dict | Regression level; int for all tools, dict for per-tool with `default` |
+| `tool_overrides` | dict | Optional per-tool overrides for `synth_args` and `abc_args`, keyed by synthesis tool name |
+
+**Runtime effects:**
+
+- `rtl-buddy synth` loads `synth.yaml`, generates `artefacts/{synth_name}/synth.f`, writes a Yosys script to `synth.ys`, captures output in `synth.log`, and emits either `synth.rtlil` or a mapped `synth_netlist.v`.
+- Without `libraries`, the Yosys backend runs a technology-independent flow and writes RTLIL.
+- With `libraries`, the backend reads Liberty files from `cfg-synth-libs`, runs `dfflibmap` and `abc -liberty`, writes a Verilog netlist, and reports area when Yosys prints a chip-area line.
+- If `constraints` contains one or more `create_clock -period` entries, the backend passes the minimum period to ABC as `-D <period_ps>` and reports WNS when ABC timing is available.
+- A run passes only when the tool exits with code 0 and `synth.log` contains no lines starting with `ERROR:`.
+
+---
+
+## synth_regression.yaml
+
+**Required keys:**
+
+- `rtl-buddy-filetype: synth_reg_config`
+- `synth-configs`
+
+**Example:**
+
+```yaml
+rtl-buddy-filetype: synth_reg_config
+
+synth-configs:
+  - "design/example_block_a/synth/synth.yaml"
+  - "design/example_block_b/synth/synth.yaml"
+```
+
+**Runtime effects:**
+
+- `rtl-buddy synth-regression` iterates each listed `synth.yaml` file and filters syntheses by `--reg-level`.
+- Paths in `synth-configs` are resolved relative to the `synth_regression.yaml` file.
+- `synth-regression` changes directory into each synthesis suite directory before executing its entries.
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,6 +43,7 @@ nav:
       - Plugins: concepts/plugins.md
       - cocotb: concepts/cocotb.md
       - Spec Traceability: concepts/spec-traceability.md
+      - Synthesis: concepts/synthesis.md
   - Reference:
       - CLI: reference/cli.md
       - YAML Formats: reference/yaml.md

--- a/src/rtl_buddy/config/__init__.py
+++ b/src/rtl_buddy/config/__init__.py
@@ -15,6 +15,7 @@ from .spec import SpecConfig, SpecBlock, SpecCoverageItem
 from .verible import VeribleConfig
 from .coverage import CoverageConfig, CoverageConfigFile
 from .coverview import CoverviewConfig, CoverviewConfigFile
+from .synth import SynthConfig, SynthSuiteConfig, SynthRegConfig, SynthToolConfig
 
 __all__ = [
     "TestConfig",
@@ -34,4 +35,8 @@ __all__ = [
     "SpecConfig",
     "SpecBlock",
     "SpecCoverageItem",
+    "SynthConfig",
+    "SynthSuiteConfig",
+    "SynthRegConfig",
+    "SynthToolConfig",
 ]

--- a/src/rtl_buddy/config/__init__.py
+++ b/src/rtl_buddy/config/__init__.py
@@ -15,7 +15,13 @@ from .spec import SpecConfig, SpecBlock, SpecCoverageItem
 from .verible import VeribleConfig
 from .coverage import CoverageConfig, CoverageConfigFile
 from .coverview import CoverviewConfig, CoverviewConfigFile
-from .synth import SynthConfig, SynthSuiteConfig, SynthRegConfig, SynthToolConfig
+from .synth import (
+    SynthConfig,
+    SynthSuiteConfig,
+    SynthRegConfig,
+    SynthToolConfig,
+    SynthLibConfig,
+)
 
 __all__ = [
     "TestConfig",
@@ -39,4 +45,5 @@ __all__ = [
     "SynthSuiteConfig",
     "SynthRegConfig",
     "SynthToolConfig",
+    "SynthLibConfig",
 ]

--- a/src/rtl_buddy/config/root.py
+++ b/src/rtl_buddy/config/root.py
@@ -16,7 +16,12 @@ from .rtl import RtlBuilderConfig
 from .verible import VeribleConfigFile
 from .coverage import CoverageConfigFile
 from .coverview import CoverviewConfigFile
-from .synth import SynthToolConfig, SynthToolConfigFile
+from .synth import (
+    SynthToolConfig,
+    SynthToolConfigFile,
+    SynthLibConfig,
+    SynthLibConfigFile,
+)
 from ..errors import FatalRtlBuddyError
 from ..logging_utils import log_event
 
@@ -96,6 +101,9 @@ class RootConfigFile:
     synth_tools: list[SynthToolConfigFile] = field(
         rename="cfg-synth-tools", default_factory=list
     )
+    synth_libs: list[SynthLibConfigFile] = field(
+        rename="cfg-synth-libs", default_factory=list
+    )
 
 
 class RootConfig:
@@ -138,6 +146,7 @@ class RootConfig:
         self.coverage_cfgs = dict()
         self.coverview_cfgs = dict()
         self.synth_tool_cfgs = dict()
+        self.synth_lib_cfgs = dict()
         self.platform_cfg = None
         self.reg_cfg = None  # initialise later when get_rtl_reg_cfg is called
 
@@ -177,6 +186,12 @@ class RootConfig:
             # Populate synth tool configs
             self.synth_tool_cfgs = {
                 cfg.name: SynthToolConfig(cfg) for cfg in data.synth_tools
+            }
+
+            # Populate synth lib configs
+            self.synth_lib_cfgs = {
+                cfg.name: SynthLibConfig(cfg, self.root_cfg_path)
+                for cfg in data.synth_libs
             }
 
             # Initialise regression config
@@ -363,6 +378,24 @@ class RootConfig:
         if cfg is None:
             raise FatalRtlBuddyError(
                 f"synthesis tool '{name}' not found in cfg-synth-tools"
+            )
+        return cfg
+
+    def get_synth_lib_cfg(self, name: str):
+        """
+        Get synthesis library configuration by name.
+
+        Args:
+          name (str): Library name as defined in cfg-synth-libs.
+        Returns:
+          cfg (SynthLibConfig): Matching synthesis library configuration.
+        Raises:
+          FatalRtlBuddyError: If no library with that name is configured.
+        """
+        cfg = self.synth_lib_cfgs.get(name)
+        if cfg is None:
+            raise FatalRtlBuddyError(
+                f"synthesis library '{name}' not found in cfg-synth-libs"
             )
         return cfg
 

--- a/src/rtl_buddy/config/root.py
+++ b/src/rtl_buddy/config/root.py
@@ -16,6 +16,7 @@ from .rtl import RtlBuilderConfig
 from .verible import VeribleConfigFile
 from .coverage import CoverageConfigFile
 from .coverview import CoverviewConfigFile
+from .synth import SynthToolConfig, SynthToolConfigFile
 from ..errors import FatalRtlBuddyError
 from ..logging_utils import log_event
 
@@ -92,6 +93,9 @@ class RootConfigFile:
     coverviews: list[CoverviewConfigFile] = field(
         rename="cfg-coverview", default_factory=list
     )
+    synth_tools: list[SynthToolConfigFile] = field(
+        rename="cfg-synth-tools", default_factory=list
+    )
 
 
 class RootConfig:
@@ -133,6 +137,7 @@ class RootConfig:
         self.verible_cfgs = dict()
         self.coverage_cfgs = dict()
         self.coverview_cfgs = dict()
+        self.synth_tool_cfgs = dict()
         self.platform_cfg = None
         self.reg_cfg = None  # initialise later when get_rtl_reg_cfg is called
 
@@ -167,6 +172,11 @@ class RootConfig:
             self.coverage_cfgs = {cfg.name: cfg.initialise() for cfg in data.coverages}
             self.coverview_cfgs = {
                 cfg.name: cfg.initialise(self.root_cfg_path) for cfg in data.coverviews
+            }
+
+            # Populate synth tool configs
+            self.synth_tool_cfgs = {
+                cfg.name: SynthToolConfig(cfg) for cfg in data.synth_tools
             }
 
             # Initialise regression config
@@ -337,6 +347,24 @@ class RootConfig:
           cfg (CoverviewConfig|None): Matching Coverview configuration, if present.
         """
         return self.coverview_cfgs.get(simulator_name)
+
+    def get_synth_tool_cfg(self, name: str):
+        """
+        Get synthesis tool configuration by name.
+
+        Args:
+          name (str): Tool name as defined in cfg-synth-tools.
+        Returns:
+          cfg (SynthToolConfig): Matching synthesis tool configuration.
+        Raises:
+          FatalRtlBuddyError: If no tool with that name is configured.
+        """
+        cfg = self.synth_tool_cfgs.get(name)
+        if cfg is None:
+            raise FatalRtlBuddyError(
+                f"synthesis tool '{name}' not found in cfg-synth-tools"
+            )
+        return cfg
 
     def get_project_rootdir(self):
         """

--- a/src/rtl_buddy/config/synth.py
+++ b/src/rtl_buddy/config/synth.py
@@ -1,0 +1,257 @@
+import logging
+import os
+import pprint
+from dataclasses import dataclass
+
+from serde import serde, field
+from serde.yaml import from_yaml
+from typing import Literal
+
+from .model import ModelConfig, ModelConfigLoader
+from ..errors import FatalRtlBuddyError
+from ..logging_utils import log_event
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SynthToolOpts:
+    synth_args: str = ""
+    abc_args: str = ""
+
+
+@serde
+class SynthToolOptsFile:
+    synth_args: str = field(rename="synth-args", default="")
+    abc_args: str = field(rename="abc-args", default="")
+
+
+@serde
+class SynthToolConfigFile:
+    name: str
+    tool: str
+    opts: SynthToolOptsFile = field(default_factory=SynthToolOptsFile)
+
+
+class SynthToolConfig:
+    def __init__(self, cfg: SynthToolConfigFile):
+        self._cfg = cfg
+
+    def get_name(self) -> str:
+        return self._cfg.name
+
+    def get_executable(self) -> str:
+        return self._cfg.tool
+
+    def get_opts(self, overrides: dict | None = None) -> SynthToolOpts:
+        synth_args = self._cfg.opts.synth_args
+        abc_args = self._cfg.opts.abc_args
+        if overrides:
+            synth_args = overrides.get("synth_args", synth_args)
+            abc_args = overrides.get("abc_args", abc_args)
+        return SynthToolOpts(synth_args=synth_args, abc_args=abc_args)
+
+
+@serde
+class SynthConfigFile:
+    name: str
+    desc: str
+    model: str
+    model_path: str = field(rename="model_path")
+    tool: str
+    constraints: str | None = None
+    params: dict | None = None
+    defines: dict | None = None
+    reglvl: int | dict | None = field(rename="reglvl", default=None)
+    tool_overrides: dict | None = None
+
+    def initialise(self, config_dir: str) -> "SynthConfig":
+        model = ModelConfigLoader(os.path.join(config_dir, self.model_path)).get_model(
+            self.model
+        )
+        constraints = (
+            os.path.join(config_dir, self.constraints)
+            if self.constraints is not None
+            else None
+        )
+        return SynthConfig(
+            name=self.name,
+            desc=self.desc,
+            model=model,
+            tool=self.tool,
+            constraints=constraints,
+            params=self.params,
+            defines=self.defines,
+            _reglvl=self.reglvl,
+            tool_overrides=self.tool_overrides,
+        )
+
+
+@dataclass
+class SynthConfig:
+    name: str
+    desc: str
+    model: ModelConfig
+    tool: str
+    constraints: str | None
+    params: dict | None
+    defines: dict | None
+    _reglvl: int | dict | None
+    tool_overrides: dict | None
+
+    def get_name(self) -> str:
+        return self.name
+
+    def get_model(self) -> ModelConfig:
+        return self.model
+
+    def get_top(self) -> str:
+        return self.model.name
+
+    def get_constraints(self) -> str | None:
+        return self.constraints
+
+    def get_params(self) -> dict | None:
+        return self.params
+
+    def get_defines(self) -> dict | None:
+        return self.defines
+
+    def get_tool_name(self) -> str:
+        return self.tool
+
+    def get_tool_overrides_for(self, tool_name: str) -> dict | None:
+        if self.tool_overrides is None:
+            return None
+        return self.tool_overrides.get(tool_name)
+
+    def get_reglvl(self, tool_name: str) -> int:
+        match self._reglvl:
+            case int() as lvl:
+                return lvl
+            case dict() if tool_name in self._reglvl:
+                return self._reglvl[tool_name]
+            case dict() if "default" in self._reglvl:
+                return self._reglvl["default"]
+            case None:
+                return 0
+            case _:
+                log_event(
+                    logger,
+                    logging.ERROR,
+                    "synth_config.reglvl_malformed",
+                    synth=self.name,
+                    tool=tool_name,
+                )
+                raise FatalRtlBuddyError(
+                    f"Malformed synth.yaml, specify reglvl for {self.name} with {tool_name} or default"
+                )
+
+    def __str__(self):
+        return pprint.pformat(self)
+
+
+@serde
+class SynthSuiteConfigFile:
+    filetype: Literal["synth_config"] = field(rename="rtl-buddy-filetype")
+    syntheses: list[SynthConfigFile]
+
+
+class SynthSuiteConfig:
+    def __init__(self, path: str):
+        self.path = path
+        self.syntheses = {}
+        try:
+            with open(path, "r") as f:
+                data = from_yaml(SynthSuiteConfigFile, f.read())
+        except Exception as e:
+            log_event(
+                logger,
+                logging.ERROR,
+                "synth_suite_config.load_failed",
+                path=path,
+                error=e,
+            )
+            raise FatalRtlBuddyError(f'failed to load "{path}"') from e
+
+        config_dir = os.path.dirname(os.path.abspath(path))
+        try:
+            self.syntheses = {s.name: s.initialise(config_dir) for s in data.syntheses}
+        except Exception as e:
+            log_event(
+                logger,
+                logging.ERROR,
+                "synth_suite_config.syntheses_malformed",
+                path=path,
+                error=e,
+            )
+            raise FatalRtlBuddyError(f"{path}: syntheses section malformed") from e
+
+    def get_syntheses(self, name: str | None = None) -> list[SynthConfig]:
+        if name is not None:
+            if name not in self.syntheses:
+                log_event(
+                    logger,
+                    logging.ERROR,
+                    "synth_suite_config.synth_missing",
+                    path=self.path,
+                    synth=name,
+                )
+                raise FatalRtlBuddyError(
+                    f"synthesis '{name}' not found in suite {self.path}"
+                )
+            return [self.syntheses[name]]
+        return list(self.syntheses.values())
+
+    def get_synth_names(self) -> list[str]:
+        return list(self.syntheses.keys())
+
+    def get_path(self) -> str:
+        return self.path
+
+    def __str__(self):
+        return pprint.pformat(self)
+
+
+@serde
+class SynthRegConfigFile:
+    filetype: Literal["synth_reg_config"] = field(rename="rtl-buddy-filetype")
+    synth_configs: list[str] = field(rename="synth-configs", default_factory=list)
+
+
+class SynthRegConfig:
+    def __init__(self, name: str, path: str):
+        self.name = name
+        self.path = path
+        self.suite_configs = []
+        try:
+            with open(path, "r") as f:
+                data = from_yaml(SynthRegConfigFile, f.read())
+            self.suite_configs = [
+                SynthSuiteConfig(os.path.join(os.path.dirname(path), p))
+                for p in data.synth_configs
+            ]
+        except FatalRtlBuddyError:
+            raise
+        except Exception as e:
+            log_event(
+                logger,
+                logging.ERROR,
+                "synth_reg_config.load_failed",
+                name=name,
+                path=path,
+                error=e,
+            )
+            raise FatalRtlBuddyError(f'{name}: failed to load "{path}"') from e
+
+    def get_name(self) -> str:
+        return self.name
+
+    def get_path(self) -> str:
+        return self.path
+
+    def get_suite_configs(self) -> list[SynthSuiteConfig]:
+        return self.suite_configs
+
+    def __str__(self):
+        return pprint.pformat(self)

--- a/src/rtl_buddy/config/synth.py
+++ b/src/rtl_buddy/config/synth.py
@@ -14,6 +14,26 @@ from ..logging_utils import log_event
 logger = logging.getLogger(__name__)
 
 
+@serde
+class SynthLibConfigFile:
+    name: str
+    path: str
+
+
+class SynthLibConfig:
+    def __init__(self, cfg: SynthLibConfigFile, root_cfg_path: str):
+        self._name = cfg.name
+        self._path = os.path.normpath(
+            os.path.join(os.path.dirname(root_cfg_path), cfg.path)
+        )
+
+    def get_name(self) -> str:
+        return self._name
+
+    def get_path(self) -> str:
+        return self._path
+
+
 @dataclass
 class SynthToolOpts:
     synth_args: str = ""
@@ -62,6 +82,7 @@ class SynthConfigFile:
     constraints: str | None = None
     params: dict | None = None
     defines: dict | None = None
+    libraries: list[str] | None = None
     reglvl: int | dict | None = field(rename="reglvl", default=None)
     tool_overrides: dict | None = None
 
@@ -82,6 +103,7 @@ class SynthConfigFile:
             constraints=constraints,
             params=self.params,
             defines=self.defines,
+            libraries=self.libraries,
             _reglvl=self.reglvl,
             tool_overrides=self.tool_overrides,
         )
@@ -96,6 +118,7 @@ class SynthConfig:
     constraints: str | None
     params: dict | None
     defines: dict | None
+    libraries: list[str] | None
     _reglvl: int | dict | None
     tool_overrides: dict | None
 
@@ -116,6 +139,9 @@ class SynthConfig:
 
     def get_defines(self) -> dict | None:
         return self.defines
+
+    def get_libraries(self) -> list[str] | None:
+        return self.libraries
 
     def get_tool_name(self) -> str:
         return self.tool

--- a/src/rtl_buddy/logging_utils.py
+++ b/src/rtl_buddy/logging_utils.py
@@ -321,6 +321,16 @@ def _human_message(event: str, fields: Mapping[str, Any]) -> str:
             return "verible binaries unavailable"
         case "verible.command_invalid":
             return f'verible: invalid command "{fields.get("command")}"'
+        case "synth.sdc_multi_clock":
+            periods = fields.get("periods_ns", [])
+            used = fields.get("used_ns")
+            return (
+                f"multi-clock SDC ({len(periods)} clocks: {periods} ns) — "
+                f"abc constraint set to minimum {used} ns as a workaround; "
+                "consider separate synth entries per clock domain"
+            )
+        case "synth.sdc_no_clock":
+            return f'no create_clock found in SDC "{fields.get("sdc")}"; abc runs unconstrained'
         case "coverage.metric.failed":
             return (
                 f'coverage metric "{fields.get("metric")}" failed'

--- a/src/rtl_buddy/rtl_buddy.py
+++ b/src/rtl_buddy/rtl_buddy.py
@@ -1346,6 +1346,7 @@ class RtlBuddy:
         raise typer.Exit(0)
 
     def _render_synth_summary(self, title, synth_results, *, metadata=None):
+        has_gates = any("gate_count" in r["results"].results for r in synth_results)
         has_area = any("area_um2" in r["results"].results for r in synth_results)
         has_timing = any("crit_path_ps" in r["results"].results for r in synth_results)
         rows = []
@@ -1356,6 +1357,9 @@ class RtlBuddy:
                 "result": res["result"],
                 "desc": res["desc"],
             }
+            if has_gates:
+                gc = res.get("gate_count")
+                row["gates"] = str(gc) if gc is not None else "-"
             if has_area:
                 area = res.get("area_um2")
                 row["area"] = f"{area:.2f} µm²" if area is not None else "-"
@@ -1369,6 +1373,8 @@ class RtlBuddy:
             ("result", "Result"),
             ("desc", "Description"),
         ]
+        if has_gates:
+            columns.append(("gates", "Gates"))
         if has_area:
             columns.append(("area", "Area"))
         if has_timing:

--- a/src/rtl_buddy/rtl_buddy.py
+++ b/src/rtl_buddy/rtl_buddy.py
@@ -1346,21 +1346,36 @@ class RtlBuddy:
         raise typer.Exit(0)
 
     def _render_synth_summary(self, title, synth_results, *, metadata=None):
-        rows = [
-            {
+        has_area = any("area_um2" in r["results"].results for r in synth_results)
+        has_timing = any("crit_path_ps" in r["results"].results for r in synth_results)
+        rows = []
+        for r in synth_results:
+            res = r["results"].results
+            row = {
                 "synth_name": r["synth_name"],
-                "result": r["results"].results["result"],
-                "desc": r["results"].results["desc"],
+                "result": res["result"],
+                "desc": res["desc"],
             }
-            for r in synth_results
+            if has_area:
+                area = res.get("area_um2")
+                row["area"] = f"{area:.2f} µm²" if area is not None else "-"
+            if has_timing:
+                cp = res.get("crit_path_ps")
+                row["crit_path"] = f"{cp / 1000:.3f} ns" if cp is not None else "-"
+            rows.append(row)
+
+        columns = [
+            ("synth_name", "Synthesis"),
+            ("result", "Result"),
+            ("desc", "Description"),
         ]
+        if has_area:
+            columns.append(("area", "Area"))
+        if has_timing:
+            columns.append(("crit_path", "Crit Path"))
         render_summary(
             title=title,
-            columns=[
-                ("synth_name", "Synthesis"),
-                ("result", "Result"),
-                ("desc", "Description"),
-            ],
+            columns=columns,
             rows=rows,
             logger=logger,
             metadata=metadata,

--- a/src/rtl_buddy/rtl_buddy.py
+++ b/src/rtl_buddy/rtl_buddy.py
@@ -16,6 +16,7 @@ import click
 
 from .config import RegConfig, RootConfig, SuiteConfig, TestConfig
 from .config.model import ModelConfigLoader
+from .config.synth import SynthRegConfig, SynthSuiteConfig
 from .docs_access import get_page, get_section, list_pages
 from .errors import FatalRtlBuddyError, FilelistError
 from .logging_utils import (
@@ -27,6 +28,8 @@ from .logging_utils import (
 )
 from .runner.test_results import SetupFailResults, SkipResults
 from .runner.test_runner import RunDepth, TestRunner
+from .runner.synth_runner import SynthRunner
+from .runner.synth_results import SynthSkipResults
 from .seed_mode import SeedMode
 from .skill_install import app as skill_app
 from .tools.coverage import CoverageReporter
@@ -52,7 +55,14 @@ class RtlBuddy:
     Handles cli entry into RTL Buddy
     """
 
-    _GIT_COMMANDS = {"test", "randtest", "regression", "filelist"}
+    _GIT_COMMANDS = {
+        "test",
+        "randtest",
+        "regression",
+        "filelist",
+        "synth",
+        "synth-regression",
+    }
 
     def cb_builder(value: str | None) -> str | None:
         if value is None:
@@ -94,6 +104,10 @@ class RtlBuddy:
             self.do_gen_model_filelist
         )
         self.app.command("verible", help="run verible cmd")(self.do_verible)
+        self.app.command("synth", help="run synthesis")(self.do_cmd_synth)
+        self.app.command("synth-regression", help="run synthesis regression")(
+            self.do_synth_regression
+        )
         self.app.add_typer(
             skill_app, name="skill", help="manage the rtl_buddy agent skill"
         )
@@ -1330,6 +1344,179 @@ class RtlBuddy:
                 f"Uncovered items: {', '.join(uncovered)}", style="yellow"
             )
         raise typer.Exit(0)
+
+    def _render_synth_summary(self, title, synth_results, *, metadata=None):
+        rows = [
+            {
+                "synth_name": r["synth_name"],
+                "result": r["results"].results["result"],
+                "desc": r["results"].results["desc"],
+            }
+            for r in synth_results
+        ]
+        render_summary(
+            title=title,
+            columns=[
+                ("synth_name", "Synthesis"),
+                ("result", "Result"),
+                ("desc", "Description"),
+            ],
+            rows=rows,
+            logger=logger,
+            metadata=metadata,
+        )
+
+    def _exit_code_from_synth_results(self, synth_results):
+        return 0 if all(r["results"].is_pass() for r in synth_results) else 1
+
+    def _do_synth_suite(self, suite_cfg, synth_name=None, reg_level=None):
+        syntheses = suite_cfg.get_syntheses(synth_name)
+        suite_dir = str(Path(suite_cfg.get_path()).resolve().parent)
+        results = []
+        for s in syntheses:
+            tool_name = s.get_tool_name()
+            t_lvl = s.get_reglvl(tool_name)
+            if reg_level is not None and t_lvl > reg_level:
+                log_event(
+                    logger,
+                    logging.INFO,
+                    "synth_suite.skip",
+                    synth=s.get_name(),
+                    reason="above_regression_level",
+                    synth_level=t_lvl,
+                    reg_level=reg_level,
+                )
+                results.append(
+                    {
+                        "synth_name": s.get_name(),
+                        "results": SynthSkipResults(
+                            name=s.get_name() + "/results",
+                            desc=f"lvl {t_lvl} > cmd reg_level {reg_level}",
+                        ),
+                    }
+                )
+                continue
+            runner = SynthRunner(
+                name=self.name + "/synth_runner",
+                root_cfg=self.root_cfg,
+                synth_cfg=s,
+                suite_dir=suite_dir,
+            )
+            results.append({"synth_name": s.get_name(), "results": runner.run()})
+        return results
+
+    def do_cmd_synth(
+        self,
+        synth_config: Annotated[
+            str,
+            typer.Option("-c", "--synth-config", help="synth.yaml to use"),
+        ] = "synth.yaml",
+        synth_name: Annotated[
+            str,
+            typer.Argument(
+                help="name of synthesis to run", show_default="run all syntheses"
+            ),
+        ] = None,
+        list_synths: Annotated[
+            bool,
+            typer.Option(
+                "--list", help="list syntheses in the selected config and exit"
+            ),
+        ] = False,
+    ):
+        """
+        run synthesis
+        """
+        suite_cfg = SynthSuiteConfig(path=synth_config)
+        log_event(
+            logger,
+            logging.INFO,
+            "command.synth",
+            command="synth",
+            synth=synth_name or "all",
+            synth_config=synth_config,
+        )
+
+        if list_synths:
+            emit_console_text("  ".join(suite_cfg.get_synth_names()), stream="stdout")
+            raise typer.Exit(0)
+
+        synth_results = self._do_synth_suite(suite_cfg, synth_name=synth_name)
+        self._render_synth_summary("Synthesis Results Summary", synth_results)
+        raise typer.Exit(self._exit_code_from_synth_results(synth_results))
+
+    def do_synth_regression(
+        self,
+        reg_config: Annotated[
+            str,
+            typer.Option(
+                "-c",
+                "--reg-config",
+                help="path to synth_regression.yaml",
+                show_default="Use ./synth_regression.yaml if present",
+            ),
+        ] = None,
+        reg_level: Annotated[
+            int,
+            typer.Option(
+                "-l", "--reg-level", help="synthesis regression level to stop at"
+            ),
+        ] = 0,
+    ):
+        """
+        run synthesis regression
+        """
+        log_event(
+            logger,
+            logging.INFO,
+            "command.synth_regression",
+            reg_config=reg_config,
+            reg_level=reg_level,
+        )
+
+        start_dir = os.getcwd()
+        if reg_config is not None:
+            reg_cfg_path = os.path.join(start_dir, reg_config)
+        else:
+            local = os.path.join(start_dir, "synth_regression.yaml")
+            reg_cfg_path = local if os.path.isfile(local) else None
+            if reg_cfg_path is None:
+                raise FatalRtlBuddyError(
+                    "synth_regression.yaml not found; pass -c to specify a path"
+                )
+
+        synth_reg = SynthRegConfig(
+            name=self.name + "/synth_reg_config", path=reg_cfg_path
+        )
+        emit_console_text(
+            f"Running synthesis regression from {os.path.dirname(reg_cfg_path)}",
+            style="cyan",
+        )
+
+        all_results = []
+        try:
+            for suite_cfg in synth_reg.get_suite_configs():
+                suite_dir = os.path.dirname(suite_cfg.get_path())
+                log_event(
+                    logger,
+                    logging.INFO,
+                    "synth_regression.suite_start",
+                    suite=suite_cfg.get_path(),
+                )
+                os.chdir(suite_dir)
+                suite_results = self._do_synth_suite(
+                    suite_cfg, synth_name=None, reg_level=reg_level
+                )
+                all_results.extend(suite_results)
+        finally:
+            os.chdir(start_dir)
+
+        self._render_synth_summary(
+            "Synthesis Regression Summary",
+            all_results,
+            metadata=[f"Reg Level: {reg_level}"],
+        )
+        raise typer.Exit(self._exit_code_from_synth_results(all_results))
 
     def do_lint(self):
         assert False, "not yet impl"

--- a/src/rtl_buddy/rtl_buddy.py
+++ b/src/rtl_buddy/rtl_buddy.py
@@ -1348,7 +1348,7 @@ class RtlBuddy:
     def _render_synth_summary(self, title, synth_results, *, metadata=None):
         has_gates = any("gate_count" in r["results"].results for r in synth_results)
         has_area = any("area_um2" in r["results"].results for r in synth_results)
-        has_timing = any("crit_path_ps" in r["results"].results for r in synth_results)
+        has_timing = any("wns_ps" in r["results"].results for r in synth_results)
         rows = []
         for r in synth_results:
             res = r["results"].results
@@ -1364,8 +1364,11 @@ class RtlBuddy:
                 area = res.get("area_um2")
                 row["area"] = f"{area:.2f} µm²" if area is not None else "-"
             if has_timing:
-                cp = res.get("crit_path_ps")
-                row["crit_path"] = f"{cp / 1000:.3f} ns" if cp is not None else "-"
+                wns = res.get("wns_ps")
+                if wns is not None:
+                    row["wns"] = f"{'+' if wns >= 0 else ''}{wns / 1000:.3f} ns"
+                else:
+                    row["wns"] = "-"
             rows.append(row)
 
         columns = [
@@ -1378,7 +1381,7 @@ class RtlBuddy:
         if has_area:
             columns.append(("area", "Area"))
         if has_timing:
-            columns.append(("crit_path", "Crit Path"))
+            columns.append(("wns", "WNS"))
         render_summary(
             title=title,
             columns=columns,

--- a/src/rtl_buddy/runner/synth_results.py
+++ b/src/rtl_buddy/runner/synth_results.py
@@ -21,7 +21,12 @@ class SynthResults:
 
 class SynthPassResults(SynthResults):
     def __init__(
-        self, name, *, area_um2: float | None = None, crit_path_ps: float | None = None
+        self,
+        name,
+        *,
+        area_um2: float | None = None,
+        gate_count: int | None = None,
+        crit_path_ps: float | None = None,
     ):
         super().__init__(
             name=name,
@@ -29,6 +34,8 @@ class SynthPassResults(SynthResults):
         )
         if area_um2 is not None:
             self.results["area_um2"] = area_um2
+        if gate_count is not None:
+            self.results["gate_count"] = gate_count
         if crit_path_ps is not None:
             self.results["crit_path_ps"] = crit_path_ps
 

--- a/src/rtl_buddy/runner/synth_results.py
+++ b/src/rtl_buddy/runner/synth_results.py
@@ -1,0 +1,43 @@
+import pprint
+
+
+class SynthResults:
+    def __init__(self, name, results=None):
+        if results is None:
+            results = {"result": "NA", "desc": "NA"}
+        self.name = name
+        self.results = results
+        if "result" not in results:
+            results["result"] = "NA"
+        if "desc" not in results:
+            results["desc"] = "NA"
+
+    def is_pass(self):
+        return self.results["result"] in ("PASS", "SKIP")
+
+    def __str__(self):
+        return "synth_results: " + pprint.pformat(self.results)
+
+
+class SynthPassResults(SynthResults):
+    def __init__(self, name):
+        super().__init__(
+            name=name,
+            results={"result": "PASS", "name": name, "desc": "Synthesis passed"},
+        )
+
+
+class SynthFailResults(SynthResults):
+    def __init__(self, name, desc):
+        super().__init__(
+            name=name,
+            results={"result": "FAIL", "name": name, "desc": desc},
+        )
+
+
+class SynthSkipResults(SynthResults):
+    def __init__(self, name, desc):
+        super().__init__(
+            name=name,
+            results={"result": "SKIP", "name": name, "desc": desc},
+        )

--- a/src/rtl_buddy/runner/synth_results.py
+++ b/src/rtl_buddy/runner/synth_results.py
@@ -26,7 +26,7 @@ class SynthPassResults(SynthResults):
         *,
         area_um2: float | None = None,
         gate_count: int | None = None,
-        crit_path_ps: float | None = None,
+        wns_ps: float | None = None,
     ):
         super().__init__(
             name=name,
@@ -36,8 +36,8 @@ class SynthPassResults(SynthResults):
             self.results["area_um2"] = area_um2
         if gate_count is not None:
             self.results["gate_count"] = gate_count
-        if crit_path_ps is not None:
-            self.results["crit_path_ps"] = crit_path_ps
+        if wns_ps is not None:
+            self.results["wns_ps"] = wns_ps
 
 
 class SynthFailResults(SynthResults):

--- a/src/rtl_buddy/runner/synth_results.py
+++ b/src/rtl_buddy/runner/synth_results.py
@@ -20,11 +20,17 @@ class SynthResults:
 
 
 class SynthPassResults(SynthResults):
-    def __init__(self, name):
+    def __init__(
+        self, name, *, area_um2: float | None = None, crit_path_ps: float | None = None
+    ):
         super().__init__(
             name=name,
             results={"result": "PASS", "name": name, "desc": "Synthesis passed"},
         )
+        if area_um2 is not None:
+            self.results["area_um2"] = area_um2
+        if crit_path_ps is not None:
+            self.results["crit_path_ps"] = crit_path_ps
 
 
 class SynthFailResults(SynthResults):

--- a/src/rtl_buddy/runner/synth_runner.py
+++ b/src/rtl_buddy/runner/synth_runner.py
@@ -31,5 +31,6 @@ class SynthRunner:
             synth_cfg=self.synth_cfg,
             tool_cfg=tool_cfg,
             suite_dir=self.suite_dir,
+            root_cfg=self.root_cfg,
         )
         return backend.run()

--- a/src/rtl_buddy/runner/synth_runner.py
+++ b/src/rtl_buddy/runner/synth_runner.py
@@ -1,0 +1,35 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+from ..config.synth import SynthConfig
+from ..logging_utils import log_event
+from ..runner.synth_results import SynthResults
+from ..tools.synth_yosys import YosysSynth
+
+
+class SynthRunner:
+    def __init__(self, name: str, root_cfg, synth_cfg: SynthConfig, suite_dir: str):
+        self.name = name
+        self.root_cfg = root_cfg
+        self.synth_cfg = synth_cfg
+        self.suite_dir = suite_dir
+
+    def run(self) -> SynthResults:
+        log_event(
+            logger,
+            logging.DEBUG,
+            "synth_runner.start",
+            runner=self.name,
+            synth=self.synth_cfg.get_name(),
+        )
+        tool_name = self.synth_cfg.get_tool_name()
+        tool_cfg = self.root_cfg.get_synth_tool_cfg(tool_name)
+
+        backend = YosysSynth(
+            name=self.name + "/yosys",
+            synth_cfg=self.synth_cfg,
+            tool_cfg=tool_cfg,
+            suite_dir=self.suite_dir,
+        )
+        return backend.run()

--- a/src/rtl_buddy/skill/SKILL.md
+++ b/src/rtl_buddy/skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rtl-buddy
-description: Use rtl_buddy to orchestrate SystemVerilog compile/sim workflows, randomized tests, regressions, filelist generation, and verible checks. Trigger this skill when asked to run or debug rtl_buddy commands or interpret root_config.yaml, tests.yaml, models.yaml, and regression.yaml.
+description: Use rtl_buddy to orchestrate SystemVerilog compile/sim workflows, randomized tests, regressions, synthesis flows, filelist generation, and verible checks. Trigger this skill when asked to run or debug rtl_buddy commands or interpret root_config.yaml, tests.yaml, models.yaml, regression.yaml, synth.yaml, or synth_regression.yaml.
 ---
 
 # rtl_buddy
@@ -26,10 +26,12 @@ This skill ships with the CLI, so its content matches the installed major. Surfa
 
 Use `rtl-buddy --machine docs show reference/yaml` for exact schemas.
 
-- **`root_config.yaml`** — project root, platform/build defaults, regression default path.
+- **`root_config.yaml`** — project root, platform/build defaults, regression default path, synthesis tool defaults (`cfg-synth-tools`).
 - **`regression.yaml`** — repo-level suite list for `regression`.
 - **`tests.yaml`** — suite-level tests/testbenches; run `test` and `randtest` from this directory.
-- **`models.yaml`** — design source filelists referenced by `tests.yaml`.
+- **`models.yaml`** — design source filelists referenced by `tests.yaml` and `synth.yaml`.
+- **`synth.yaml`** — synthesis runs; `model` name is the top; `tool` selects `cfg-synth-tools` entry; `params`/`defines`/`tool_overrides` for per-run customization.
+- **`synth_regression.yaml`** — repo-level synthesis suite list for `synth-regression`.
 - **`specs.yaml`** — spec traceability data; consumed by `rtl-buddy spec`.
 
 ## Pass/fail detection

--- a/src/rtl_buddy/tools/synth_yosys.py
+++ b/src/rtl_buddy/tools/synth_yosys.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import re
 import subprocess
 from pathlib import Path
 
@@ -74,6 +75,18 @@ class YosysSynth:
                 paths.append(os.path.normpath(os.path.join(fl_dir, line)))
         return paths
 
+    def _parse_clock_period_ps(self, sdc_path: str) -> int | None:
+        """Extract the first create_clock period (ns) and return it in picoseconds."""
+        try:
+            with open(sdc_path) as f:
+                for line in f:
+                    m = re.search(r"create_clock\s+.*-period\s+([\d.]+)", line)
+                    if m:
+                        return int(float(m.group(1)) * 1000)
+        except OSError:
+            pass
+        return None
+
     def _resolve_lib_paths(self) -> list[str]:
         libraries = self.synth_cfg.get_libraries()
         if not libraries or self.root_cfg is None:
@@ -113,7 +126,29 @@ class YosysSynth:
         if mapped:
             for lib in lib_paths:
                 lines.append(f"dfflibmap -liberty {lib}")
-            lines.append(f"abc -liberty {lib_paths[0]}")
+            abc_cmd = f"abc -liberty {lib_paths[0]}"
+            constraints = self.synth_cfg.get_constraints()
+            if constraints:
+                period_ps = self._parse_clock_period_ps(constraints)
+                if period_ps is not None:
+                    abc_cmd += f" -D {period_ps}"
+                    log_event(
+                        logger,
+                        logging.DEBUG,
+                        "synth.sdc_period",
+                        synth=self.synth_cfg.get_name(),
+                        period_ps=period_ps,
+                        sdc=constraints,
+                    )
+                else:
+                    log_event(
+                        logger,
+                        logging.WARNING,
+                        "synth.sdc_no_clock",
+                        synth=self.synth_cfg.get_name(),
+                        sdc=constraints,
+                    )
+            lines.append(abc_cmd)
             lines.append(f"write_verilog {self._netlist_path(mapped=True)}")
         else:
             if opts.abc_args:

--- a/src/rtl_buddy/tools/synth_yosys.py
+++ b/src/rtl_buddy/tools/synth_yosys.py
@@ -47,8 +47,28 @@ class YosysSynth:
             model_cfg=self.synth_cfg.get_model(),
             output_path=fl_path,
         )
-        vlog_fl.write_output(output_filepath=fl_path, unroll=True)
+        vlog_fl.write_output(
+            output_filepath=fl_path, unroll=True, strip=True, deduplicate=True
+        )
         return fl_path
+
+    def _source_files_from_filelist(self, fl_path: str) -> list[str]:
+        """Return absolute source file paths from a (possibly stripped) filelist."""
+        fl_dir = os.path.dirname(os.path.abspath(fl_path))
+        _SKIP = ("+incdir+", "+libext+", "-y ", "-F ", "-f ")
+        _SOURCE_PREFIX = "-v "
+        paths = []
+        with open(fl_path) as f:
+            for line in f:
+                line = line.strip()
+                if not line or line.startswith("//"):
+                    continue
+                if any(line.startswith(opt) for opt in _SKIP):
+                    continue
+                if line.startswith(_SOURCE_PREFIX):
+                    line = line[len(_SOURCE_PREFIX):]
+                paths.append(os.path.normpath(os.path.join(fl_dir, line)))
+        return paths
 
     def _write_script(self, fl_path: str) -> str:
         top = self.synth_cfg.get_top()
@@ -61,8 +81,10 @@ class YosysSynth:
         if defines:
             define_flags = " " + " ".join(f"-D {k}={v}" for k, v in defines.items())
 
+        source_files = self._source_files_from_filelist(fl_path)
         lines = []
-        lines.append(f"read_verilog -sv{define_flags} -f {fl_path}")
+        for src in source_files:
+            lines.append(f"read_verilog -sv -defer{define_flags} {src}")
 
         if params:
             for key, value in params.items():

--- a/src/rtl_buddy/tools/synth_yosys.py
+++ b/src/rtl_buddy/tools/synth_yosys.py
@@ -1,0 +1,174 @@
+import logging
+import os
+import subprocess
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+from .vlog_filelist import VlogFilelist
+from ..config.synth import SynthConfig, SynthToolConfig
+from ..errors import FilelistError
+from ..logging_utils import log_event, task_status
+from ..runner.synth_results import SynthFailResults, SynthPassResults, SynthResults
+
+
+class YosysSynth:
+    def __init__(
+        self,
+        name: str,
+        synth_cfg: SynthConfig,
+        tool_cfg: SynthToolConfig,
+        suite_dir: str,
+    ):
+        self.name = name
+        self.synth_cfg = synth_cfg
+        self.tool_cfg = tool_cfg
+
+        artefact_root = Path(suite_dir) / "artefacts" / synth_cfg.get_name()
+        artefact_root.mkdir(parents=True, exist_ok=True)
+        self.artefact_dir = str(artefact_root)
+
+    def _filelist_path(self) -> str:
+        return os.path.join(self.artefact_dir, "synth.f")
+
+    def _script_path(self) -> str:
+        return os.path.join(self.artefact_dir, "synth.ys")
+
+    def _log_path(self) -> str:
+        return os.path.join(self.artefact_dir, "synth.log")
+
+    def _netlist_path(self) -> str:
+        return os.path.join(self.artefact_dir, "synth.rtlil")
+
+    def _write_filelist(self) -> str:
+        fl_path = self._filelist_path()
+        vlog_fl = VlogFilelist(
+            name=self.name + "/filelist",
+            model_cfg=self.synth_cfg.get_model(),
+            output_path=fl_path,
+        )
+        vlog_fl.write_output(output_filepath=fl_path, unroll=True)
+        return fl_path
+
+    def _write_script(self, fl_path: str) -> str:
+        top = self.synth_cfg.get_top()
+        overrides = self.synth_cfg.get_tool_overrides_for(self.tool_cfg.get_name())
+        opts = self.tool_cfg.get_opts(overrides)
+        params = self.synth_cfg.get_params()
+
+        defines = self.synth_cfg.get_defines()
+        define_flags = ""
+        if defines:
+            define_flags = " " + " ".join(f"-D {k}={v}" for k, v in defines.items())
+
+        lines = []
+        lines.append(f"read_verilog -sv{define_flags} -f {fl_path}")
+
+        if params:
+            for key, value in params.items():
+                lines.append(f"chparam -set {key} {value} {top}")
+
+        synth_cmd = f"synth -top {top}"
+        if opts.synth_args:
+            synth_cmd += f" {opts.synth_args}"
+        lines.append(synth_cmd)
+
+        if opts.abc_args:
+            lines.append(f"abc {opts.abc_args}")
+
+        lines.append(f"write_rtlil {self._netlist_path()}")
+
+        script = "\n".join(lines) + "\n"
+        script_path = self._script_path()
+        with open(script_path, "w") as f:
+            f.write(script)
+        return script_path
+
+    def run(self) -> SynthResults:
+        log_event(
+            logger,
+            logging.INFO,
+            "synth.start",
+            synth=self.synth_cfg.get_name(),
+            tool=self.tool_cfg.get_executable(),
+            top=self.synth_cfg.get_top(),
+        )
+
+        try:
+            fl_path = self._write_filelist()
+        except FilelistError as e:
+            log_event(
+                logger,
+                logging.ERROR,
+                "synth.filelist_failed",
+                synth=self.synth_cfg.get_name(),
+                error=str(e),
+            )
+            return SynthFailResults(
+                name=self.name + "/results", desc=f"Filelist error: {e}"
+            )
+
+        script_path = self._write_script(fl_path)
+        log_path = self._log_path()
+
+        cmd = [self.tool_cfg.get_executable(), "-s", script_path]
+        log_event(
+            logger,
+            logging.DEBUG,
+            "synth.run_cmd",
+            synth=self.synth_cfg.get_name(),
+            cmd=" ".join(cmd),
+        )
+
+        with task_status(f"synth {self.synth_cfg.get_name()}"):
+            with open(log_path, "w") as log_f:
+                result = subprocess.run(
+                    cmd,
+                    stdout=log_f,
+                    stderr=subprocess.STDOUT,
+                    check=False,
+                )
+
+        if result.returncode != 0:
+            log_event(
+                logger,
+                logging.WARNING,
+                "synth.failed",
+                synth=self.synth_cfg.get_name(),
+                returncode=result.returncode,
+                log=log_path,
+            )
+            return SynthFailResults(
+                name=self.name + "/results",
+                desc=f"Tool exited with code {result.returncode}",
+            )
+
+        try:
+            with open(log_path, "r") as f:
+                log_text = f.read()
+        except OSError:
+            log_text = ""
+
+        error_lines = [ln for ln in log_text.splitlines() if ln.startswith("ERROR:")]
+        if error_lines:
+            log_event(
+                logger,
+                logging.WARNING,
+                "synth.errors_in_log",
+                synth=self.synth_cfg.get_name(),
+                count=len(error_lines),
+                log=log_path,
+            )
+            return SynthFailResults(
+                name=self.name + "/results",
+                desc=f"{len(error_lines)} ERROR(s) in synthesis log",
+            )
+
+        log_event(
+            logger,
+            logging.INFO,
+            "synth.passed",
+            synth=self.synth_cfg.get_name(),
+            log=log_path,
+        )
+        return SynthPassResults(name=self.name + "/results")

--- a/src/rtl_buddy/tools/synth_yosys.py
+++ b/src/rtl_buddy/tools/synth_yosys.py
@@ -123,6 +123,12 @@ class YosysSynth:
         m = re.search(r"Chip area for module[^:]*:\s*([\d.]+)", log_text)
         return float(m.group(1)) if m else None
 
+    def _parse_gate_count(self, log_text: str) -> int | None:
+        matches = re.findall(
+            r"^\s+(\d+)\s+(?:[\d.]+\s+)?cells$", log_text, re.MULTILINE
+        )
+        return int(matches[-1]) if matches else None
+
     def _parse_critical_path_ps(self, log_text: str) -> float | None:
         m = re.search(r"Delay\s*=\s*([\d.]+)\s*ps", log_text)
         return float(m.group(1)) if m else None
@@ -286,6 +292,7 @@ class YosysSynth:
             )
 
         area_um2 = self._parse_area_um2(log_text)
+        gate_count = self._parse_gate_count(log_text)
         crit_path_ps = self._parse_critical_path_ps(log_text)
 
         log_event(
@@ -294,11 +301,13 @@ class YosysSynth:
             "synth.passed",
             synth=self.synth_cfg.get_name(),
             area_um2=area_um2,
+            gate_count=gate_count,
             crit_path_ps=crit_path_ps,
             log=log_path,
         )
         return SynthPassResults(
             name=self.name + "/results",
             area_um2=area_um2,
+            gate_count=gate_count,
             crit_path_ps=crit_path_ps,
         )

--- a/src/rtl_buddy/tools/synth_yosys.py
+++ b/src/rtl_buddy/tools/synth_yosys.py
@@ -38,6 +38,7 @@ class YosysSynth:
         artefact_root = Path(suite_dir) / "artefacts" / synth_cfg.get_name()
         artefact_root.mkdir(parents=True, exist_ok=True)
         self.artefact_dir = str(artefact_root)
+        self._period_ps: int | None = None
 
     def _filelist_path(self) -> str:
         return os.path.join(self.artefact_dir, "synth.f")
@@ -190,6 +191,7 @@ class YosysSynth:
                         synth=self.synth_cfg.get_name(),
                         sdc=constraints,
                     )
+            self._period_ps = period_ps
 
             abc_script = (
                 _ABC_SCRIPT_WITH_TIMING
@@ -294,6 +296,11 @@ class YosysSynth:
         area_um2 = self._parse_area_um2(log_text)
         gate_count = self._parse_gate_count(log_text)
         crit_path_ps = self._parse_critical_path_ps(log_text)
+        wns_ps = (
+            self._period_ps - crit_path_ps
+            if self._period_ps is not None and crit_path_ps is not None
+            else None
+        )
 
         log_event(
             logger,
@@ -302,12 +309,12 @@ class YosysSynth:
             synth=self.synth_cfg.get_name(),
             area_um2=area_um2,
             gate_count=gate_count,
-            crit_path_ps=crit_path_ps,
+            wns_ps=wns_ps,
             log=log_path,
         )
         return SynthPassResults(
             name=self.name + "/results",
             area_um2=area_um2,
             gate_count=gate_count,
-            crit_path_ps=crit_path_ps,
+            wns_ps=wns_ps,
         )

--- a/src/rtl_buddy/tools/synth_yosys.py
+++ b/src/rtl_buddy/tools/synth_yosys.py
@@ -12,6 +12,14 @@ from ..errors import FilelistError
 from ..logging_utils import log_event, task_status
 from ..runner.synth_results import SynthFailResults, SynthPassResults, SynthResults
 
+# Default ABC script for liberty without timing constraint
+_ABC_SCRIPT_NO_TIMING = (
+    "strash; &get -n; &fraig -x; &put; scorr; dc2; dretime; strash; "
+    "&get -n; &dch -f; &nf {D}; &put"
+)
+# Same but with stime -p appended to report critical-path delay
+_ABC_SCRIPT_WITH_TIMING = _ABC_SCRIPT_NO_TIMING + "; stime -p"
+
 
 class YosysSynth:
     def __init__(
@@ -111,6 +119,14 @@ class YosysSynth:
             return []
         return [self.root_cfg.get_synth_lib_cfg(name).get_path() for name in libraries]
 
+    def _parse_area_um2(self, log_text: str) -> float | None:
+        m = re.search(r"Chip area for module[^:]*:\s*([\d.]+)", log_text)
+        return float(m.group(1)) if m else None
+
+    def _parse_critical_path_ps(self, log_text: str) -> float | None:
+        m = re.search(r"Delay\s*=\s*([\d.]+)\s*ps", log_text)
+        return float(m.group(1)) if m else None
+
     def _write_script(self, fl_path: str) -> str:
         top = self.synth_cfg.get_top()
         overrides = self.synth_cfg.get_tool_overrides_for(self.tool_cfg.get_name())
@@ -144,8 +160,10 @@ class YosysSynth:
         if mapped:
             for lib in lib_paths:
                 lines.append(f"dfflibmap -liberty {lib}")
+
             abc_cmd = f"abc -liberty {lib_paths[0]}"
             constraints = self.synth_cfg.get_constraints()
+            period_ps = None
             if constraints:
                 period_ps = self._parse_clock_period_ps(constraints)
                 if period_ps is not None:
@@ -166,8 +184,16 @@ class YosysSynth:
                         synth=self.synth_cfg.get_name(),
                         sdc=constraints,
                     )
+
+            abc_script = (
+                _ABC_SCRIPT_WITH_TIMING
+                if period_ps is not None
+                else _ABC_SCRIPT_NO_TIMING
+            )
+            abc_cmd += f' -script "+{abc_script}"'
             lines.append(abc_cmd)
             lines.append(f"write_verilog {self._netlist_path(mapped=True)}")
+            lines.append(f"stat -liberty {lib_paths[0]}")
         else:
             if opts.abc_args:
                 lines.append(f"abc {opts.abc_args}")
@@ -259,11 +285,20 @@ class YosysSynth:
                 desc=f"{len(error_lines)} ERROR(s) in synthesis log",
             )
 
+        area_um2 = self._parse_area_um2(log_text)
+        crit_path_ps = self._parse_critical_path_ps(log_text)
+
         log_event(
             logger,
             logging.INFO,
             "synth.passed",
             synth=self.synth_cfg.get_name(),
+            area_um2=area_um2,
+            crit_path_ps=crit_path_ps,
             log=log_path,
         )
-        return SynthPassResults(name=self.name + "/results")
+        return SynthPassResults(
+            name=self.name + "/results",
+            area_um2=area_um2,
+            crit_path_ps=crit_path_ps,
+        )

--- a/src/rtl_buddy/tools/synth_yosys.py
+++ b/src/rtl_buddy/tools/synth_yosys.py
@@ -76,16 +76,34 @@ class YosysSynth:
         return paths
 
     def _parse_clock_period_ps(self, sdc_path: str) -> int | None:
-        """Extract the first create_clock period (ns) and return it in picoseconds."""
+        """Extract create_clock periods from SDC and return the minimum in picoseconds.
+
+        ABC -D takes a single timing window; for multi-clock designs this is a
+        workaround — the minimum period is used, which over-constrains slower domains.
+        """
+        periods = []
         try:
             with open(sdc_path) as f:
                 for line in f:
                     m = re.search(r"create_clock\s+.*-period\s+([\d.]+)", line)
                     if m:
-                        return int(float(m.group(1)) * 1000)
+                        periods.append(float(m.group(1)))
         except OSError:
-            pass
-        return None
+            return None
+        if not periods:
+            return None
+        if len(periods) > 1:
+            log_event(
+                logger,
+                logging.WARNING,
+                "synth.sdc_multi_clock",
+                synth=self.synth_cfg.get_name(),
+                clocks=len(periods),
+                periods_ns=periods,
+                used_ns=min(periods),
+                sdc=sdc_path,
+            )
+        return int(min(periods) * 1000)
 
     def _resolve_lib_paths(self) -> list[str]:
         libraries = self.synth_cfg.get_libraries()

--- a/src/rtl_buddy/tools/synth_yosys.py
+++ b/src/rtl_buddy/tools/synth_yosys.py
@@ -19,10 +19,12 @@ class YosysSynth:
         synth_cfg: SynthConfig,
         tool_cfg: SynthToolConfig,
         suite_dir: str,
+        root_cfg=None,
     ):
         self.name = name
         self.synth_cfg = synth_cfg
         self.tool_cfg = tool_cfg
+        self.root_cfg = root_cfg
 
         artefact_root = Path(suite_dir) / "artefacts" / synth_cfg.get_name()
         artefact_root.mkdir(parents=True, exist_ok=True)
@@ -37,7 +39,9 @@ class YosysSynth:
     def _log_path(self) -> str:
         return os.path.join(self.artefact_dir, "synth.log")
 
-    def _netlist_path(self) -> str:
+    def _netlist_path(self, mapped: bool = False) -> str:
+        if mapped:
+            return os.path.join(self.artefact_dir, "synth_netlist.v")
         return os.path.join(self.artefact_dir, "synth.rtlil")
 
     def _write_filelist(self) -> str:
@@ -70,19 +74,30 @@ class YosysSynth:
                 paths.append(os.path.normpath(os.path.join(fl_dir, line)))
         return paths
 
+    def _resolve_lib_paths(self) -> list[str]:
+        libraries = self.synth_cfg.get_libraries()
+        if not libraries or self.root_cfg is None:
+            return []
+        return [self.root_cfg.get_synth_lib_cfg(name).get_path() for name in libraries]
+
     def _write_script(self, fl_path: str) -> str:
         top = self.synth_cfg.get_top()
         overrides = self.synth_cfg.get_tool_overrides_for(self.tool_cfg.get_name())
         opts = self.tool_cfg.get_opts(overrides)
         params = self.synth_cfg.get_params()
+        lib_paths = self._resolve_lib_paths()
+        mapped = bool(lib_paths)
 
         defines = self.synth_cfg.get_defines()
         define_flags = ""
         if defines:
             define_flags = " " + " ".join(f"-D {k}={v}" for k, v in defines.items())
 
-        source_files = self._source_files_from_filelist(fl_path)
         lines = []
+        for lib in lib_paths:
+            lines.append(f"read_liberty -lib {lib}")
+
+        source_files = self._source_files_from_filelist(fl_path)
         for src in source_files:
             lines.append(f"read_verilog -sv -defer{define_flags} {src}")
 
@@ -95,10 +110,15 @@ class YosysSynth:
             synth_cmd += f" {opts.synth_args}"
         lines.append(synth_cmd)
 
-        if opts.abc_args:
-            lines.append(f"abc {opts.abc_args}")
-
-        lines.append(f"write_rtlil {self._netlist_path()}")
+        if mapped:
+            for lib in lib_paths:
+                lines.append(f"dfflibmap -liberty {lib}")
+            lines.append(f"abc -liberty {lib_paths[0]}")
+            lines.append(f"write_verilog {self._netlist_path(mapped=True)}")
+        else:
+            if opts.abc_args:
+                lines.append(f"abc {opts.abc_args}")
+            lines.append(f"write_rtlil {self._netlist_path()}")
 
         script = "\n".join(lines) + "\n"
         script_path = self._script_path()

--- a/src/rtl_buddy/tools/synth_yosys.py
+++ b/src/rtl_buddy/tools/synth_yosys.py
@@ -66,7 +66,7 @@ class YosysSynth:
                 if any(line.startswith(opt) for opt in _SKIP):
                     continue
                 if line.startswith(_SOURCE_PREFIX):
-                    line = line[len(_SOURCE_PREFIX):]
+                    line = line[len(_SOURCE_PREFIX) :]
                 paths.append(os.path.normpath(os.path.join(fl_dir, line)))
         return paths
 

--- a/src/rtl_buddy/tools/vlog_filelist.py
+++ b/src/rtl_buddy/tools/vlog_filelist.py
@@ -165,14 +165,14 @@ class VlogFilelist:
             if flatten:
                 line_path = os.path.basename(line_path)
 
+            if strip:
+                line_option = ""
+
             line = f"{line_option}{line_path}\n" if line_option else f"{line_path}\n"
             if deduplicate:
                 if line in out_lines:
                     # logger.info(f'Duplicate detected, discarding: "{line_option or ""}{line_path}"')
                     continue
-
-            if strip:
-                line_option = ""
 
             # logger.debug(f'Post-proc: "{line_option}{line_path}"')
             out_lines.append(line)

--- a/tests/test_synth.py
+++ b/tests/test_synth.py
@@ -673,6 +673,57 @@ def test_resolve_lib_paths_unknown_name_raises(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# SDC clock period parsing
+# ---------------------------------------------------------------------------
+
+
+def test_parse_clock_period_ps_basic(tmp_path):
+    sdc = tmp_path / "c.sdc"
+    sdc.write_text("create_clock -period 10.0 [get_ports clk]\n")
+    ys = _make_yosys(tmp_path)
+    assert ys._parse_clock_period_ps(str(sdc)) == 10000
+
+
+def test_parse_clock_period_ps_fractional(tmp_path):
+    sdc = tmp_path / "c.sdc"
+    sdc.write_text("create_clock -period 3.333 [get_ports clk]\n")
+    ys = _make_yosys(tmp_path)
+    assert ys._parse_clock_period_ps(str(sdc)) == 3333
+
+
+def test_parse_clock_period_ps_no_clock_returns_none(tmp_path):
+    sdc = tmp_path / "c.sdc"
+    sdc.write_text("set_input_delay 2.0 -clock clk [all_inputs]\n")
+    ys = _make_yosys(tmp_path)
+    assert ys._parse_clock_period_ps(str(sdc)) is None
+
+
+def test_parse_clock_period_ps_missing_file_returns_none(tmp_path):
+    ys = _make_yosys(tmp_path)
+    assert ys._parse_clock_period_ps(str(tmp_path / "missing.sdc")) is None
+
+
+def test_write_script_lib_flow_with_sdc_adds_D_flag(tmp_path):
+    sv = tmp_path / "top.sv"
+    sv.write_text("")
+    fl = tmp_path / "synth.f"
+    fl.write_text(f"-v {sv}\n")
+    lib = tmp_path / "cells.lib"
+    lib.write_text("")
+    sdc = tmp_path / "c.sdc"
+    sdc.write_text("create_clock -period 5.0 [get_ports clk]\n")
+
+    root_cfg = _FakeRootCfg({"mylib": str(lib)})
+    ys = _make_yosys(
+        tmp_path,
+        synth_cfg=_make_synth_cfg(libraries=["mylib"], constraints=str(sdc)),
+        root_cfg=root_cfg,
+    )
+    script = Path(ys._write_script(str(fl))).read_text()
+    assert f"abc -liberty {lib} -D 5000" in script
+
+
+# ---------------------------------------------------------------------------
 # VlogFilelist strip=True fix
 # ---------------------------------------------------------------------------
 

--- a/tests/test_synth.py
+++ b/tests/test_synth.py
@@ -1,0 +1,616 @@
+"""Tests for synthesis flow: config, Yosys backend, and filelist strip fix."""
+
+from contextlib import nullcontext
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+from rtl_buddy.config.synth import (
+    SynthConfig,
+    SynthRegConfig,
+    SynthSuiteConfig,
+    SynthToolConfig,
+    SynthToolConfigFile,
+)
+from rtl_buddy.runner.synth_results import (
+    SynthFailResults,
+    SynthPassResults,
+    SynthSkipResults,
+)
+from rtl_buddy.tools import synth_yosys as synth_yosys_module
+from rtl_buddy.tools.synth_yosys import YosysSynth
+from rtl_buddy.tools.vlog_filelist import VlogFilelist
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _tool_cfg(name="yosys", exe="yosys", synth_args="", abc_args=""):
+    cfg_file = SynthToolConfigFile(
+        name=name,
+        tool=exe,
+        opts=_make_opts_file(synth_args, abc_args),
+    )
+    return SynthToolConfig(cfg_file)
+
+
+def _make_opts_file(synth_args="", abc_args=""):
+    from rtl_buddy.config.synth import SynthToolOptsFile
+
+    return SynthToolOptsFile(synth_args=synth_args, abc_args=abc_args)
+
+
+def _make_synth_cfg(
+    *,
+    name="test_synth",
+    model_name="my_module",
+    model_path="/fake/models.yaml",
+    tool="yosys",
+    constraints=None,
+    params=None,
+    defines=None,
+    reglvl=None,
+    tool_overrides=None,
+):
+    from rtl_buddy.config.model import ModelConfig
+
+    model = ModelConfig(name=model_name, filelist=[], path=model_path)
+    return SynthConfig(
+        name=name,
+        desc="test synth",
+        model=model,
+        tool=tool,
+        constraints=constraints,
+        params=params,
+        defines=defines,
+        _reglvl=reglvl,
+        tool_overrides=tool_overrides,
+    )
+
+
+def _make_yosys(tmp_path, synth_cfg=None, tool_cfg=None):
+    synth_cfg = synth_cfg or _make_synth_cfg()
+    tool_cfg = tool_cfg or _tool_cfg()
+    return YosysSynth(
+        name="test/yosys",
+        synth_cfg=synth_cfg,
+        tool_cfg=tool_cfg,
+        suite_dir=str(tmp_path),
+    )
+
+
+# ---------------------------------------------------------------------------
+# SynthToolConfig
+# ---------------------------------------------------------------------------
+
+
+def test_synth_tool_config_returns_base_opts():
+    cfg = _tool_cfg(synth_args="-flatten", abc_args="-fast")
+    opts = cfg.get_opts()
+    assert opts.synth_args == "-flatten"
+    assert opts.abc_args == "-fast"
+
+
+def test_synth_tool_config_overrides_merge_over_base():
+    cfg = _tool_cfg(synth_args="-flatten", abc_args="")
+    opts = cfg.get_opts({"synth_args": "-flatten -nordff", "abc_args": "-fast"})
+    assert opts.synth_args == "-flatten -nordff"
+    assert opts.abc_args == "-fast"
+
+
+def test_synth_tool_config_partial_override_keeps_unset_base():
+    cfg = _tool_cfg(synth_args="-flatten", abc_args="-O2")
+    opts = cfg.get_opts({"synth_args": "-nordff"})
+    assert opts.synth_args == "-nordff"
+    assert opts.abc_args == "-O2"  # unchanged
+
+
+def test_synth_tool_config_none_override_returns_base():
+    cfg = _tool_cfg(synth_args="-flatten")
+    assert cfg.get_opts(None).synth_args == "-flatten"
+    assert cfg.get_opts({}).synth_args == "-flatten"
+
+
+# ---------------------------------------------------------------------------
+# SynthConfig
+# ---------------------------------------------------------------------------
+
+
+def test_synth_config_top_is_model_name():
+    cfg = _make_synth_cfg(model_name="my_top")
+    assert cfg.get_top() == "my_top"
+
+
+def test_synth_config_reglvl_int():
+    cfg = _make_synth_cfg(reglvl=500)
+    assert cfg.get_reglvl("yosys") == 500
+
+
+def test_synth_config_reglvl_none_defaults_to_zero():
+    cfg = _make_synth_cfg(reglvl=None)
+    assert cfg.get_reglvl("yosys") == 0
+
+
+def test_synth_config_reglvl_dict_tool_specific():
+    cfg = _make_synth_cfg(reglvl={"yosys": 100, "dc": 200, "default": 50})
+    assert cfg.get_reglvl("yosys") == 100
+    assert cfg.get_reglvl("dc") == 200
+    assert cfg.get_reglvl("quartus") == 50  # falls back to default
+
+
+def test_synth_config_tool_overrides_for_matching_tool():
+    cfg = _make_synth_cfg(tool_overrides={"yosys": {"abc_args": "-fast"}})
+    assert cfg.get_tool_overrides_for("yosys") == {"abc_args": "-fast"}
+
+
+def test_synth_config_tool_overrides_for_non_matching_tool():
+    cfg = _make_synth_cfg(tool_overrides={"yosys": {"abc_args": "-fast"}})
+    assert cfg.get_tool_overrides_for("dc") is None
+
+
+def test_synth_config_tool_overrides_none():
+    cfg = _make_synth_cfg(tool_overrides=None)
+    assert cfg.get_tool_overrides_for("yosys") is None
+
+
+# ---------------------------------------------------------------------------
+# SynthSuiteConfig — YAML loading
+# ---------------------------------------------------------------------------
+
+_SUITE_YAML = dedent("""\
+    rtl-buddy-filetype: synth_config
+
+    syntheses:
+      - name: "synth_a"
+        desc: "First synth"
+        model: "mod_a"
+        model_path: "{models_path}"
+        tool: "yosys"
+        reglvl: 0
+      - name: "synth_b"
+        desc: "Second synth"
+        model: "mod_b"
+        model_path: "{models_path}"
+        tool: "yosys"
+        reglvl: 1000
+        params:
+          WIDTH: 8
+        defines:
+          TARGET_SYNTH: 1
+""")
+
+_MODELS_YAML = dedent("""\
+    rtl-buddy-filetype: model_config
+
+    models:
+      - name: "mod_a"
+        filelist: ["top_a.sv"]
+      - name: "mod_b"
+        filelist: ["top_b.sv"]
+""")
+
+
+def _write_suite(tmp_path):
+    models_yaml = tmp_path / "models.yaml"
+    models_yaml.write_text(_MODELS_YAML)
+    suite_yaml = tmp_path / "synth.yaml"
+    suite_yaml.write_text(_SUITE_YAML.format(models_path="models.yaml"))
+    return suite_yaml
+
+
+def test_synth_suite_config_loads_all_syntheses(tmp_path):
+    suite_yaml = _write_suite(tmp_path)
+    cfg = SynthSuiteConfig(str(suite_yaml))
+    assert cfg.get_synth_names() == ["synth_a", "synth_b"]
+
+
+def test_synth_suite_config_get_by_name(tmp_path):
+    suite_yaml = _write_suite(tmp_path)
+    cfg = SynthSuiteConfig(str(suite_yaml))
+    results = cfg.get_syntheses("synth_a")
+    assert len(results) == 1
+    assert results[0].get_name() == "synth_a"
+    assert results[0].get_top() == "mod_a"
+
+
+def test_synth_suite_config_params_and_defines_loaded(tmp_path):
+    suite_yaml = _write_suite(tmp_path)
+    cfg = SynthSuiteConfig(str(suite_yaml))
+    synth_b = cfg.get_syntheses("synth_b")[0]
+    assert synth_b.get_params() == {"WIDTH": 8}
+    assert synth_b.get_defines() == {"TARGET_SYNTH": 1}
+
+
+def test_synth_suite_config_missing_name_raises(tmp_path):
+    from rtl_buddy.errors import FatalRtlBuddyError
+
+    suite_yaml = _write_suite(tmp_path)
+    cfg = SynthSuiteConfig(str(suite_yaml))
+    with pytest.raises(FatalRtlBuddyError, match="not found"):
+        cfg.get_syntheses("nonexistent")
+
+
+# ---------------------------------------------------------------------------
+# SynthRegConfig — YAML loading
+# ---------------------------------------------------------------------------
+
+_REG_YAML = dedent("""\
+    rtl-buddy-filetype: synth_reg_config
+
+    synth-configs:
+      - "sandbox/synth.yaml"
+""")
+
+
+def test_synth_reg_config_loads_suite_paths(tmp_path):
+    sandbox = tmp_path / "sandbox"
+    sandbox.mkdir()
+    models_yaml = sandbox / "models.yaml"
+    models_yaml.write_text(_MODELS_YAML)
+    suite_yaml = sandbox / "synth.yaml"
+    suite_yaml.write_text(_SUITE_YAML.format(models_path="models.yaml"))
+
+    reg_yaml = tmp_path / "synth_regression.yaml"
+    reg_yaml.write_text(_REG_YAML)
+
+    reg_cfg = SynthRegConfig(name="reg", path=str(reg_yaml))
+    suites = reg_cfg.get_suite_configs()
+    assert len(suites) == 1
+    assert suites[0].get_synth_names() == ["synth_a", "synth_b"]
+
+
+# ---------------------------------------------------------------------------
+# SynthResults
+# ---------------------------------------------------------------------------
+
+
+def test_synth_pass_results_is_pass():
+    assert SynthPassResults("r").is_pass()
+    assert SynthPassResults("r").results["result"] == "PASS"
+
+
+def test_synth_fail_results_is_not_pass():
+    r = SynthFailResults("r", desc="Tool exited with code 1")
+    assert not r.is_pass()
+    assert r.results["result"] == "FAIL"
+    assert "code 1" in r.results["desc"]
+
+
+def test_synth_skip_results_is_pass():
+    assert SynthSkipResults("r", desc="skipped").is_pass()
+
+
+# ---------------------------------------------------------------------------
+# YosysSynth — artefact paths
+# ---------------------------------------------------------------------------
+
+
+def test_yosys_synth_artefact_dir_created(tmp_path):
+    ys = _make_yosys(tmp_path)
+    assert Path(ys.artefact_dir).is_dir()
+    assert Path(ys.artefact_dir).name == "test_synth"
+
+
+# ---------------------------------------------------------------------------
+# YosysSynth — _source_files_from_filelist
+# ---------------------------------------------------------------------------
+
+
+def test_source_files_strips_v_prefix(tmp_path):
+    fl = tmp_path / "synth.f"
+    sv = tmp_path / "top.sv"
+    sv.write_text("")
+    fl.write_text(f"-v {sv}\n")
+    ys = _make_yosys(tmp_path)
+    paths = ys._source_files_from_filelist(str(fl))
+    assert paths == [str(sv)]
+
+
+def test_source_files_plain_path(tmp_path):
+    fl = tmp_path / "synth.f"
+    sv = tmp_path / "top.sv"
+    sv.write_text("")
+    fl.write_text(f"{sv}\n")
+    ys = _make_yosys(tmp_path)
+    paths = ys._source_files_from_filelist(str(fl))
+    assert paths == [str(sv)]
+
+
+def test_source_files_skips_incdir(tmp_path):
+    fl = tmp_path / "synth.f"
+    sv = tmp_path / "top.sv"
+    sv.write_text("")
+    fl.write_text(f"+incdir+../inc\n-v {sv}\n")
+    ys = _make_yosys(tmp_path)
+    paths = ys._source_files_from_filelist(str(fl))
+    assert paths == [str(sv)]
+
+
+def test_source_files_skips_comments_and_blank_lines(tmp_path):
+    fl = tmp_path / "synth.f"
+    sv = tmp_path / "top.sv"
+    sv.write_text("")
+    fl.write_text(f"// generated\n\n-v {sv}\n")
+    ys = _make_yosys(tmp_path)
+    paths = ys._source_files_from_filelist(str(fl))
+    assert paths == [str(sv)]
+
+
+def test_source_files_resolves_relative_paths(tmp_path):
+    fl = tmp_path / "synth.f"
+    sv = tmp_path / "src" / "top.sv"
+    sv.parent.mkdir()
+    sv.write_text("")
+    fl.write_text("-v src/top.sv\n")
+    ys = _make_yosys(tmp_path)
+    paths = ys._source_files_from_filelist(str(fl))
+    assert paths == [str(sv)]
+
+
+# ---------------------------------------------------------------------------
+# YosysSynth — _write_script
+# ---------------------------------------------------------------------------
+
+
+def test_write_script_basic(tmp_path):
+    sv = tmp_path / "top.sv"
+    sv.write_text("")
+    fl = tmp_path / "synth.f"
+    fl.write_text(f"-v {sv}\n")
+
+    ys = _make_yosys(tmp_path, synth_cfg=_make_synth_cfg(model_name="my_top"))
+    script_path = ys._write_script(str(fl))
+    script = Path(script_path).read_text()
+
+    assert f"read_verilog -sv -defer {sv}" in script
+    assert "synth -top my_top" in script
+    assert "write_rtlil" in script
+
+
+def test_write_script_includes_synth_args(tmp_path):
+    sv = tmp_path / "top.sv"
+    sv.write_text("")
+    fl = tmp_path / "synth.f"
+    fl.write_text(f"-v {sv}\n")
+
+    ys = _make_yosys(
+        tmp_path,
+        tool_cfg=_tool_cfg(synth_args="-flatten"),
+    )
+    script = Path(ys._write_script(str(fl))).read_text()
+    assert "synth -top my_module -flatten" in script
+
+
+def test_write_script_includes_abc_args(tmp_path):
+    sv = tmp_path / "top.sv"
+    sv.write_text("")
+    fl = tmp_path / "synth.f"
+    fl.write_text(f"-v {sv}\n")
+
+    ys = _make_yosys(tmp_path, tool_cfg=_tool_cfg(abc_args="-fast"))
+    script = Path(ys._write_script(str(fl))).read_text()
+    assert "abc -fast" in script
+
+
+def test_write_script_no_abc_when_empty(tmp_path):
+    sv = tmp_path / "top.sv"
+    sv.write_text("")
+    fl = tmp_path / "synth.f"
+    fl.write_text(f"-v {sv}\n")
+
+    ys = _make_yosys(tmp_path, tool_cfg=_tool_cfg(abc_args=""))
+    script = Path(ys._write_script(str(fl))).read_text()
+    assert "\nabc " not in script  # abc as a standalone command line
+
+
+def test_write_script_params(tmp_path):
+    sv = tmp_path / "top.sv"
+    sv.write_text("")
+    fl = tmp_path / "synth.f"
+    fl.write_text(f"-v {sv}\n")
+
+    ys = _make_yosys(
+        tmp_path,
+        synth_cfg=_make_synth_cfg(model_name="top", params={"WIDTH": 8, "DEPTH": 16}),
+    )
+    script = Path(ys._write_script(str(fl))).read_text()
+    assert "chparam -set WIDTH 8 top" in script
+    assert "chparam -set DEPTH 16 top" in script
+
+
+def test_write_script_defines(tmp_path):
+    sv = tmp_path / "top.sv"
+    sv.write_text("")
+    fl = tmp_path / "synth.f"
+    fl.write_text(f"-v {sv}\n")
+
+    ys = _make_yosys(
+        tmp_path,
+        synth_cfg=_make_synth_cfg(defines={"TARGET_SYNTH": 1, "WIDTH": 8}),
+    )
+    script = Path(ys._write_script(str(fl))).read_text()
+    assert "-D TARGET_SYNTH=1" in script
+    assert "-D WIDTH=8" in script
+
+
+def test_write_script_tool_overrides_applied(tmp_path):
+    sv = tmp_path / "top.sv"
+    sv.write_text("")
+    fl = tmp_path / "synth.f"
+    fl.write_text(f"-v {sv}\n")
+
+    ys = _make_yosys(
+        tmp_path,
+        synth_cfg=_make_synth_cfg(
+            tool_overrides={"yosys": {"synth_args": "-nordff", "abc_args": "-fast"}}
+        ),
+        tool_cfg=_tool_cfg(synth_args="-flatten", abc_args=""),
+    )
+    script = Path(ys._write_script(str(fl))).read_text()
+    assert "synth -top my_module -nordff" in script
+    assert "abc -fast" in script
+
+
+# ---------------------------------------------------------------------------
+# YosysSynth — run() pass/fail detection
+# ---------------------------------------------------------------------------
+
+
+def _fake_subprocess_run(returncode=0, write_log=None):
+
+    def _run(cmd, stdout, stderr, check):
+        if write_log:
+            stdout.write(write_log)
+        return type("R", (), {"returncode": returncode})()
+
+    return _run
+
+
+def _setup_run(tmp_path):
+    """Write a minimal valid filelist so _write_filelist succeeds."""
+    sv = tmp_path / "top.sv"
+    sv.write_text("module my_module(); endmodule")
+
+    models_yaml = tmp_path / "models.yaml"
+    models_yaml.write_text(
+        dedent(f"""\
+        rtl-buddy-filetype: model_config
+        models:
+          - name: "my_module"
+            filelist: ["-v {sv}"]
+        """)
+    )
+    from rtl_buddy.config.model import ModelConfig
+
+    model = ModelConfig(name="my_module", filelist=[f"-v {sv}"], path=str(models_yaml))
+    return model
+
+
+def test_run_returns_pass_on_clean_exit(tmp_path, monkeypatch):
+    model = _setup_run(tmp_path)
+    synth_cfg = SynthConfig(
+        name="s",
+        desc="",
+        model=model,
+        tool="yosys",
+        constraints=None,
+        params=None,
+        defines=None,
+        _reglvl=None,
+        tool_overrides=None,
+    )
+    ys = YosysSynth(
+        "t", synth_cfg=synth_cfg, tool_cfg=_tool_cfg(), suite_dir=str(tmp_path)
+    )
+    monkeypatch.setattr(
+        synth_yosys_module, "task_status", lambda *a, **kw: nullcontext()
+    )
+    monkeypatch.setattr(
+        synth_yosys_module.subprocess, "run", _fake_subprocess_run(returncode=0)
+    )
+    result = ys.run()
+    assert isinstance(result, SynthPassResults)
+
+
+def test_run_returns_fail_on_nonzero_exit(tmp_path, monkeypatch):
+    model = _setup_run(tmp_path)
+    synth_cfg = SynthConfig(
+        name="s",
+        desc="",
+        model=model,
+        tool="yosys",
+        constraints=None,
+        params=None,
+        defines=None,
+        _reglvl=None,
+        tool_overrides=None,
+    )
+    ys = YosysSynth(
+        "t", synth_cfg=synth_cfg, tool_cfg=_tool_cfg(), suite_dir=str(tmp_path)
+    )
+    monkeypatch.setattr(
+        synth_yosys_module, "task_status", lambda *a, **kw: nullcontext()
+    )
+    monkeypatch.setattr(
+        synth_yosys_module.subprocess, "run", _fake_subprocess_run(returncode=1)
+    )
+    result = ys.run()
+    assert isinstance(result, SynthFailResults)
+    assert "code 1" in result.results["desc"]
+
+
+def test_run_returns_fail_on_error_in_log(tmp_path, monkeypatch):
+    model = _setup_run(tmp_path)
+    synth_cfg = SynthConfig(
+        name="s",
+        desc="",
+        model=model,
+        tool="yosys",
+        constraints=None,
+        params=None,
+        defines=None,
+        _reglvl=None,
+        tool_overrides=None,
+    )
+    ys = YosysSynth(
+        "t", synth_cfg=synth_cfg, tool_cfg=_tool_cfg(), suite_dir=str(tmp_path)
+    )
+    monkeypatch.setattr(
+        synth_yosys_module, "task_status", lambda *a, **kw: nullcontext()
+    )
+    monkeypatch.setattr(
+        synth_yosys_module.subprocess,
+        "run",
+        _fake_subprocess_run(returncode=0, write_log="ERROR: something went wrong\n"),
+    )
+    result = ys.run()
+    assert isinstance(result, SynthFailResults)
+    assert "ERROR" in result.results["desc"]
+
+
+# ---------------------------------------------------------------------------
+# VlogFilelist strip=True fix
+# ---------------------------------------------------------------------------
+
+
+def _write_models(tmp_path, filelist_entries):
+    from rtl_buddy.config.model import ModelConfig
+
+    fl_file = tmp_path / "src.f"
+    fl_file.write_text("\n".join(filelist_entries) + "\n")
+    return ModelConfig(
+        name="m",
+        filelist=[f"-F {fl_file}"],
+        path=str(tmp_path / "models.yaml"),
+    )
+
+
+def test_vlog_filelist_strip_removes_option_prefix(tmp_path):
+    sv = tmp_path / "top.sv"
+    sv.write_text("")
+    model = _write_models(tmp_path, [f"-v {sv}"])
+    out = tmp_path / "out.f"
+    fl = VlogFilelist(name="t", model_cfg=model, output_path=str(out))
+    fl.write_output(output_filepath=str(out), unroll=True, strip=True)
+    lines = [
+        ln for ln in out.read_text().splitlines() if ln and not ln.startswith("//")
+    ]
+    assert all(not ln.startswith("-") for ln in lines), (
+        f"Option prefix not stripped: {lines}"
+    )
+
+
+def test_vlog_filelist_strip_false_keeps_option_prefix(tmp_path):
+    sv = tmp_path / "top.sv"
+    sv.write_text("")
+    model = _write_models(tmp_path, [f"-v {sv}"])
+    out = tmp_path / "out.f"
+    fl = VlogFilelist(name="t", model_cfg=model, output_path=str(out))
+    fl.write_output(output_filepath=str(out), unroll=True, strip=False)
+    lines = [
+        ln for ln in out.read_text().splitlines() if ln and not ln.startswith("//")
+    ]
+    assert any(ln.startswith("-v ") for ln in lines), f"Expected -v prefix: {lines}"

--- a/tests/test_synth.py
+++ b/tests/test_synth.py
@@ -691,6 +691,16 @@ def test_parse_clock_period_ps_fractional(tmp_path):
     assert ys._parse_clock_period_ps(str(sdc)) == 3333
 
 
+def test_parse_clock_period_ps_multi_clock_returns_minimum(tmp_path):
+    sdc = tmp_path / "c.sdc"
+    sdc.write_text(
+        "create_clock -period 10.0 [get_ports clk_fast]\n"
+        "create_clock -period 40.0 [get_ports clk_slow]\n"
+    )
+    ys = _make_yosys(tmp_path)
+    assert ys._parse_clock_period_ps(str(sdc)) == 10000
+
+
 def test_parse_clock_period_ps_no_clock_returns_none(tmp_path):
     sdc = tmp_path / "c.sdc"
     sdc.write_text("set_input_delay 2.0 -clock clk [all_inputs]\n")

--- a/tests/test_synth.py
+++ b/tests/test_synth.py
@@ -52,6 +52,7 @@ def _make_synth_cfg(
     constraints=None,
     params=None,
     defines=None,
+    libraries=None,
     reglvl=None,
     tool_overrides=None,
 ):
@@ -66,12 +67,13 @@ def _make_synth_cfg(
         constraints=constraints,
         params=params,
         defines=defines,
+        libraries=libraries,
         _reglvl=reglvl,
         tool_overrides=tool_overrides,
     )
 
 
-def _make_yosys(tmp_path, synth_cfg=None, tool_cfg=None):
+def _make_yosys(tmp_path, synth_cfg=None, tool_cfg=None, root_cfg=None):
     synth_cfg = synth_cfg or _make_synth_cfg()
     tool_cfg = tool_cfg or _tool_cfg()
     return YosysSynth(
@@ -79,6 +81,7 @@ def _make_yosys(tmp_path, synth_cfg=None, tool_cfg=None):
         synth_cfg=synth_cfg,
         tool_cfg=tool_cfg,
         suite_dir=str(tmp_path),
+        root_cfg=root_cfg,
     )
 
 
@@ -499,6 +502,7 @@ def test_run_returns_pass_on_clean_exit(tmp_path, monkeypatch):
         constraints=None,
         params=None,
         defines=None,
+        libraries=None,
         _reglvl=None,
         tool_overrides=None,
     )
@@ -525,6 +529,7 @@ def test_run_returns_fail_on_nonzero_exit(tmp_path, monkeypatch):
         constraints=None,
         params=None,
         defines=None,
+        libraries=None,
         _reglvl=None,
         tool_overrides=None,
     )
@@ -552,6 +557,7 @@ def test_run_returns_fail_on_error_in_log(tmp_path, monkeypatch):
         constraints=None,
         params=None,
         defines=None,
+        libraries=None,
         _reglvl=None,
         tool_overrides=None,
     )
@@ -569,6 +575,101 @@ def test_run_returns_fail_on_error_in_log(tmp_path, monkeypatch):
     result = ys.run()
     assert isinstance(result, SynthFailResults)
     assert "ERROR" in result.results["desc"]
+
+
+# ---------------------------------------------------------------------------
+# YosysSynth — library-mapped flow
+# ---------------------------------------------------------------------------
+
+
+class _FakeLibCfg:
+    def __init__(self, path):
+        self._path = path
+
+    def get_path(self):
+        return self._path
+
+
+class _FakeRootCfg:
+    def __init__(self, lib_map):
+        self._lib_map = lib_map
+
+    def get_synth_lib_cfg(self, name):
+        from rtl_buddy.errors import FatalRtlBuddyError
+
+        if name not in self._lib_map:
+            raise FatalRtlBuddyError(f"synthesis library '{name}' not found")
+        return _FakeLibCfg(self._lib_map[name])
+
+
+def test_write_script_lib_flow_emits_read_liberty_and_mapping(tmp_path):
+    sv = tmp_path / "top.sv"
+    sv.write_text("")
+    fl = tmp_path / "synth.f"
+    fl.write_text(f"-v {sv}\n")
+    lib = tmp_path / "cells.lib"
+    lib.write_text("")
+
+    root_cfg = _FakeRootCfg({"mylib": str(lib)})
+    ys = _make_yosys(
+        tmp_path,
+        synth_cfg=_make_synth_cfg(libraries=["mylib"]),
+        root_cfg=root_cfg,
+    )
+    script = Path(ys._write_script(str(fl))).read_text()
+
+    assert f"read_liberty -lib {lib}" in script
+    assert f"dfflibmap -liberty {lib}" in script
+    assert f"abc -liberty {lib}" in script
+    assert "write_verilog" in script
+    assert "write_rtlil" not in script
+
+
+def test_write_script_lib_flow_no_standalone_abc(tmp_path):
+    sv = tmp_path / "top.sv"
+    sv.write_text("")
+    fl = tmp_path / "synth.f"
+    fl.write_text(f"-v {sv}\n")
+    lib = tmp_path / "cells.lib"
+    lib.write_text("")
+
+    root_cfg = _FakeRootCfg({"mylib": str(lib)})
+    ys = _make_yosys(
+        tmp_path,
+        synth_cfg=_make_synth_cfg(libraries=["mylib"]),
+        tool_cfg=_tool_cfg(abc_args="-fast"),
+        root_cfg=root_cfg,
+    )
+    script = Path(ys._write_script(str(fl))).read_text()
+    assert "\nabc -fast" not in script
+
+
+def test_write_script_no_lib_flow_unchanged(tmp_path):
+    sv = tmp_path / "top.sv"
+    sv.write_text("")
+    fl = tmp_path / "synth.f"
+    fl.write_text(f"-v {sv}\n")
+
+    ys = _make_yosys(tmp_path, synth_cfg=_make_synth_cfg(libraries=None))
+    script = Path(ys._write_script(str(fl))).read_text()
+
+    assert "read_liberty" not in script
+    assert "dfflibmap" not in script
+    assert "write_rtlil" in script
+    assert "write_verilog" not in script
+
+
+def test_resolve_lib_paths_unknown_name_raises(tmp_path):
+    from rtl_buddy.errors import FatalRtlBuddyError
+
+    root_cfg = _FakeRootCfg({})
+    ys = _make_yosys(
+        tmp_path,
+        synth_cfg=_make_synth_cfg(libraries=["unknown_lib"]),
+        root_cfg=root_cfg,
+    )
+    with pytest.raises(FatalRtlBuddyError, match="not found"):
+        ys._resolve_lib_paths()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add tool-agnostic synthesis flow (`rb synth`, `rb synth-regression`) mirroring the simulation workflow
- Synthesis tool defaults live in `cfg-synth-tools` in `root_config.yaml`; `synth.yaml` expresses design intent only (model, constraints, params, defines)
- Yosys is the first backend; additional tools can be added by extending `cfg-synth-tools` and adding a new backend class
- Fixes a pre-existing bug in `VlogFilelist` where `strip=True` was a no-op

## New config schemas

```yaml
# synth.yaml
rtl-buddy-filetype: synth_config
syntheses:
  - name: "sandbox_synth"
    model: "test_module"
    model_path: "../../design/sandbox/models.yaml"
    tool: "yosys"
    constraints: "constraints.sdc"
    params: {WIDTH: 8}
    defines: {TARGET_SYNTH: 1}
    reglvl: 0
    tool_overrides:
      yosys:
        abc_args: "-fast"
```

```yaml
# root_config.yaml addition
cfg-synth-tools:
  - name: "yosys"
    tool: "yosys"
    opts:
      synth-args: ""
      abc-args: ""
```

```yaml
# synth_regression.yaml
rtl-buddy-filetype: synth_reg_config
synth-configs:
  - "synth/sandbox/synth.yaml"
```

## New files

| File | Purpose |
|------|---------|
| `config/synth.py` | `SynthConfig`, `SynthSuiteConfig`, `SynthRegConfig`, `SynthToolConfig` |
| `runner/synth_runner.py` | Resolves tool config, dispatches to backend |
| `runner/synth_results.py` | `SynthResults` / Pass / Fail / Skip |
| `tools/synth_yosys.py` | Generates `synth.f` + `synth.ys`, runs yosys, detects failure via exit code and `ERROR:` log scan |
| `tests/test_synth.py` | 37 pytest tests covering config, script generation, pass/fail detection, filelist strip fix |
| `docs/concepts/synthesis.md` | Concept page including Yosys install from `rtl-buddy/yosys` |

## Modified files

| File | Change |
|------|--------|
| `config/root.py` | `cfg-synth-tools` in `RootConfigFile`; `get_synth_tool_cfg()` |
| `config/__init__.py` | Export new synth config types |
| `rtl_buddy.py` | `rb synth` and `rb synth-regression` commands |
| `tools/vlog_filelist.py` | Fix `strip=True` no-op: option prefix was baked into `line` before strip was applied |
| `AGENTS.md` | Synthesis files added to key files tree and implementation notes |
| `skill/SKILL.md` | Updated description and YAML types |
| `mkdocs.yml` | Synthesis added to Concepts nav |

## Yosys backend notes

- Source files are emitted as individual `read_verilog -sv -defer` commands (not `-f filelist`) — Yosys does not support `-f`; `-defer` ensures only the top hierarchy is elaborated, avoiding errors from unreachable parameterized modules in shared source files
- Artefacts: `artefacts/<synth_name>/synth.f`, `synth.ys`, `synth.log`, `synth.rtlil`
- Pass/fail: exit code 0 + no `ERROR:` lines in log

## Test plan

- [x] `rb synth -c synth/sandbox/synth.yaml` passes on a project with yosys installed
- [x] `rb synth-regression -c synth_regression.yaml` runs all suites and renders summary table
- [x] `rb synth --list` lists synthesis names without running
- [x] `rb synth-regression --reg-level 0` skips runs with `reglvl > 0`
- [x] `tool_overrides` merges correctly over root-config defaults
- [x] Unknown tool name raises a clear `FatalRtlBuddyError`

Generated with [Claude Code](https://claude.com/claude-code)
