### PR TITLE
Fix orphaned tool subprocesses on interrupt

### DIFF
--- a/src/rtl_buddy/process_utils.py
+++ b/src/rtl_buddy/process_utils.py
@@ -1,0 +1,124 @@
+import os
+import signal
+import subprocess
+from dataclasses import dataclass
+from typing import IO
+
+
+@dataclass
+class ManagedProcessResult:
+    returncode: int
+    stdout: str | bytes | None = None
+    stderr: str | bytes | None = None
+    timed_out: bool = False
+
+
+def _terminate_process_group(
+    proc: subprocess.Popen,
+    *,
+    terminate_signal: int,
+    kill_timeout: float,
+) -> None:
+    if proc.poll() is not None:
+        return
+
+    def _send_signal(sig: int) -> None:
+        if os.name == "nt":
+            if sig == signal.SIGKILL:
+                proc.kill()
+            else:
+                proc.terminate()
+            return
+
+        try:
+            os.killpg(proc.pid, sig)
+        except PermissionError:
+            proc.send_signal(sig)
+
+    try:
+        _send_signal(terminate_signal)
+        proc.wait(timeout=kill_timeout)
+    except ProcessLookupError:
+        return
+    except subprocess.TimeoutExpired:
+        _send_signal(signal.SIGKILL)
+        proc.wait()
+
+
+def run_managed_process(
+    cmd: list[str],
+    *,
+    stdout: int | IO | None = None,
+    stderr: int | IO | None = None,
+    capture_output: bool = False,
+    text: bool = False,
+    cwd: str | None = None,
+    env: dict[str, str] | None = None,
+    timeout: float | None = None,
+    timeout_returncode: int | None = None,
+    terminate_signal: int = signal.SIGTERM,
+    kill_timeout: float = 5,
+) -> ManagedProcessResult:
+    """Run a long-lived tool process with consistent cleanup.
+
+    Simulators may need a non-default graceful-stop signal, such as SIGQUIT, to
+    flush waveform data before exit.
+    """
+    if capture_output:
+        stdout = subprocess.PIPE
+        stderr = subprocess.PIPE
+
+    proc = subprocess.Popen(
+        cmd,
+        stdout=stdout,
+        stderr=stderr,
+        text=text,
+        cwd=cwd,
+        env=env,
+        start_new_session=(os.name != "nt"),
+    )
+
+    previous_handlers = {}
+
+    def _signal_handler(signum, frame):
+        _terminate_process_group(
+            proc, terminate_signal=terminate_signal, kill_timeout=kill_timeout
+        )
+        previous = previous_handlers.get(signum)
+        if callable(previous):
+            previous(signum, frame)
+        if signum == signal.SIGINT:
+            raise KeyboardInterrupt
+        raise SystemExit(128 + signum)
+
+    for signum in (signal.SIGINT, signal.SIGTERM):
+        previous_handlers[signum] = signal.getsignal(signum)
+        signal.signal(signum, _signal_handler)
+
+    try:
+        try:
+            stdout_data, stderr_data = proc.communicate(timeout=timeout)
+            return ManagedProcessResult(
+                returncode=proc.returncode, stdout=stdout_data, stderr=stderr_data
+            )
+        except subprocess.TimeoutExpired:
+            _terminate_process_group(
+                proc, terminate_signal=terminate_signal, kill_timeout=kill_timeout
+            )
+            stdout_data, stderr_data = proc.communicate()
+            return ManagedProcessResult(
+                returncode=(
+                    timeout_returncode
+                    if timeout_returncode is not None
+                    else proc.returncode
+                ),
+                stdout=stdout_data,
+                stderr=stderr_data,
+                timed_out=True,
+            )
+    finally:
+        _terminate_process_group(
+            proc, terminate_signal=terminate_signal, kill_timeout=kill_timeout
+        )
+        for signum, handler in previous_handlers.items():
+            signal.signal(signum, handler)

--- a/src/rtl_buddy/tools/synth_yosys.py
+++ b/src/rtl_buddy/tools/synth_yosys.py
@@ -10,6 +10,7 @@ from .vlog_filelist import VlogFilelist
 from ..config.synth import SynthConfig, SynthToolConfig
 from ..errors import FilelistError
 from ..logging_utils import log_event, task_status
+from ..process_utils import run_managed_process
 from ..runner.synth_results import SynthFailResults, SynthPassResults, SynthResults
 
 # Default ABC script for liberty without timing constraint
