### PR TITLE
feat: integrate rtl-buddy-cdc as a first-class CDC tool

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -51,6 +51,8 @@ Usage: rtl-buddy [OPTIONS] COMMAND [ARGS]...
 │ wave-install-nvim  install nvim plugin for rb wave annotation                        │
 │ synth              run synthesis                                                     │
 │ synth-regression   run synthesis regression                                          │
+│ cdc                run CDC lint                                                      │
+│ cdc-regression     run CDC lint regression                                           │
 │ skill              manage the rtl_buddy agent skill                                  │
 │ docs               browse bundled documentation                                      │
 │ spec               spec traceability commands                                        │

--- a/docs/reference/yaml.md
+++ b/docs/reference/yaml.md
@@ -1,5 +1,5 @@
 ---
-description: Canonical reference for rtl_buddy YAML configuration files, including root_config.yaml, regression.yaml, tests.yaml, models.yaml, synth.yaml, and synth_regression.yaml.
+description: Canonical reference for rtl_buddy YAML configuration files, including root_config.yaml, regression.yaml, tests.yaml, models.yaml, synth.yaml, synth_regression.yaml, cdc.yaml, and cdc_regression.yaml.
 ---
 
 # YAML Formats
@@ -86,6 +86,13 @@ cfg-synth-libs:
     lef-paths:           # required for OpenROAD backend
       - "pdk/sky130hd/lef/sky130_fd_sc_hd_merged.lef"
 
