### PR TITLE
ci: serialize gh-pages docs publishing

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -84,6 +84,9 @@ jobs:
     if: github.event_name == 'push'
     needs: build
     runs-on: ubuntu-latest
+    concurrency:
+      group: gh-pages
+      cancel-in-progress: false
     permissions:
       contents: write
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -210,6 +210,9 @@ jobs:
     needs: release
     if: needs.release.outputs.new_tag != '' && needs.release.outputs.is_prerelease != 'true'
     runs-on: ubuntu-latest
+    concurrency:
+      group: gh-pages
+      cancel-in-progress: false
     permissions:
       contents: write
 


### PR DESCRIPTION
## Summary
- add a shared gh-pages concurrency group to the Docs deploy job
- add the same group to the Release publish_docs job so docs branch writes queue instead of racing

## Validation
- uv run python -c "import yaml, pathlib; [yaml.safe_load(p.read_text()) for p in pathlib.Path('.github/workflows').glob('*.yml')]; print('workflow yaml ok')"
- git diff --check