@@ -251,11 +252,10 @@ class YosysSynth:
 
         with task_status(f"synth {self.synth_cfg.get_name()}"):
             with open(log_path, "w") as log_f:
-                result = subprocess.run(
+                result = run_managed_process(
                     cmd,
                     stdout=log_f,
                     stderr=subprocess.STDOUT,
-                    check=False,
                 )
 
         if result.returncode != 0:

--- a/src/rtl_buddy/tools/vlog_sim.py
+++ b/src/rtl_buddy/tools/vlog_sim.py
@@ -24,11 +24,11 @@ from .artifact_paths import test_artifact_dir, test_build_dir_name
 
 import time
 import pprint
-import subprocess
 from pathlib import Path
 
 from ..errors import FatalRtlBuddyError
 from ..logging_utils import log_event, task_status
+from ..process_utils import run_managed_process
 
 
 def force_symlink(target, link_name):
@@ -324,7 +324,7 @@ class VlogSim:
         s_time = time.time()
         with task_status(f"Compiling {self.test_name}", spinner="dots12"):
             try:
-                result = subprocess.run(
+                result = run_managed_process(
                     run_cmd, capture_output=True, text=True, cwd=compile_work_dir
                 )
             except FileNotFoundError:
@@ -484,40 +484,31 @@ class VlogSim:
         ):
             extra_env = self._get_extra_sim_env(run_id=run_id)
             sim_env = {**os.environ, **extra_env} if extra_env else None
-            popen_kwargs = dict(preexec_fn=os.setpgrp, cwd=artifact_dir)
-            if sim_env is not None:
-                popen_kwargs["env"] = sim_env
             with open(err_path, "w+") as test_err_fp:
                 with open(log_path, "w+") as test_out_fp:
-                    with subprocess.Popen(
-                        run_cmd, stdout=test_out_fp, stderr=test_err_fp, **popen_kwargs
-                    ) as process:
+                    result = run_managed_process(
+                        run_cmd,
+                        stdout=test_out_fp,
+                        stderr=test_err_fp,
+                        cwd=artifact_dir,
+                        env=sim_env,
+                        timeout=timeout,
+                        timeout_returncode=4444,
+                        terminate_signal=signal.SIGQUIT,
+                    )
+                    returncode = result.returncode
 
-                        def signal_handler(_no, _frame):
-                            process.send_signal(signal.SIGQUIT)
-                            raise KeyboardInterrupt
-
-                        signal.signal(signal.SIGINT, signal_handler)
-
-                        returncode = None
-                        try:
-                            returncode = process.wait(timeout)
-                        except subprocess.TimeoutExpired:
-                            pass
-
-                        t_time = time.time() - s_time
-                        if returncode is None:
-                            process.send_signal(signal.SIGQUIT)
-                            returncode = 4444
-                            log_event(
-                                logger,
-                                logging.ERROR,
-                                "sim.timeout",
-                                test=self.test_name,
-                                run_id=run_id,
-                                timeout_sec=timeout,
-                                **artifact_paths,
-                            )
+                    t_time = time.time() - s_time
+                    if result.timed_out:
+                        log_event(
+                            logger,
+                            logging.ERROR,
+                            "sim.timeout",
+                            test=self.test_name,
+                            run_id=run_id,
+                            timeout_sec=timeout,
+                            **artifact_paths,
+                        )
 
         with open(randseed_path, "w") as f:
             f.write(str(seed) + "\n")

--- a/tests/test_process_utils.py
+++ b/tests/test_process_utils.py
@@ -1,0 +1,134 @@
+import signal
+import subprocess
+
+import pytest
+
+from rtl_buddy import process_utils
+
+
+class FakeProcess:
+    def __init__(self, *, returncode=0, communicate_exc=None):
+        self.pid = 4321
+        self.returncode = returncode
+        self.communicate_exc = communicate_exc
+        self.wait_calls = []
+        self.completed = False
+        self.killed = False
+        self.terminated = False
+
+    def poll(self):
+        if self.completed:
+            return self.returncode
+        if self.killed:
+            return -9
+        if self.terminated:
+            return -15
+        return None
+
+    def communicate(self, timeout=None):
+        if self.communicate_exc is not None:
+            exc = self.communicate_exc
+            self.communicate_exc = None
+            raise exc
+        self.completed = True
+        return "", ""
+
+    def wait(self, timeout=None):
+        self.wait_calls.append(timeout)
+        return self.poll()
+
+    def terminate(self):
+        self.terminated = True
+
+    def kill(self):
+        self.killed = True
+
+
+def test_run_managed_process_terminates_group_on_keyboard_interrupt(monkeypatch):
+    proc = FakeProcess(communicate_exc=KeyboardInterrupt)
+    signals_sent = []
+
+    monkeypatch.setattr(
+        process_utils.subprocess,
+        "Popen",
+        lambda *args, **kwargs: proc,
+    )
+    monkeypatch.setattr(
+        process_utils.os,
+        "killpg",
+        lambda pid, sig: signals_sent.append((pid, sig)),
+    )
+
+    with pytest.raises(KeyboardInterrupt):
+        process_utils.run_managed_process(["tool"])
+
+    assert signals_sent == [(proc.pid, signal.SIGTERM)]
+    assert proc.wait_calls == [5]
+
+
+def test_run_managed_process_uses_timeout_signal_and_returncode(monkeypatch):
+    proc = FakeProcess(
+        returncode=0,
+        communicate_exc=subprocess.TimeoutExpired(["tool"], timeout=10),
+    )
+    signals_sent = []
+
+    monkeypatch.setattr(
+        process_utils.subprocess,
+        "Popen",
+        lambda *args, **kwargs: proc,
+    )
+    monkeypatch.setattr(
+        process_utils.os,
+        "killpg",
+        lambda pid, sig: signals_sent.append((pid, sig)),
+    )
+
+    result = process_utils.run_managed_process(
+        ["tool"],
+        timeout=10,
+        timeout_returncode=4444,
+        terminate_signal=signal.SIGQUIT,
+    )
+
+    assert result.returncode == 4444
+    assert result.timed_out
+    assert signals_sent == [(proc.pid, signal.SIGQUIT)]
+
+
+def test_run_managed_process_falls_back_when_group_signal_denied(monkeypatch):
+    proc = FakeProcess(communicate_exc=KeyboardInterrupt)
+    direct_signals = []
+
+    def _deny_group_signal(_pid, _sig):
+        raise PermissionError
+
+    proc.send_signal = direct_signals.append
+    monkeypatch.setattr(
+        process_utils.subprocess,
+        "Popen",
+        lambda *args, **kwargs: proc,
+    )
+    monkeypatch.setattr(process_utils.os, "killpg", _deny_group_signal)
+
+    with pytest.raises(KeyboardInterrupt):
+        process_utils.run_managed_process(["tool"])
+
+    assert direct_signals == [signal.SIGTERM]
+
+
+def test_run_managed_process_restores_signal_handlers(monkeypatch):
+    proc = FakeProcess()
+    original_int = signal.getsignal(signal.SIGINT)
+    original_term = signal.getsignal(signal.SIGTERM)
+
+    monkeypatch.setattr(
+        process_utils.subprocess,
+        "Popen",
+        lambda *args, **kwargs: proc,
+    )
+
+    process_utils.run_managed_process(["tool"])
+
+    assert signal.getsignal(signal.SIGINT) == original_int
+    assert signal.getsignal(signal.SIGTERM) == original_term

--- a/tests/test_setup_failures.py
+++ b/tests/test_setup_failures.py
@@ -2,6 +2,7 @@ from contextlib import nullcontext
 
 from rtl_buddy.errors import FilelistError
 from rtl_buddy.logging_utils import setup_logging
+from rtl_buddy.process_utils import ManagedProcessResult
 from rtl_buddy.rtl_buddy import RtlBuddy
 from rtl_buddy.runner.test_results import (
     FilelistFailResults,
@@ -265,20 +266,6 @@ class DummyPreprocTestCfg(DummyExecuteTestCfg):
         return self._script_path
 
 
-class DummyProcess:
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exc_type, exc, tb):
-        return False
-
-    def wait(self, _timeout):
-        return 0
-
-    def send_signal(self, _sig):
-        return None
-
-
 def test_vlog_sim_missing_hier_seed_file_is_nonfatal(tmp_path, monkeypatch):
     log_path = tmp_path / "rtl_buddy.log"
     setup_logging(color=False, log_path=log_path)
@@ -287,12 +274,8 @@ def test_vlog_sim_missing_hier_seed_file_is_nonfatal(tmp_path, monkeypatch):
         "rtl_buddy.tools.vlog_sim.task_status", lambda *args, **kwargs: nullcontext()
     )
     monkeypatch.setattr(
-        "rtl_buddy.tools.vlog_sim.signal.signal", lambda *_args, **_kwargs: None
-    )
-    monkeypatch.setattr("rtl_buddy.tools.vlog_sim.os.setpgrp", lambda: None)
-    monkeypatch.setattr(
-        "rtl_buddy.tools.vlog_sim.subprocess.Popen",
-        lambda *args, **kwargs: DummyProcess(),
+        "rtl_buddy.tools.vlog_sim.run_managed_process",
+        lambda *args, **kwargs: ManagedProcessResult(returncode=0),
     )
 
     sim = VlogSim(

--- a/tests/test_synth.py
+++ b/tests/test_synth.py
@@ -18,6 +18,7 @@ from rtl_buddy.runner.synth_results import (
     SynthPassResults,
     SynthSkipResults,
 )
+from rtl_buddy.process_utils import ManagedProcessResult
 from rtl_buddy.tools import synth_yosys as synth_yosys_module
 from rtl_buddy.tools.synth_yosys import YosysSynth
 from rtl_buddy.tools.vlog_filelist import VlogFilelist
@@ -462,14 +463,16 @@ def test_write_script_tool_overrides_applied(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def _fake_subprocess_run(returncode=0, write_log=None):
+def _fake_managed_process(returncode=0, write_log=None, calls=None):
+    calls = calls if calls is not None else []
 
-    def _run(cmd, stdout, stderr, check):
+    def _run_managed_process(cmd, stdout, stderr, **kwargs):
+        calls.append({"cmd": cmd, "stdout": stdout, "stderr": stderr, **kwargs})
         if write_log:
             stdout.write(write_log)
-        return type("R", (), {"returncode": returncode})()
+        return ManagedProcessResult(returncode=returncode)
 
-    return _run
+    return _run_managed_process
 
 
 def _setup_run(tmp_path):
@@ -513,7 +516,7 @@ def test_run_returns_pass_on_clean_exit(tmp_path, monkeypatch):
         synth_yosys_module, "task_status", lambda *a, **kw: nullcontext()
     )
     monkeypatch.setattr(
-        synth_yosys_module.subprocess, "run", _fake_subprocess_run(returncode=0)
+        synth_yosys_module, "run_managed_process", _fake_managed_process(returncode=0)
     )
     result = ys.run()
     assert isinstance(result, SynthPassResults)
@@ -540,7 +543,7 @@ def test_run_returns_fail_on_nonzero_exit(tmp_path, monkeypatch):
         synth_yosys_module, "task_status", lambda *a, **kw: nullcontext()
     )
     monkeypatch.setattr(
-        synth_yosys_module.subprocess, "run", _fake_subprocess_run(returncode=1)
+        synth_yosys_module, "run_managed_process", _fake_managed_process(returncode=1)
     )
     result = ys.run()
     assert isinstance(result, SynthFailResults)