+cfg-cdc-tools:
+  - name: "rtl-buddy-cdc"
+    tool: "rtl-buddy-cdc"
+    opts:
+      sync-depth: 2          # forwarded as `--sync-depth N` (CDC-002 required depth)
+      extra-args: ""         # appended verbatim to every invocation
+
 cfg-rtl-reg:
   reg-cfg-path: "design/regression.yaml"
 ```
@@ -100,6 +107,7 @@ cfg-rtl-reg:
 - `cfg-surfer` configures the Surfer waveform viewer used by `rb wave`. `path` is a bare executable name (resolved via PATH) or a relative/absolute path to the binary. `editor-cmd` supports `%f` (file path) and `%l` (line number) placeholders. `editor-terminal` controls how the editor is launched: `tmux` opens a new tmux window, `iterm2` and `terminal` use AppleScript, empty string runs the command directly (suitable for GUI editors like VS Code). `editor-sock` is an optional Unix socket path that enables nvim remote reuse: rtl-buddy launches nvim with `--listen <sock>` on first use and reconnects for subsequent events. `ctrl-sock` is an optional Unix socket for the wave control server, which lets nvim send signals to Surfer — press `<Space>wa` (or your `<leader>wa`) on a signal name to add it to the waveform view. Install the bundled nvim plugin first with `rb wave-install-nvim`.
 - `cfg-synth-tools` defines synthesis tool entries selected by `synth.yaml` `tool` fields. `tool` is the executable name on `PATH`. For the Yosys backend, `opts.synth-args` are appended to the `synth` command and `opts.abc-args` are used by the unmapped ABC step. For the OpenROAD backend, `opts.strategy` controls optional resynthesis (`AREA` = none, `TIMING`/`TIMING_ANNEAL` = `resynth_annealing`, `TIMING_GENETIC` = `resynth_genetic`).
 - `cfg-synth-libs` defines named Liberty files for technology-mapped synthesis. `path` is resolved relative to `root_config.yaml`. The optional `lef-paths` list specifies LEF files required by the OpenROAD backend for technology loading; ignored by the Yosys backend.
+- `cfg-cdc-tools` defines CDC tool entries selected by `cdc.yaml` `tool` fields. `tool` is the executable name on `PATH` (or an absolute path). `opts.sync-depth` is forwarded as `--sync-depth N` and controls CDC-002's required synchronizer depth. `opts.extra-args` is appended verbatim to every analyzer invocation.
 - `cfg-rtl-reg.reg-cfg-path` is the fallback regression file for `rtl-buddy regression` when no `./regression.yaml` exists in the cwd.
 - `cfg-verible[].path` is the directory containing Verible executables. Absolute paths are used as-is; relative paths are resolved from the directory containing `root_config.yaml`.
 
@@ -387,6 +395,91 @@ synth-configs:
 - `rtl-buddy synth-regression` iterates each listed `synth.yaml` file and filters syntheses by `--reg-level`.
 - Paths in `synth-configs` are resolved relative to the `synth_regression.yaml` file.
 - `synth-regression` changes directory into each synthesis suite directory before executing its entries.
+
+---
+
+## cdc.yaml
+
+**Required keys:**
+
+- `rtl-buddy-filetype: cdc_config`
+- `analyses`
+
+**Example:**
+
+```yaml
+rtl-buddy-filetype: cdc_config
+
+analyses:
+  - name: "ip_cdc_handshake_lint"
+    desc: "CDC lint of the request/ack handshake IP"
+    model: "ip_cdc_handshake"
+    model_path: "../../design/common/models.yaml"
+    tool: "rtl-buddy-cdc"
+    constraints: "ip_cdc_handshake.sdc"
+    waivers: "ip_cdc_handshake.waivers"   # optional
+    reglvl: 0
+
+  - name: "alu_accel_lint"
+    desc: "CDC lint of the ALU accelerator"
+    model: "alu_accel_top"
+    model_path: "../../design/alu_accel/models.yaml"
+    tool: "rtl-buddy-cdc"
+    constraints: "alu_accel_top.sdc"
+    reglvl:
+      default: 0
+      rtl-buddy-cdc: 100
+    tool_overrides:
+      rtl-buddy-cdc:
+        sync_depth: 3
+        extra_args: "--strict"
+```
+
+**Field reference:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Analysis identifier; used on the CLI and in `artefacts/{name}/` |
+| `desc` | string | Human-readable analysis description |
+| `model` | string | Model name from `models.yaml`; also used as the top module for elaboration |
+| `model_path` | string | Path to `models.yaml`, resolved relative to the `cdc.yaml` file |
+| `tool` | string | CDC tool name from `root_config.yaml` `cfg-cdc-tools` |
+| `constraints` | string | SDC file path, resolved relative to the `cdc.yaml` file |
+| `waivers` | string | Optional waiver file path, resolved relative to the `cdc.yaml` file |
+| `reglvl` | int or dict | Regression level; int for all tools, dict for per-tool with `default` |
+| `tool_overrides` | dict | Optional per-tool overrides for `sync_depth` or `extra_args`, keyed by CDC tool name |
+
+**Runtime effects:**
+
+- `rtl-buddy cdc` loads `cdc.yaml`, resolves sources via `models.yaml`, and dispatches to the backend selected by `tool`.
+- The bundled `rtl-buddy-cdc` backend invokes the standalone `rtl-buddy-cdc lint` CLI as a subprocess. The analysis receives the model's resolved filelist, the SDC, an optional waivers file, and the merged tool opts (root `cfg-cdc-tools` baseline plus any matching `tool_overrides.<tool>`).
+- Each analysis writes a text report and a machine-readable JSON report under `artefacts/{name}/`; the JSON summary is parsed to populate the pass/fail/skip result for the CLI table.
+- `rtl-buddy cdc <name> --list` lists configured analyses without running them.
+
+---
+
+## cdc_regression.yaml
+
+**Required keys:**
+
+- `rtl-buddy-filetype: cdc_reg_config`
+- `cdc-configs`
+
+**Example:**
+
+```yaml
+rtl-buddy-filetype: cdc_reg_config
+
+cdc-configs:
+  - "design/example_block_a/lint/cdc.yaml"
+  - "design/example_block_b/lint/cdc.yaml"
+```
+
+**Runtime effects:**
+
+- `rtl-buddy cdc-regression` iterates each listed `cdc.yaml` file and filters analyses by `--reg-level`.
+- Paths in `cdc-configs` are resolved relative to the `cdc_regression.yaml` file.
+- `cdc-regression` changes directory into each CDC suite directory before executing its entries.
 
 ---
 

--- a/src/rtl_buddy/config/cdc.py
+++ b/src/rtl_buddy/config/cdc.py
@@ -133,21 +133,32 @@ class CdcConfig:
     def get_tool_name(self) -> str:
         return self.tool
 
-    def get_tool_overrides(self) -> dict | None:
-        return self.tool_overrides
+    def get_tool_overrides_for(self, tool_name: str) -> dict | None:
+        if self.tool_overrides is None:
+            return None
+        return self.tool_overrides.get(tool_name)
 
-    def get_reglvl(self, _tool_name: str) -> int:
-        # CDC reglvl is a flat int for now; we accept the same dict-by-tool
-        # form as synth purely so users can mix-and-match without surprise.
-        rl = self._reglvl
-        if rl is None:
-            return 0
-        if isinstance(rl, int):
-            return rl
-        if isinstance(rl, dict):
-            v = rl.get(_tool_name)
-            return int(v) if v is not None else 0
-        return 0
+    def get_reglvl(self, tool_name: str) -> int:
+        match self._reglvl:
+            case int() as lvl:
+                return lvl
+            case dict() if tool_name in self._reglvl:
+                return self._reglvl[tool_name]
+            case dict() if "default" in self._reglvl:
+                return self._reglvl["default"]
+            case None:
+                return 0
+            case _:
+                log_event(
+                    logger,
+                    logging.ERROR,
+                    "cdc_config.reglvl_malformed",
+                    cdc=self.name,
+                    tool=tool_name,
+                )
+                raise FatalRtlBuddyError(
+                    f"Malformed cdc.yaml, specify reglvl for {self.name} with {tool_name} or default"
+                )
 
     def __str__(self):
         return pprint.pformat(self)

--- a/src/rtl_buddy/config/cdc.py
+++ b/src/rtl_buddy/config/cdc.py
@@ -1,0 +1,265 @@
+"""Configuration schema for CDC (clock-domain-crossing) lint runs.
+
+Mirrors the synthesis schema (``config/synth.py``) at a smaller surface:
+each ``cdc.yaml`` lists one or more analyses; each analysis names a
+model + an SDC + optionally a waiver file; the project's
+``root_config.yaml`` declares the available CDC tools under
+``cfg-cdc-tools``.
+"""
+
+import logging
+import os
+import pprint
+from dataclasses import dataclass
+
+from serde import field, serde
+from serde.yaml import from_yaml
+from typing import Literal
+
+from .model import ModelConfig, ModelConfigLoader
+from ..errors import FatalRtlBuddyError
+from ..logging_utils import log_event
+
+logger = logging.getLogger(__name__)
+
+
+# ---- tool config -----------------------------------------------------------
+
+
+@dataclass
+class CdcToolOpts:
+    sync_depth: int | None = None
+    extra_args: str = ""
+
+
+@serde
+class CdcToolOptsFile:
+    sync_depth: int | None = field(rename="sync-depth", default=None)
+    extra_args: str = field(rename="extra-args", default="")
+
+
+@serde
+class CdcToolConfigFile:
+    name: str
+    tool: str
+    opts: CdcToolOptsFile = field(default_factory=CdcToolOptsFile)
+
+
+class CdcToolConfig:
+    """One entry from ``cfg-cdc-tools`` in ``root_config.yaml``."""
+
+    def __init__(self, cfg: CdcToolConfigFile):
+        self._cfg = cfg
+
+    def get_name(self) -> str:
+        return self._cfg.name
+
+    def get_executable(self) -> str:
+        return self._cfg.tool
+
+    def get_opts(self, overrides: dict | None = None) -> CdcToolOpts:
+        sync_depth = self._cfg.opts.sync_depth
+        extra_args = self._cfg.opts.extra_args
+        if overrides:
+            sync_depth = overrides.get("sync_depth", sync_depth)
+            extra_args = overrides.get("extra_args", extra_args)
+        return CdcToolOpts(sync_depth=sync_depth, extra_args=extra_args)
+
+
+# ---- per-analysis config ---------------------------------------------------
+
+
+@serde
+class CdcConfigFile:
+    name: str
+    desc: str
+    model: str
+    model_path: str = field(rename="model_path")
+    tool: str
+    constraints: str
+    waivers: str | None = None
+    reglvl: int | dict | None = field(rename="reglvl", default=None)
+    tool_overrides: dict | None = None
+
+    def initialise(self, config_dir: str) -> "CdcConfig":
+        model = ModelConfigLoader(
+            os.path.join(config_dir, self.model_path)
+        ).get_model(self.model)
+        constraints = os.path.join(config_dir, self.constraints)
+        waivers = (
+            os.path.join(config_dir, self.waivers) if self.waivers is not None else None
+        )
+        return CdcConfig(
+            name=self.name,
+            desc=self.desc,
+            model=model,
+            tool=self.tool,
+            constraints=constraints,
+            waivers=waivers,
+            _reglvl=self.reglvl,
+            tool_overrides=self.tool_overrides,
+        )
+
+
+@dataclass
+class CdcConfig:
+    name: str
+    desc: str
+    model: ModelConfig
+    tool: str
+    constraints: str
+    waivers: str | None
+    _reglvl: int | dict | None
+    tool_overrides: dict | None
+
+    def get_name(self) -> str:
+        return self.name
+
+    def get_desc(self) -> str:
+        return self.desc
+
+    def get_model(self) -> ModelConfig:
+        return self.model
+
+    def get_top(self) -> str:
+        return self.model.name
+
+    def get_constraints(self) -> str:
+        return self.constraints
+
+    def get_waivers(self) -> str | None:
+        return self.waivers
+
+    def get_tool_name(self) -> str:
+        return self.tool
+
+    def get_tool_overrides(self) -> dict | None:
+        return self.tool_overrides
+
+    def get_reglvl(self, _tool_name: str) -> int:
+        # CDC reglvl is a flat int for now; we accept the same dict-by-tool
+        # form as synth purely so users can mix-and-match without surprise.
+        rl = self._reglvl
+        if rl is None:
+            return 0
+        if isinstance(rl, int):
+            return rl
+        if isinstance(rl, dict):
+            v = rl.get(_tool_name)
+            return int(v) if v is not None else 0
+        return 0
+
+    def __str__(self):
+        return pprint.pformat(self)
+
+
+# ---- suite (a single cdc.yaml) --------------------------------------------
+
+
+@serde
+class CdcSuiteConfigFile:
+    filetype: Literal["cdc_config"] = field(rename="rtl-buddy-filetype")
+    analyses: list[CdcConfigFile]
+
+
+class CdcSuiteConfig:
+    def __init__(self, path: str):
+        self.path = path
+        self.analyses: dict[str, CdcConfig] = {}
+        try:
+            with open(path, "r") as f:
+                data = from_yaml(CdcSuiteConfigFile, f.read())
+        except Exception as e:
+            log_event(
+                logger,
+                logging.ERROR,
+                "cdc_suite_config.load_failed",
+                path=path,
+                error=e,
+            )
+            raise FatalRtlBuddyError(f'failed to load "{path}"') from e
+
+        config_dir = os.path.dirname(os.path.abspath(path))
+        try:
+            self.analyses = {a.name: a.initialise(config_dir) for a in data.analyses}
+        except Exception as e:
+            log_event(
+                logger,
+                logging.ERROR,
+                "cdc_suite_config.analyses_malformed",
+                path=path,
+                error=e,
+            )
+            raise FatalRtlBuddyError(f"{path}: analyses section malformed") from e
+
+    def get_analyses(self, name: str | None = None) -> list[CdcConfig]:
+        if name is not None:
+            if name not in self.analyses:
+                log_event(
+                    logger,
+                    logging.ERROR,
+                    "cdc_suite_config.analysis_missing",
+                    path=self.path,
+                    analysis=name,
+                )
+                raise FatalRtlBuddyError(
+                    f"CDC analysis '{name}' not found in suite {self.path}"
+                )
+            return [self.analyses[name]]
+        return list(self.analyses.values())
+
+    def get_analysis_names(self) -> list[str]:
+        return list(self.analyses.keys())
+
+    def get_path(self) -> str:
+        return self.path
+
+    def __str__(self):
+        return pprint.pformat(self)
+
+
+# ---- regression (a list of cdc.yaml suites) -------------------------------
+
+
+@serde
+class CdcRegConfigFile:
+    filetype: Literal["cdc_reg_config"] = field(rename="rtl-buddy-filetype")
+    cdc_configs: list[str] = field(rename="cdc-configs", default_factory=list)
+
+
+class CdcRegConfig:
+    def __init__(self, name: str, path: str):
+        self.name = name
+        self.path = path
+        self.suite_configs: list[CdcSuiteConfig] = []
+        try:
+            with open(path, "r") as f:
+                data = from_yaml(CdcRegConfigFile, f.read())
+            self.suite_configs = [
+                CdcSuiteConfig(os.path.join(os.path.dirname(path), p))
+                for p in data.cdc_configs
+            ]
+        except FatalRtlBuddyError:
+            raise
+        except Exception as e:
+            log_event(
+                logger,
+                logging.ERROR,
+                "cdc_reg_config.load_failed",
+                name=name,
+                path=path,
+                error=e,
+            )
+            raise FatalRtlBuddyError(f'{name}: failed to load "{path}"') from e
+
+    def get_name(self) -> str:
+        return self.name
+
+    def get_path(self) -> str:
+        return self.path
+
+    def get_suite_configs(self) -> list[CdcSuiteConfig]:
+        return self.suite_configs
+
+    def __str__(self):
+        return pprint.pformat(self)

--- a/src/rtl_buddy/config/cdc.py
+++ b/src/rtl_buddy/config/cdc.py
@@ -82,9 +82,9 @@ class CdcConfigFile:
     tool_overrides: dict | None = None
 
     def initialise(self, config_dir: str) -> "CdcConfig":
-        model = ModelConfigLoader(
-            os.path.join(config_dir, self.model_path)
-        ).get_model(self.model)
+        model = ModelConfigLoader(os.path.join(config_dir, self.model_path)).get_model(
+            self.model
+        )
         constraints = os.path.join(config_dir, self.constraints)
         waivers = (
             os.path.join(config_dir, self.waivers) if self.waivers is not None else None

--- a/src/rtl_buddy/config/root.py
+++ b/src/rtl_buddy/config/root.py
@@ -421,9 +421,7 @@ class RootConfig:
         """
         cfg = self.cdc_tool_cfgs.get(name)
         if cfg is None:
-            raise FatalRtlBuddyError(
-                f"CDC tool '{name}' not found in cfg-cdc-tools"
-            )
+            raise FatalRtlBuddyError(f"CDC tool '{name}' not found in cfg-cdc-tools")
         return cfg
 
     def get_synth_lib_cfg(self, name: str):

--- a/src/rtl_buddy/config/root.py
+++ b/src/rtl_buddy/config/root.py
@@ -23,6 +23,7 @@ from .synth import (
     SynthLibConfig,
     SynthLibConfigFile,
 )
+from .cdc import CdcToolConfig, CdcToolConfigFile
 from ..errors import FatalRtlBuddyError
 from ..logging_utils import log_event
 
@@ -106,6 +107,9 @@ class RootConfigFile:
     synth_libs: list[SynthLibConfigFile] = field(
         rename="cfg-synth-libs", default_factory=list
     )
+    cdc_tools: list[CdcToolConfigFile] = field(
+        rename="cfg-cdc-tools", default_factory=list
+    )
 
 
 class RootConfig:
@@ -150,6 +154,7 @@ class RootConfig:
         self.surfer_cfgs: dict = {}
         self.synth_tool_cfgs = dict()
         self.synth_lib_cfgs = dict()
+        self.cdc_tool_cfgs: dict = {}
         self.platform_cfg = None
         self.reg_cfg = None  # initialise later when get_rtl_reg_cfg is called
 
@@ -198,6 +203,11 @@ class RootConfig:
             self.synth_lib_cfgs = {
                 cfg.name: SynthLibConfig(cfg, self.root_cfg_path)
                 for cfg in data.synth_libs
+            }
+
+            # Populate CDC tool configs
+            self.cdc_tool_cfgs = {
+                cfg.name: CdcToolConfig(cfg) for cfg in data.cdc_tools
             }
 
             # Initialise regression config
@@ -395,6 +405,24 @@ class RootConfig:
         if cfg is None:
             raise FatalRtlBuddyError(
                 f"synthesis tool '{name}' not found in cfg-synth-tools"
+            )
+        return cfg
+
+    def get_cdc_tool_cfg(self, name: str):
+        """
+        Get CDC tool configuration by name.
+
+        Args:
+          name (str): Tool name as defined in cfg-cdc-tools.
+        Returns:
+          cfg (CdcToolConfig): Matching CDC tool configuration.
+        Raises:
+          FatalRtlBuddyError: If no tool with that name is configured.
+        """
+        cfg = self.cdc_tool_cfgs.get(name)
+        if cfg is None:
+            raise FatalRtlBuddyError(
+                f"CDC tool '{name}' not found in cfg-cdc-tools"
             )
         return cfg
 

--- a/src/rtl_buddy/rtl_buddy.py
+++ b/src/rtl_buddy/rtl_buddy.py
@@ -15,6 +15,7 @@ from typing_extensions import Annotated
 import click
 
 from .config import RegConfig, RootConfig, SuiteConfig, TestConfig
+from .config.cdc import CdcRegConfig, CdcSuiteConfig
 from .config.model import ModelConfigLoader
 from .config.synth import SynthRegConfig, SynthSuiteConfig
 from .docs_access import get_page, get_section, list_pages
@@ -26,6 +27,8 @@ from .logging_utils import (
     render_summary,
     setup_logging,
 )
+from .runner.cdc_runner import CdcRunner
+from .runner.cdc_results import CdcSkipResults
 from .runner.test_results import SetupFailResults, SkipResults
 from .runner.test_runner import RunDepth, TestRunner
 from .runner.synth_runner import SynthRunner
@@ -63,6 +66,8 @@ class RtlBuddy:
         "wave",
         "synth",
         "synth-regression",
+        "cdc",
+        "cdc-regression",
     }
 
     def cb_builder(value: str | None) -> str | None:
@@ -114,6 +119,10 @@ class RtlBuddy:
         self.app.command("synth", help="run synthesis")(self.do_cmd_synth)
         self.app.command("synth-regression", help="run synthesis regression")(
             self.do_synth_regression
+        )
+        self.app.command("cdc", help="run CDC lint")(self.do_cmd_cdc)
+        self.app.command("cdc-regression", help="run CDC lint regression")(
+            self.do_cdc_regression
         )
         self.app.add_typer(
             skill_app, name="skill", help="manage the rtl_buddy agent skill"
@@ -1557,6 +1566,191 @@ class RtlBuddy:
             metadata=[f"Reg Level: {reg_level}"],
         )
         raise typer.Exit(self._exit_code_from_synth_results(all_results))
+
+    # --- CDC subcommands ----------------------------------------------------
+
+    def _render_cdc_summary(self, title, cdc_results, *, metadata=None):
+        rows = []
+        for r in cdc_results:
+            res = r["results"].results
+            row = {
+                "cdc_name": r["cdc_name"],
+                "result": res["result"],
+                "desc": res["desc"],
+                "violations": str(res.get("violations", "-")),
+                "suppressed": str(res.get("suppressed", "-")),
+            }
+            crossings = res.get("crossings")
+            row["crossings"] = str(crossings) if crossings is not None else "-"
+            rows.append(row)
+
+        columns = [
+            ("cdc_name", "CDC Analysis"),
+            ("result", "Result"),
+            ("desc", "Description"),
+            ("violations", "Violations"),
+            ("suppressed", "Suppressed"),
+            ("crossings", "Crossings"),
+        ]
+        render_summary(
+            title=title,
+            columns=columns,
+            rows=rows,
+            logger=logger,
+            metadata=metadata,
+        )
+
+    def _exit_code_from_cdc_results(self, cdc_results):
+        return 0 if all(r["results"].is_pass() for r in cdc_results) else 1
+
+    def _do_cdc_suite(self, suite_cfg, cdc_name=None, reg_level=None):
+        analyses = suite_cfg.get_analyses(cdc_name)
+        suite_dir = str(Path(suite_cfg.get_path()).resolve().parent)
+        results = []
+        for a in analyses:
+            tool_name = a.get_tool_name()
+            t_lvl = a.get_reglvl(tool_name)
+            if reg_level is not None and t_lvl > reg_level:
+                log_event(
+                    logger,
+                    logging.INFO,
+                    "cdc_suite.skip",
+                    cdc=a.get_name(),
+                    reason="above_regression_level",
+                    cdc_level=t_lvl,
+                    reg_level=reg_level,
+                )
+                results.append(
+                    {
+                        "cdc_name": a.get_name(),
+                        "results": CdcSkipResults(
+                            name=a.get_name() + "/results",
+                            desc=f"lvl {t_lvl} > cmd reg_level {reg_level}",
+                        ),
+                    }
+                )
+                continue
+            runner = CdcRunner(
+                name=self.name + "/cdc_runner",
+                root_cfg=self.root_cfg,
+                cdc_cfg=a,
+                suite_dir=suite_dir,
+            )
+            results.append({"cdc_name": a.get_name(), "results": runner.run()})
+        return results
+
+    def do_cmd_cdc(
+        self,
+        cdc_config: Annotated[
+            str,
+            typer.Option("-c", "--cdc-config", help="cdc.yaml to use"),
+        ] = "cdc.yaml",
+        cdc_name: Annotated[
+            str,
+            typer.Argument(
+                help="name of CDC analysis to run", show_default="run all analyses"
+            ),
+        ] = None,
+        list_cdcs: Annotated[
+            bool,
+            typer.Option(
+                "--list", help="list analyses in the selected config and exit"
+            ),
+        ] = False,
+    ):
+        """
+        run CDC lint
+        """
+        suite_cfg = CdcSuiteConfig(path=cdc_config)
+        log_event(
+            logger,
+            logging.INFO,
+            "command.cdc",
+            command="cdc",
+            cdc=cdc_name or "all",
+            cdc_config=cdc_config,
+        )
+
+        if list_cdcs:
+            emit_console_text(
+                "  ".join(suite_cfg.get_analysis_names()), stream="stdout"
+            )
+            raise typer.Exit(0)
+
+        cdc_results = self._do_cdc_suite(suite_cfg, cdc_name=cdc_name)
+        self._render_cdc_summary("CDC Lint Results Summary", cdc_results)
+        raise typer.Exit(self._exit_code_from_cdc_results(cdc_results))
+
+    def do_cdc_regression(
+        self,
+        reg_config: Annotated[
+            str,
+            typer.Option(
+                "-c",
+                "--reg-config",
+                help="path to cdc_regression.yaml",
+                show_default="Use ./cdc_regression.yaml if present",
+            ),
+        ] = None,
+        reg_level: Annotated[
+            int,
+            typer.Option(
+                "-l", "--reg-level", help="CDC regression level to stop at"
+            ),
+        ] = 0,
+    ):
+        """
+        run CDC lint regression
+        """
+        log_event(
+            logger,
+            logging.INFO,
+            "command.cdc_regression",
+            reg_config=reg_config,
+            reg_level=reg_level,
+        )
+
+        start_dir = os.getcwd()
+        if reg_config is not None:
+            reg_cfg_path = os.path.join(start_dir, reg_config)
+        else:
+            local = os.path.join(start_dir, "cdc_regression.yaml")
+            reg_cfg_path = local if os.path.isfile(local) else None
+            if reg_cfg_path is None:
+                raise FatalRtlBuddyError(
+                    "cdc_regression.yaml not found; pass -c to specify a path"
+                )
+
+        cdc_reg = CdcRegConfig(name=self.name + "/cdc_reg_config", path=reg_cfg_path)
+        emit_console_text(
+            f"Running CDC regression from {os.path.dirname(reg_cfg_path)}",
+            style="cyan",
+        )
+
+        all_results = []
+        try:
+            for suite_cfg in cdc_reg.get_suite_configs():
+                suite_dir = os.path.dirname(suite_cfg.get_path())
+                log_event(
+                    logger,
+                    logging.INFO,
+                    "cdc_regression.suite_start",
+                    suite=suite_cfg.get_path(),
+                )
+                os.chdir(suite_dir)
+                suite_results = self._do_cdc_suite(
+                    suite_cfg, cdc_name=None, reg_level=reg_level
+                )
+                all_results.extend(suite_results)
+        finally:
+            os.chdir(start_dir)
+
+        self._render_cdc_summary(
+            "CDC Regression Summary",
+            all_results,
+            metadata=[f"Reg Level: {reg_level}"],
+        )
+        raise typer.Exit(self._exit_code_from_cdc_results(all_results))
 
     def do_cmd_wave(
         self,

--- a/src/rtl_buddy/rtl_buddy.py
+++ b/src/rtl_buddy/rtl_buddy.py
@@ -1694,9 +1694,7 @@ class RtlBuddy:
         ] = None,
         reg_level: Annotated[
             int,
-            typer.Option(
-                "-l", "--reg-level", help="CDC regression level to stop at"
-            ),
+            typer.Option("-l", "--reg-level", help="CDC regression level to stop at"),
         ] = 0,
     ):
         """

--- a/src/rtl_buddy/runner/cdc_results.py
+++ b/src/rtl_buddy/runner/cdc_results.py
@@ -1,0 +1,75 @@
+"""Result records for a single CDC analysis run."""
+
+import pprint
+
+
+class CdcResults:
+    def __init__(self, name, results=None):
+        if results is None:
+            results = {"result": "NA", "desc": "NA"}
+        self.name = name
+        self.results = results
+        if "result" not in results:
+            results["result"] = "NA"
+        if "desc" not in results:
+            results["desc"] = "NA"
+
+    def is_pass(self) -> bool:
+        return self.results["result"] in ("PASS", "SKIP")
+
+    def __str__(self):
+        return "cdc_results: " + pprint.pformat(self.results)
+
+
+class CdcPassResults(CdcResults):
+    def __init__(
+        self,
+        name,
+        *,
+        violations: int = 0,
+        suppressed: int = 0,
+        crossings: int | None = None,
+    ):
+        # A "pass" in CDC means: zero unsuppressed violations. We still
+        # surface the suppressed count and the crossing total so the
+        # summary table can show why a clean run is clean.
+        desc = "no rule violations"
+        if suppressed:
+            desc = f"no rule violations ({suppressed} suppressed)"
+        super().__init__(
+            name=name,
+            results={"result": "PASS", "name": name, "desc": desc},
+        )
+        self.results["violations"] = violations
+        self.results["suppressed"] = suppressed
+        if crossings is not None:
+            self.results["crossings"] = crossings
+
+
+class CdcFailResults(CdcResults):
+    def __init__(
+        self,
+        name,
+        *,
+        violations: int,
+        suppressed: int = 0,
+        crossings: int | None = None,
+        desc: str | None = None,
+    ):
+        msg = desc or f"{violations} CDC violation(s)"
+        super().__init__(
+            name=name,
+            results={"result": "FAIL", "name": name, "desc": msg},
+        )
+        self.results["violations"] = violations
+        self.results["suppressed"] = suppressed
+        if crossings is not None:
+            self.results["crossings"] = crossings
+
+
+class CdcSkipResults(CdcResults):
+    def __init__(self, name, desc):
+        super().__init__(
+            name=name,
+            results={"result": "SKIP", "name": name, "desc": desc},
+        )

--- a/src/rtl_buddy/runner/cdc_runner.py
+++ b/src/rtl_buddy/runner/cdc_runner.py
@@ -1,0 +1,45 @@
+"""Per-analysis CDC runner — picks the right tool wrapper based on the
+analysis config's ``tool`` field and delegates."""
+
+import logging
+
+from ..config.cdc import CdcConfig
+from ..errors import FatalRtlBuddyError
+from ..logging_utils import log_event
+from ..runner.cdc_results import CdcResults
+from ..tools.cdc_rtl_buddy import RtlBuddyCdc
+
+logger = logging.getLogger(__name__)
+
+
+class CdcRunner:
+    def __init__(self, name: str, root_cfg, cdc_cfg: CdcConfig, suite_dir: str):
+        self.name = name
+        self.root_cfg = root_cfg
+        self.cdc_cfg = cdc_cfg
+        self.suite_dir = suite_dir
+
+    def run(self) -> CdcResults:
+        log_event(
+            logger,
+            logging.DEBUG,
+            "cdc_runner.start",
+            runner=self.name,
+            cdc=self.cdc_cfg.get_name(),
+        )
+        tool_name = self.cdc_cfg.get_tool_name()
+        try:
+            tool_cfg = self.root_cfg.get_cdc_tool_cfg(tool_name)
+        except FatalRtlBuddyError:
+            raise
+
+        # Today only one backend (rtl-buddy-cdc); structured for easy
+        # extension when alternative CDC tools are added.
+        backend = RtlBuddyCdc(
+            name=self.name + "/rtl_buddy_cdc",
+            cdc_cfg=self.cdc_cfg,
+            tool_cfg=tool_cfg,
+            suite_dir=self.suite_dir,
+            root_cfg=self.root_cfg,
+        )
+        return backend.run()

--- a/src/rtl_buddy/tools/cdc_rtl_buddy.py
+++ b/src/rtl_buddy/tools/cdc_rtl_buddy.py
@@ -1,0 +1,238 @@
+"""rtl-buddy-cdc tool wrapper.
+
+Drives the standalone ``rtl-buddy-cdc lint`` CLI: hands it the model's
+filelist of SystemVerilog sources, the SDC, and an optional waiver
+file, then parses the JSON report it emits to populate
+:class:`CdcResults`. Keeping the integration at subprocess granularity
+means rtl_buddy isn't tied to the analyzer's Python API and can pick
+up new releases via ``uv sync`` without code changes here.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+from .vlog_filelist import VlogFilelist
+from ..config.cdc import CdcConfig, CdcToolConfig
+from ..errors import FatalRtlBuddyError
+from ..logging_utils import log_event, task_status
+from ..process_utils import run_managed_process
+from ..runner.cdc_results import CdcFailResults, CdcPassResults, CdcResults
+
+
+_FILELIST_SKIP_PREFIXES = ("+incdir+", "+libext+", "-y ", "-F ", "-f ")
+_FILELIST_SOURCE_PREFIX = "-v "
+
+
+class RtlBuddyCdc:
+    def __init__(
+        self,
+        name: str,
+        cdc_cfg: CdcConfig,
+        tool_cfg: CdcToolConfig,
+        suite_dir: str,
+        root_cfg=None,
+    ):
+        self.name = name
+        self.cdc_cfg = cdc_cfg
+        self.tool_cfg = tool_cfg
+        self.root_cfg = root_cfg
+
+        artefact_root = Path(suite_dir) / "artefacts" / cdc_cfg.get_name()
+        artefact_root.mkdir(parents=True, exist_ok=True)
+        self.artefact_dir = str(artefact_root)
+
+    # --- artefact paths -----------------------------------------------------
+
+    def _filelist_path(self) -> str:
+        return os.path.join(self.artefact_dir, "cdc.f")
+
+    def _report_path(self, fmt: str) -> str:
+        return os.path.join(self.artefact_dir, f"cdc.{fmt}")
+
+    def _log_path(self) -> str:
+        return os.path.join(self.artefact_dir, "cdc.log")
+
+    # --- helpers ------------------------------------------------------------
+
+    def _write_filelist(self) -> str:
+        fl_path = self._filelist_path()
+        vlog_fl = VlogFilelist(
+            name=self.name + "/filelist",
+            model_cfg=self.cdc_cfg.get_model(),
+            output_path=fl_path,
+        )
+        vlog_fl.write_output(
+            output_filepath=fl_path, unroll=True, strip=True, deduplicate=True
+        )
+        return fl_path
+
+    def _source_files_from_filelist(self, fl_path: str) -> list[str]:
+        """Return absolute source file paths from a stripped filelist.
+
+        Mirrors the helper in :mod:`tools.synth_yosys` rather than
+        importing it, because the synth tool's helper is private. If we
+        grow more tool wrappers that need this, factor it out.
+        """
+        fl_dir = os.path.dirname(os.path.abspath(fl_path))
+        paths: list[str] = []
+        with open(fl_path) as f:
+            for raw in f:
+                line = raw.strip()
+                if not line or line.startswith("//"):
+                    continue
+                if any(line.startswith(opt) for opt in _FILELIST_SKIP_PREFIXES):
+                    continue
+                if line.startswith(_FILELIST_SOURCE_PREFIX):
+                    line = line[len(_FILELIST_SOURCE_PREFIX) :]
+                paths.append(os.path.normpath(os.path.join(fl_dir, line)))
+        return paths
+
+    # --- run ----------------------------------------------------------------
+
+    def run(self) -> CdcResults:
+        fl_path = self._write_filelist()
+        sources = self._source_files_from_filelist(fl_path)
+        if not sources:
+            raise FatalRtlBuddyError(
+                f"{self.cdc_cfg.get_name()}: filelist {fl_path} produced no sources"
+            )
+
+        sdc_path = self.cdc_cfg.get_constraints()
+        if not os.path.isfile(sdc_path):
+            raise FatalRtlBuddyError(
+                f"{self.cdc_cfg.get_name()}: SDC not found: {sdc_path}"
+            )
+        waivers_path = self.cdc_cfg.get_waivers()
+        if waivers_path is not None and not os.path.isfile(waivers_path):
+            raise FatalRtlBuddyError(
+                f"{self.cdc_cfg.get_name()}: waivers file not found: {waivers_path}"
+            )
+
+        # Always emit JSON so we can parse violation counts; also keep a
+        # human-readable text report alongside for the user.
+        json_report = self._report_path("json")
+        text_report = self._report_path("txt")
+        log_path = self._log_path()
+
+        executable = self.tool_cfg.get_executable() or "rtl-buddy-cdc"
+        opts = self.tool_cfg.get_opts(self.cdc_cfg.get_tool_overrides())
+
+        cmd_text = [
+            executable,
+            "lint",
+            "--top",
+            self.cdc_cfg.get_top(),
+            "--sdc",
+            sdc_path,
+            "--format",
+            "text",
+            "--output",
+            text_report,
+        ]
+        if waivers_path is not None:
+            cmd_text += ["--waivers", waivers_path]
+        if opts.extra_args:
+            cmd_text += opts.extra_args.split()
+        cmd_text += sources
+
+        cmd_json = [
+            executable,
+            "lint",
+            "--top",
+            self.cdc_cfg.get_top(),
+            "--sdc",
+            sdc_path,
+            "--format",
+            "json",
+            "--output",
+            json_report,
+        ]
+        if waivers_path is not None:
+            cmd_json += ["--waivers", waivers_path]
+        if opts.extra_args:
+            cmd_json += opts.extra_args.split()
+        cmd_json += sources
+
+        with task_status(f"Running CDC {self.cdc_cfg.get_name()}"):
+            log_event(
+                logger,
+                logging.INFO,
+                "cdc.start",
+                analysis=self.cdc_cfg.get_name(),
+                tool=executable,
+                top=self.cdc_cfg.get_top(),
+            )
+            # Run twice: once for human-readable text, once for JSON we
+            # parse below. Both invocations elaborate the design; if
+            # this becomes a hotspot, switch to running once with JSON
+            # and rendering the text from the parsed payload.
+            text_proc = self._run(cmd_text, log_path)
+            json_proc = self._run(cmd_json, log_path, append=True)
+
+        # Either invocation succeeding (exit 0) or returning the rule-
+        # violation exit code (1) is a successful run; anything else
+        # (typically 2 = elaboration failure) is a hard fail.
+        for proc in (text_proc, json_proc):
+            if proc.returncode not in (0, 1):
+                return CdcFailResults(
+                    name=self.cdc_cfg.get_name(),
+                    violations=0,
+                    desc=(
+                        f"rtl-buddy-cdc exited with code {proc.returncode} "
+                        f"(see {log_path})"
+                    ),
+                )
+
+        if not os.path.isfile(json_report):
+            return CdcFailResults(
+                name=self.cdc_cfg.get_name(),
+                violations=0,
+                desc=f"no JSON report produced (see {log_path})",
+            )
+
+        try:
+            payload = json.loads(Path(json_report).read_text())
+        except json.JSONDecodeError as e:
+            return CdcFailResults(
+                name=self.cdc_cfg.get_name(),
+                violations=0,
+                desc=f"could not parse JSON report: {e}",
+            )
+
+        summary = payload.get("summary", {})
+        violations = int(summary.get("violations", 0))
+        suppressed = int(summary.get("suppressed", 0))
+        crossings = summary.get("crossings")
+        crossings = int(crossings) if crossings is not None else None
+
+        if violations == 0:
+            return CdcPassResults(
+                name=self.cdc_cfg.get_name(),
+                violations=0,
+                suppressed=suppressed,
+                crossings=crossings,
+            )
+        return CdcFailResults(
+            name=self.cdc_cfg.get_name(),
+            violations=violations,
+            suppressed=suppressed,
+            crossings=crossings,
+        )
+
+    def _run(self, cmd: list[str], log_path: str, *, append: bool = False):
+        mode = "a" if append else "w"
+        with open(log_path, mode) as logf:
+            logf.write("$ " + " ".join(cmd) + "\n")
+            logf.flush()
+            return run_managed_process(
+                cmd,
+                stdout=logf,
+                stderr=subprocess.STDOUT,
+            )

--- a/src/rtl_buddy/tools/cdc_rtl_buddy.py
+++ b/src/rtl_buddy/tools/cdc_rtl_buddy.py
@@ -138,6 +138,8 @@ class RtlBuddyCdc:
         ]
         if waivers_path is not None:
             cmd_text += ["--waivers", waivers_path]
+        if opts.sync_depth is not None:
+            cmd_text += ["--sync-depth", str(opts.sync_depth)]
         if opts.extra_args:
             cmd_text += opts.extra_args.split()
         cmd_text += sources
@@ -156,6 +158,8 @@ class RtlBuddyCdc:
         ]
         if waivers_path is not None:
             cmd_json += ["--waivers", waivers_path]
+        if opts.sync_depth is not None:
+            cmd_json += ["--sync-depth", str(opts.sync_depth)]
         if opts.extra_args:
             cmd_json += opts.extra_args.split()
         cmd_json += sources

--- a/src/rtl_buddy/tools/cdc_rtl_buddy.py
+++ b/src/rtl_buddy/tools/cdc_rtl_buddy.py
@@ -122,7 +122,9 @@ class RtlBuddyCdc:
         log_path = self._log_path()
 
         executable = self.tool_cfg.get_executable() or "rtl-buddy-cdc"
-        opts = self.tool_cfg.get_opts(self.cdc_cfg.get_tool_overrides())
+        opts = self.tool_cfg.get_opts(
+            self.cdc_cfg.get_tool_overrides_for(self.tool_cfg.get_name())
+        )
 
         cmd_text = [
             executable,

--- a/tests/test_cdc.py
+++ b/tests/test_cdc.py
@@ -1,0 +1,272 @@
+"""Tests for the CDC config surface: tool config, per-analysis config,
+suite/regression YAML loading. Mirrors the structure of ``test_synth.py``.
+"""
+
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+from rtl_buddy.config.cdc import (
+    CdcConfig,
+    CdcRegConfig,
+    CdcSuiteConfig,
+    CdcToolConfig,
+    CdcToolConfigFile,
+    CdcToolOptsFile,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _tool_cfg(
+    name="rtl-buddy-cdc", exe="rtl-buddy-cdc", sync_depth=None, extra_args=""
+):
+    opts = CdcToolOptsFile(sync_depth=sync_depth, extra_args=extra_args)
+    return CdcToolConfig(CdcToolConfigFile(name=name, tool=exe, opts=opts))
+
+
+def _make_cdc_cfg(
+    *,
+    name="test_cdc",
+    model_name="my_module",
+    model_path="/fake/models.yaml",
+    tool="rtl-buddy-cdc",
+    constraints="my_module.sdc",
+    waivers=None,
+    reglvl=None,
+    tool_overrides=None,
+):
+    from rtl_buddy.config.model import ModelConfig
+
+    model = ModelConfig(name=model_name, filelist=[], path=model_path)
+    return CdcConfig(
+        name=name,
+        desc="test cdc",
+        model=model,
+        tool=tool,
+        constraints=constraints,
+        waivers=waivers,
+        _reglvl=reglvl,
+        tool_overrides=tool_overrides,
+    )
+
+
+# ---------------------------------------------------------------------------
+# CdcToolConfig — opts and overrides
+# ---------------------------------------------------------------------------
+
+
+def test_cdc_tool_config_returns_base_opts():
+    cfg = _tool_cfg(sync_depth=3, extra_args="--strict")
+    opts = cfg.get_opts()
+    assert opts.sync_depth == 3
+    assert opts.extra_args == "--strict"
+
+
+def test_cdc_tool_config_overrides_merge_over_base():
+    cfg = _tool_cfg(sync_depth=2, extra_args="")
+    opts = cfg.get_opts({"sync_depth": 4, "extra_args": "--debug"})
+    assert opts.sync_depth == 4
+    assert opts.extra_args == "--debug"
+
+
+def test_cdc_tool_config_partial_override_keeps_unset_base():
+    cfg = _tool_cfg(sync_depth=2, extra_args="--baseline")
+    opts = cfg.get_opts({"sync_depth": 4})
+    assert opts.sync_depth == 4
+    assert opts.extra_args == "--baseline"  # unchanged
+
+
+def test_cdc_tool_config_none_override_returns_base():
+    cfg = _tool_cfg(sync_depth=2)
+    assert cfg.get_opts(None).sync_depth == 2
+    assert cfg.get_opts({}).sync_depth == 2
+
+
+# ---------------------------------------------------------------------------
+# CdcConfig — reglvl semantics (mirrors synth's int/dict/default behavior)
+# ---------------------------------------------------------------------------
+
+
+def test_cdc_config_top_is_model_name():
+    cfg = _make_cdc_cfg(model_name="my_top")
+    assert cfg.get_top() == "my_top"
+
+
+def test_cdc_config_reglvl_int():
+    cfg = _make_cdc_cfg(reglvl=500)
+    assert cfg.get_reglvl("rtl-buddy-cdc") == 500
+
+
+def test_cdc_config_reglvl_none_defaults_to_zero():
+    cfg = _make_cdc_cfg(reglvl=None)
+    assert cfg.get_reglvl("rtl-buddy-cdc") == 0
+
+
+def test_cdc_config_reglvl_dict_tool_specific():
+    cfg = _make_cdc_cfg(
+        reglvl={"rtl-buddy-cdc": 100, "spyglass-cdc": 200, "default": 50}
+    )
+    assert cfg.get_reglvl("rtl-buddy-cdc") == 100
+    assert cfg.get_reglvl("spyglass-cdc") == 200
+    assert cfg.get_reglvl("questa-cdc") == 50  # falls back to default
+
+
+def test_cdc_config_reglvl_dict_default_only():
+    """A dict with only `default` must be honored for any tool."""
+    cfg = _make_cdc_cfg(reglvl={"default": 100})
+    assert cfg.get_reglvl("rtl-buddy-cdc") == 100
+    assert cfg.get_reglvl("anything") == 100
+
+
+def test_cdc_config_reglvl_malformed_dict_raises():
+    """A dict with neither the active tool nor `default` is malformed."""
+    from rtl_buddy.errors import FatalRtlBuddyError
+
+    cfg = _make_cdc_cfg(reglvl={"some-other-tool": 100})
+    with pytest.raises(FatalRtlBuddyError, match="reglvl"):
+        cfg.get_reglvl("rtl-buddy-cdc")
+
+
+# ---------------------------------------------------------------------------
+# CdcConfig — tool_overrides (nested by tool name)
+# ---------------------------------------------------------------------------
+
+
+def test_cdc_config_tool_overrides_for_matching_tool():
+    cfg = _make_cdc_cfg(tool_overrides={"rtl-buddy-cdc": {"extra_args": "--strict"}})
+    assert cfg.get_tool_overrides_for("rtl-buddy-cdc") == {"extra_args": "--strict"}
+
+
+def test_cdc_config_tool_overrides_for_non_matching_tool():
+    cfg = _make_cdc_cfg(tool_overrides={"rtl-buddy-cdc": {"extra_args": "--strict"}})
+    assert cfg.get_tool_overrides_for("spyglass-cdc") is None
+
+
+def test_cdc_config_tool_overrides_none():
+    cfg = _make_cdc_cfg(tool_overrides=None)
+    assert cfg.get_tool_overrides_for("rtl-buddy-cdc") is None
+
+
+def test_cdc_config_tool_overrides_merge_through_tool_cfg():
+    """End-to-end: a per-analysis tool_overrides entry overrides the root
+    config baseline when passed through CdcToolConfig.get_opts()."""
+    cdc_cfg = _make_cdc_cfg(
+        tool_overrides={"rtl-buddy-cdc": {"sync_depth": 4, "extra_args": "--strict"}}
+    )
+    tool_cfg = _tool_cfg(sync_depth=2, extra_args="")
+    opts = tool_cfg.get_opts(cdc_cfg.get_tool_overrides_for(tool_cfg.get_name()))
+    assert opts.sync_depth == 4
+    assert opts.extra_args == "--strict"
+
+
+# ---------------------------------------------------------------------------
+# CdcSuiteConfig — YAML loading + path resolution
+# ---------------------------------------------------------------------------
+
+_SUITE_YAML = dedent("""\
+    rtl-buddy-filetype: cdc_config
+
+    analyses:
+      - name: "cdc_a"
+        desc: "First analysis"
+        model: "mod_a"
+        model_path: "{models_path}"
+        tool: "rtl-buddy-cdc"
+        constraints: "mod_a.sdc"
+        reglvl: 0
+      - name: "cdc_b"
+        desc: "Second analysis"
+        model: "mod_b"
+        model_path: "{models_path}"
+        tool: "rtl-buddy-cdc"
+        constraints: "mod_b.sdc"
+        waivers: "mod_b.waivers"
+        reglvl: 1000
+""")
+
+_MODELS_YAML = dedent("""\
+    rtl-buddy-filetype: model_config
+
+    models:
+      - name: "mod_a"
+        filelist: ["top_a.sv"]
+      - name: "mod_b"
+        filelist: ["top_b.sv"]
+""")
+
+
+def _write_suite(tmp_path):
+    (tmp_path / "models.yaml").write_text(_MODELS_YAML)
+    suite_yaml = tmp_path / "cdc.yaml"
+    suite_yaml.write_text(_SUITE_YAML.format(models_path="models.yaml"))
+    return suite_yaml
+
+
+def test_cdc_suite_config_loads_all_analyses(tmp_path):
+    suite_yaml = _write_suite(tmp_path)
+    cfg = CdcSuiteConfig(str(suite_yaml))
+    assert cfg.get_analysis_names() == ["cdc_a", "cdc_b"]
+
+
+def test_cdc_suite_config_get_by_name(tmp_path):
+    suite_yaml = _write_suite(tmp_path)
+    cfg = CdcSuiteConfig(str(suite_yaml))
+    results = cfg.get_analyses("cdc_a")
+    assert len(results) == 1
+    assert results[0].get_name() == "cdc_a"
+    assert results[0].get_top() == "mod_a"
+
+
+def test_cdc_suite_config_paths_resolved_relative_to_yaml(tmp_path):
+    """constraints and waivers paths must be resolved relative to the
+    cdc.yaml file (matches the synth/test convention)."""
+    suite_yaml = _write_suite(tmp_path)
+    cfg = CdcSuiteConfig(str(suite_yaml))
+    cdc_a = cfg.get_analyses("cdc_a")[0]
+    cdc_b = cfg.get_analyses("cdc_b")[0]
+    assert Path(cdc_a.get_constraints()) == tmp_path / "mod_a.sdc"
+    assert Path(cdc_b.get_constraints()) == tmp_path / "mod_b.sdc"
+    assert Path(cdc_b.get_waivers()) == tmp_path / "mod_b.waivers"
+    assert cdc_a.get_waivers() is None
+
+
+def test_cdc_suite_config_missing_name_raises(tmp_path):
+    from rtl_buddy.errors import FatalRtlBuddyError
+
+    suite_yaml = _write_suite(tmp_path)
+    cfg = CdcSuiteConfig(str(suite_yaml))
+    with pytest.raises(FatalRtlBuddyError, match="not found"):
+        cfg.get_analyses("nonexistent")
+
+
+# ---------------------------------------------------------------------------
+# CdcRegConfig — YAML loading + per-suite path resolution
+# ---------------------------------------------------------------------------
+
+_REG_YAML = dedent("""\
+    rtl-buddy-filetype: cdc_reg_config
+
+    cdc-configs:
+      - "sandbox/cdc.yaml"
+""")
+
+
+def test_cdc_reg_config_loads_suite_paths(tmp_path):
+    sandbox = tmp_path / "sandbox"
+    sandbox.mkdir()
+    (sandbox / "models.yaml").write_text(_MODELS_YAML)
+    suite_yaml = sandbox / "cdc.yaml"
+    suite_yaml.write_text(_SUITE_YAML.format(models_path="models.yaml"))
+
+    reg_yaml = tmp_path / "cdc_regression.yaml"
+    reg_yaml.write_text(_REG_YAML)
+
+    reg_cfg = CdcRegConfig(name="reg", path=str(reg_yaml))
+    suites = reg_cfg.get_suite_configs()
+    assert len(suites) == 1
+    assert suites[0].get_analysis_names() == ["cdc_a", "cdc_b"]


### PR DESCRIPTION
## Summary

- Adds `rb cdc <name>` and `rb cdc-regression` subcommands, mirroring the existing synthesis flow.
- New `cfg-cdc-tools` block in `root_config.yaml` declares available CDC tools.
- Bundled tool wrapper drives the [rtl-buddy-cdc](https://github.com/rtl-buddy/rtl-buddy-cdc) CLI as a subprocess; pluggable for additional CDC backends.
- 211/211 existing pytest cases still pass.

Closes #74.

## Why

CDC bugs are devastating in silicon and impossible to catch reliably with simulation alone. Commercial tools (Spyglass, Questa CDC) are excellent but expensive and closed; the open-source EDA stack has nothing comparable. `rtl-buddy-cdc` fills that gap with a pragmatic ruleset (CDC-001 through CDC-008), waiver-file suppression, SARIF output for GitHub Code Scanning, and a `(* cdc_sync *)` SV-attribute for user-vetted synchronizers. Wiring it into rtl_buddy gives users the same per-block / regression workflow they already have for tests and synthesis.

## Surface

```bash
rb cdc <name>            [-c cdc.yaml] [--list]
rb cdc-regression        [-c cdc_regression.yaml] [-l reg_level]
```

Per-analysis YAML schema:

```yaml
rtl-buddy-filetype: cdc_config
analyses:
  - name: "ip_cdc_handshake_lint"
    desc: "CDC lint of the request/ack handshake IP"
    model: "ip_cdc_handshake"
    model_path: "../../design/common/models.yaml"
    tool: "rtl-buddy-cdc"
    constraints: "ip_cdc_handshake.sdc"
    waivers: "ip_cdc_handshake.waivers"   # optional
    reglvl: 0
