### PR TITLE
Fix OpenROAD setup filename in synthesis docs

### DIFF
--- a/docs/concepts/synthesis.md
+++ b/docs/concepts/synthesis.md
@@ -43,7 +43,7 @@ The `yosys` binary must be on `PATH` when `rb synth` is invoked.
 
 ## Installing OpenROAD
 
-OpenROAD is required only for the `openroad` backend. It must be built from source on macOS — no official binaries are published. See the build notes in your project's `tools/openroad/BUILD_OSX.md` for the full procedure. After building, symlink the binary to a directory on `PATH`:
+OpenROAD is required only for the `openroad` backend. It must be built from source on macOS — no official binaries are published. See the build notes in your project's `tools/openroad/SETUP_OSX.md` (the starter template uses that filename) for the full procedure. After building, symlink the binary to a directory on `PATH`:
 
 ```bash
 ln -s /path/to/OpenROAD/build/bin/openroad /usr/local/bin/openroad


### PR DESCRIPTION
## Summary

- update the synthesis guide to point at `tools/openroad/SETUP_OSX.md`
- clarify that the starter template uses that filename for its macOS build notes

## Why

The docs currently point readers at `tools/openroad/BUILD_OSX.md`, but the template and related setup material use `SETUP_OSX.md`. This small mismatch sends readers to a file that does not exist in the template.