@@ -568,13 +571,47 @@ def test_run_returns_fail_on_error_in_log(tmp_path, monkeypatch):
         synth_yosys_module, "task_status", lambda *a, **kw: nullcontext()
     )
     monkeypatch.setattr(
-        synth_yosys_module.subprocess,
-        "run",
-        _fake_subprocess_run(returncode=0, write_log="ERROR: something went wrong\n"),
+        synth_yosys_module,
+        "run_managed_process",
+        _fake_managed_process(returncode=0, write_log="ERROR: something went wrong\n"),
     )
     result = ys.run()
     assert isinstance(result, SynthFailResults)
     assert "ERROR" in result.results["desc"]
+
+
+def test_run_uses_managed_process_for_yosys(tmp_path, monkeypatch):
+    model = _setup_run(tmp_path)
+    synth_cfg = SynthConfig(
+        name="s",
+        desc="",
+        model=model,
+        tool="yosys",
+        constraints=None,
+        params=None,
+        defines=None,
+        libraries=None,
+        _reglvl=None,
+        tool_overrides=None,
+    )
+    ys = YosysSynth(
+        "t", synth_cfg=synth_cfg, tool_cfg=_tool_cfg(), suite_dir=str(tmp_path)
+    )
+    monkeypatch.setattr(
+        synth_yosys_module, "task_status", lambda *a, **kw: nullcontext()
+    )
+    calls = []
+    monkeypatch.setattr(
+        synth_yosys_module,
+        "run_managed_process",
+        _fake_managed_process(returncode=0, calls=calls),
+    )
+
+    result = ys.run()
+
+    assert isinstance(result, SynthPassResults)
+    assert calls
+    assert calls[0]["stderr"] == synth_yosys_module.subprocess.STDOUT
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_vlog_sim_paths.py
+++ b/tests/test_vlog_sim_paths.py
@@ -1,7 +1,7 @@
 from contextlib import nullcontext
 from pathlib import Path