```

Root config addition:

```yaml
cfg-cdc-tools:
  - name: "rtl-buddy-cdc"
    tool: "rtl-buddy-cdc"
    opts:
      sync-depth: 2          # forwarded as `--sync-depth N` (CDC-002 required depth)
      extra-args: ""         # appended verbatim to every invocation
```

## Implementation

- **`src/rtl_buddy/config/cdc.py`** — `CdcToolConfig` / `CdcConfig` / `CdcSuiteConfig` / `CdcRegConfig`, parallel to `synth.py`. Tool opts include `sync-depth` (forwarded to the analyzer's `--sync-depth` flag) and `extra-args`.
- **`src/rtl_buddy/config/root.py`** — register `cfg-cdc-tools` and add `RootConfig.get_cdc_tool_cfg()`.
- **`src/rtl_buddy/runner/cdc_results.py`** — `CdcResults` / `CdcPassResults` / `CdcFailResults` / `CdcSkipResults` (mirrors `synth_results.py`).
- **`src/rtl_buddy/runner/cdc_runner.py`** — orchestrator; today only the `rtl-buddy-cdc` backend, structured for additional ones.
- **`src/rtl_buddy/tools/cdc_rtl_buddy.py`** — tool wrapper. Drives the standalone `rtl-buddy-cdc lint` CLI: hands it the model's filelist, the SDC, an optional waiver file, and the per-tool opts (`--sync-depth`, `extra-args`). Captures both text and JSON reports, parses the JSON summary to populate `CdcResults`. Subprocess-based so rtl_buddy isn't tied to the analyzer's Python API and picks up analyzer releases via `uv sync` with no code changes here.
- **`src/rtl_buddy/rtl_buddy.py`** — register `cdc` and `cdc-regression` typer commands; add `_render_cdc_summary` / `_exit_code_from_cdc_results` / `_do_cdc_suite` helpers in the `_render_synth_*` style.

## Discoverability of `rtl-buddy-cdc`

The wrapper looks up `rtl-buddy-cdc` by PATH name (or by absolute path if `tool:` in the config is a path). Three install patterns work:

1. **Pinned via `[tool.uv.sources]` in the consumer project** (recommended for pre-release): the project template's [`feature/cdc-integration`](https://github.com/rtl-buddy/rtl-buddy-project-template/tree/feature/cdc-integration) branch demonstrates this — `uv sync` installs the analyzer into `.venv/bin/rtl-buddy-cdc`, and `uv run rb cdc` finds it transparently.
2. **`uv tool install rtl-buddy-cdc`** (user-level).
3. **PyPI dependency** (after the analyzer cuts a 0.1 release).

## Verification

End-to-end against `rtl-buddy-project-template`'s `ip_cdc_handshake` and `alu_accel_top` (the canonical golden cases for the analyzer). Sample output:

```
$ uv run rb cdc

   CDC Analysis           Result  Description         Violations  Suppressed  Crossings
   ip_cdc_handshake_lint  PASS    no rule violations  0           0           3
   alu_accel_lint         PASS    no rule violations  0           2           11