-from types import SimpleNamespace
 
+from rtl_buddy.process_utils import ManagedProcessResult
 from rtl_buddy.seed_mode import SeedMode
 from rtl_buddy.tools.artifact_paths import (
     sanitize_artifact_component,
@@ -188,12 +188,12 @@ def test_vlog_sim_compile_uses_explicit_filelist_path_and_suite_cwd(
     def _fake_run(cmd, capture_output, text, cwd):
         captured["cmd"] = list(cmd)
         captured["cwd"] = cwd
-        return SimpleNamespace(returncode=0, stdout="", stderr="")
+        return ManagedProcessResult(returncode=0, stdout="", stderr="")
 
     monkeypatch.setattr(
         vlog_sim_module, "task_status", lambda *args, **kwargs: nullcontext()
     )
-    monkeypatch.setattr(vlog_sim_module.subprocess, "run", _fake_run)
+    monkeypatch.setattr(vlog_sim_module, "run_managed_process", _fake_run)
 
     assert sim.compile() == 0
     assert captured["cwd"] == str(tmp_path / "artefacts" / "basic")
@@ -210,35 +210,24 @@ def test_vlog_sim_execute_runs_in_artifact_dir_and_updates_symlinks(
     captured = {}
     sim = _make_sim(tmp_path, monkeypatch, builder_cfg=DummyBuilderCfg(simv="bin/simv"))
 
-    class FakeProcess:
-        def __enter__(self):
-            return self
-
-        def __exit__(self, exc_type, exc, tb):
-            return False
-
-        def wait(self, timeout):
-            captured["timeout"] = timeout
-            return 0
-
-        def send_signal(self, _signal):
-            captured["signal_sent"] = True
-
-    def _fake_popen(cmd, preexec_fn, cwd, stdout, stderr):
+    def _fake_run(cmd, cwd, stdout, stderr, timeout, terminate_signal, **kwargs):
         captured["cmd"] = list(cmd)
         captured["cwd"] = cwd
+        captured["timeout"] = timeout
+        captured["terminate_signal"] = terminate_signal
         stdout.write("PASS basic\n")
         stderr.write("")
-        return FakeProcess()
+        return ManagedProcessResult(returncode=0)
 
     monkeypatch.setattr(
         vlog_sim_module, "task_status", lambda *args, **kwargs: nullcontext()
     )
-    monkeypatch.setattr(vlog_sim_module.subprocess, "Popen", _fake_popen)
+    monkeypatch.setattr(vlog_sim_module, "run_managed_process", _fake_run)
 
     assert sim.execute(run_id=1) == 0
     assert captured["cmd"][0] == str(tmp_path / "artefacts" / "basic" / "bin" / "simv")
     assert captured["cwd"] == str(tmp_path / "artefacts" / "basic" / "run-0001")
+    assert captured["terminate_signal"] == vlog_sim_module.signal.SIGQUIT
     assert (
         Path(tmp_path / "test.log").resolve()
         == Path(sim._get_log_path(run_id=1)).resolve()
@@ -259,27 +248,14 @@ def test_vlog_sim_execute_reads_replay_seed_from_nested_run_dir(tmp_path, monkey
     Path(sim._ensure_artifact_dir(run_id=3)).mkdir(parents=True, exist_ok=True)
     Path(sim._get_randseed_path(run_id=3)).write_text("4242\n")
 
-    class FakeProcess:
-        def __enter__(self):
-            return self
-
-        def __exit__(self, exc_type, exc, tb):
-            return False
-
-        def wait(self, timeout):
-            return 0
-
-        def send_signal(self, _signal):
-            captured["signal_sent"] = True
-
-    def _fake_popen(cmd, preexec_fn, cwd, stdout, stderr):
+    def _fake_run(cmd, **kwargs):
         captured["cmd"] = list(cmd)
-        return FakeProcess()
+        return ManagedProcessResult(returncode=0)
 
     monkeypatch.setattr(
         vlog_sim_module, "task_status", lambda *args, **kwargs: nullcontext()
     )
-    monkeypatch.setattr(vlog_sim_module.subprocess, "Popen", _fake_popen)
+    monkeypatch.setattr(vlog_sim_module, "run_managed_process", _fake_run)
 
     assert sim.execute(run_id=5, seed_mode=SeedMode.REPLAY, replay_run_id=3) == 0
     assert "+seed=4242" in captured["cmd"]
@@ -290,30 +266,14 @@ def test_vlog_sim_execute_reads_hier_seed_from_artifact_dir(tmp_path, monkeypatc
         tmp_path, monkeypatch, builder_cfg=DummyBuilderCfg(run_opts=["hier_inst_seed"])
     )
 
-    class FakeProcess:
-        def __init__(self, cwd):
-            self.cwd = Path(cwd)
-
-        def __enter__(self):
-            (self.cwd / "HierInstanceSeed.txt").write_text("instance_seed=99\n")
-            return self
-
-        def __exit__(self, exc_type, exc, tb):
-            return False
-
-        def wait(self, timeout):
-            return 0
-
-        def send_signal(self, _signal):
-            pass
-
-    def _fake_popen(cmd, preexec_fn, cwd, stdout, stderr):
-        return FakeProcess(cwd)
+    def _fake_run(cmd, cwd, **kwargs):
+        Path(cwd, "HierInstanceSeed.txt").write_text("instance_seed=99\n")
+        return ManagedProcessResult(returncode=0)
 
     monkeypatch.setattr(
         vlog_sim_module, "task_status", lambda *args, **kwargs: nullcontext()
     )
-    monkeypatch.setattr(vlog_sim_module.subprocess, "Popen", _fake_popen)
+    monkeypatch.setattr(vlog_sim_module, "run_managed_process", _fake_run)
 
     assert sim.execute(run_id=1) == 0
     randseed_text = Path(sim._get_randseed_path(run_id=1)).read_text()
@@ -325,31 +285,15 @@ def test_vlog_sim_multiple_runs_keep_runtime_side_files_separate(tmp_path, monke
     sim = _make_sim(tmp_path, monkeypatch)
     counter = {"value": 0}
 
-    class FakeProcess:
-        def __init__(self, cwd):
-            self.cwd = Path(cwd)
-
-        def __enter__(self):
-            counter["value"] += 1
-            (self.cwd / "wave.vcd").write_text(f"run={counter['value']}\n")
-            return self
-
-        def __exit__(self, exc_type, exc, tb):
-            return False
-
-        def wait(self, timeout):
-            return 0
-
-        def send_signal(self, _signal):
-            pass
-
-    def _fake_popen(cmd, preexec_fn, cwd, stdout, stderr):
-        return FakeProcess(cwd)
+    def _fake_run(cmd, cwd, **kwargs):
+        counter["value"] += 1
+        Path(cwd, "wave.vcd").write_text(f"run={counter['value']}\n")
+        return ManagedProcessResult(returncode=0)
 
     monkeypatch.setattr(
         vlog_sim_module, "task_status", lambda *args, **kwargs: nullcontext()
     )
-    monkeypatch.setattr(vlog_sim_module.subprocess, "Popen", _fake_popen)
+    monkeypatch.setattr(vlog_sim_module, "run_managed_process", _fake_run)
 
     assert sim.execute(run_id=1) == 0
     assert sim.execute(run_id=2) == 0


### PR DESCRIPTION
## Summary
- add a shared managed subprocess runner for long-lived external tools
- run synth and compile/sim commands through process-group cleanup
- preserve simulator SIGQUIT shutdown behavior while applying it to the process group

Fixes #70.

## Validation
- uv run pytest
- uv run ruff check src/rtl_buddy/process_utils.py src/rtl_buddy/tools/synth_yosys.py src/rtl_buddy/tools/vlog_sim.py tests/test_process_utils.py tests/test_synth.py tests/test_vlog_sim_paths.py tests/test_setup_failures.py
- uv run ruff format --check src/rtl_buddy/process_utils.py src/rtl_buddy/tools/synth_yosys.py src/rtl_buddy/tools/vlog_sim.py tests/test_process_utils.py tests/test_synth.py tests/test_vlog_sim_paths.py tests/test_setup_failures.py
- template repo: PYTHONPATH=<patched src> uv run python -m rtl_buddy --machine regression -c design/regression.yaml
- template repo temporary synth root: PYTHONPATH=<patched src> uv run --project <template dev-local> python -m rtl_buddy --machine synth -c synth.yaml
- template repo interrupted synth check: saw new Yosys activity, sent SIGINT, and verified new_survivors=[]