```

Companion changes for the project template (`cfg-cdc-tools` entry, `lint/cdc/` configs, the `rtl-buddy-cdc` git pin in `pyproject.toml`/`uv.lock`) live in [`rtl-buddy-project-template#feature/cdc-integration`](https://github.com/rtl-buddy/rtl-buddy-project-template/tree/feature/cdc-integration) and will land alongside this PR.

## Out of scope

- SARIF upload step in CI workflows (`.github/workflows/cdc.yml`).
- Multi-domain SDC import sharing with `rb synth` (today the two flows each parse SDC independently).
- In-RTL pragma-comment waivers (Spyglass-style `// rtl-buddy-cdc disable-rule` blocks). The waiver-file mechanism already exists analyzer-side.

## Test plan

- [x] 211/211 existing pytest cases pass (`uv run pytest -q`).
- [x] `rb cdc` returns clean PASS for `ip_cdc_handshake` (3 detected crossings, 0 violations).
- [x] `rb cdc` returns PASS for `alu_accel_top` (11 crossings, 2 CDC-003 findings waived).
- [x] `rb cdc-regression` runs the same analyses through the regression code path.
- [x] `rb cdc <name> --list` lists configured analyses.
- [x] `sync-depth:` in `cfg-cdc-tools.opts` is forwarded as `--sync-depth N` to the analyzer.
- [ ] Add unit coverage for `CdcSuiteConfig`/`CdcRegConfig` parsing alongside the existing `config/synth.py` tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)