### PR TITLE
feat(pnr): rb pnr subcommand + cfg-pdk schema refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,14 +63,10 @@ Prerequisites:
 
 - Python 3.11+
 - `uv`
-- A simulator on `PATH`
-  - Verilator is the recommended open-source starting point
-  - VCS is also supported as a first-class flow
-- Optional: the [rtl-buddy fork of Yosys](https://github.com/rtl-buddy/yosys) if you want to use `uv run rb synth ...`
-- Optional: Verible if you want to use `uv run rb verible ...` — e.g. `brew tap chipsalliance/verible && brew install verible` on macOS, or see [Verible releases](https://github.com/chipsalliance/verible/releases) for other platforms
-- Optional system-level coverage tools:
-  - `lcov` for LCOV and HTML coverage export
-  - [Coverview](https://github.com/antmicro/coverview) for Coverview package generation
+
+Beyond Python and `uv`, every other dependency is feature-dependent: which external tools you need depends on which `rb` commands you use. For example, `rb test` needs a simulator (Verilator / VCS), `rb synth` needs the [rtl-buddy/yosys fork](https://github.com/rtl-buddy/yosys), `rb wave` needs the [rtl-buddy/surfer fork](https://github.com/rtl-buddy/surfer).
+
+See the [installation page](https://rtl-buddy.github.io/rtl_buddy/latest/install/) for the full feature-to-dependency matrix, including integration types (Integrated tool vs Pluggable vs Pluggable — curated) and install commands.
 
 ## Documentation
 

--- a/docs/concepts/pnr.md
+++ b/docs/concepts/pnr.md
@@ -1,0 +1,152 @@
+---
+description: How to run OpenROAD place-and-route with rtl_buddy via the rb pnr command, pnr.yaml, and cfg-pnr-platforms.
+---
+
+# Place-and-Route
+
+`rb pnr` drives OpenROAD through a templated Tcl flow that consumes the tech-mapped netlist from an upstream `rb synth` run. It produces routed DEF, a post-route netlist + SDC, a timing report, and a DRC report under `pnr/<run>/artefacts/`.
+
+The flow is intentionally compact and config-driven — block-level knobs live in `pnr.yaml`, technology-level knobs live in `cfg-pdk` + `cfg-pnr-platforms` in `root_config.yaml`.
+
+## Supported backend
+
+Today only `openroad` is wired up. The `tool:` field in `pnr.yaml` selects it; the runner skips any other value with a clear message.
+
+## Installing OpenROAD
+
+`openroad` must be on `PATH`. Build from source (no official macOS binaries):
+
+```bash
+ln -s /path/to/OpenROAD/build/bin/openroad /usr/local/bin/openroad
+```
+
+See `tools/openroad/BUILD_OSX.md` in the project template for the macOS recipe.
+
+## P&R config: `pnr.yaml`
+
+`pnr.yaml` declares one or more P&R runs. Each entry references an upstream `rb synth` entry by path + name, an SDC, and a `cfg-pnr-platforms` name from `root_config.yaml`:
+
+```yaml
+rtl-buddy-filetype: pnr_config
+
+runs:
+  - name: "demo_pnr_nangate45"
+    desc: "OpenROAD P&R on Nangate45 typ corner"
+    tool: "openroad"
+    synth: "demo_synth_nangate45"
+    synth-path: "../../synth/demo/synth.yaml"
+    constraints: "../../synth/demo/constraints.sdc"
+    platform: "nangate45_typ"
+    floorplan:
+      utilization: 0.55
+      aspect: 1.0
+      core-margin: 2.0
+    reglvl: 1000
+```
+
+### Fields
+
+| Field | Description |
+|-------|-------------|
+| `name` | Run identifier used on the command line and in `artefacts/<name>/` |
+| `desc` | Human-readable description |
+| `tool` | Backend tool name — only `"openroad"` is supported today |
+| `synth` | Name of the upstream `rb synth` entry to consume |
+| `synth-path` | Path to the `synth.yaml` containing `synth`, resolved relative to `pnr.yaml` |
+| `constraints` | SDC path (required), resolved relative to `pnr.yaml` |
+| `platform` | `cfg-pnr-platforms` entry name |
+| `floorplan.utilization` | Core utilization (0–1); 55% is a reasonable default |
+| `floorplan.aspect` | Die aspect ratio; 1.0 = square |
+| `floorplan.core-margin` | Margin in microns between core area and die edge |
+| `reglvl` | Regression level for filtering (same semantics as `rb synth`) |
+
+### Where inputs come from
+
+The runner reads the upstream `synth.yaml` to find the tech-mapped netlist at `<synth_dir>/artefacts/<synth_name>/synth_netlist.v`. The top module is taken from the synth entry's `model:` field. The SDC and the PDK Liberty/LEF come from `constraints:` and the selected `cfg-pnr-platforms` entry respectively — no path duplication.
+
+## Root config: `cfg-pdk` and `cfg-pnr-platforms`
+
+PDK assets live in `cfg-pdk` (per-process, corners as sub-fields — see the [synthesis page](synthesis.md#pdk-and-synth-platform-configuration)). `cfg-pnr-platforms` is the P&R-side selector:
+
+```yaml
+cfg-pnr-platforms:
+  - name: "nangate45_typ"
+    pdk: "nangate45"
+    sta-corner: "typ"
+    cts-buffer: "BUF_X4"
+    routing-layers:
+      signal: "metal2-metal8"
+      clock:  "metal4-metal8"
+```
+
+| Field | Description |
+|-------|-------------|
+| `name` | Referenced by `platform:` in `pnr.yaml` |
+| `pdk` | `cfg-pdk` entry name |
+| `sta-corner` | Corner from the PDK used for STA; defaults to the first declared corner |
+| `cts-buffer` | Standard cell name passed to `clock_tree_synthesis -root_buf` / `-buf_list` |
+| `routing-layers.signal` | Layer range for signal routing (e.g. `metal2-metal8`) |
+| `routing-layers.clock` | Layer range for clock routing (typically higher metals) |
+
+## Running P&R
+
+```bash
+# All runs in the default ./pnr.yaml
+rb pnr
+
+# A single run from a specific config
+rb pnr demo_pnr_nangate45 -c pnr/demo/pnr.yaml
+
+# Reglvl-gated runs (1000 by default for tech-mapped flows)
+rb pnr demo_pnr_nangate45 -c pnr/demo/pnr.yaml -l 1000
+
+# List runs without executing
+rb pnr -c pnr/demo/pnr.yaml --list
+```
+
+## Results table
+
+A summary table prints after each run:
+
+```
+                              P&R Results Summary
+┏━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━┳━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━┓
+┃ P&R Run  ┃ Result ┃ Desc     ┃ Cells ┃ Area    ┃ WNS Setup┃ WNS Hold ┃ DRCs ┃
+┡━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━╇━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━┩
+│ demo_…   │ PASS   │ P&R …    │ 1392  │ 3213 µm²│ +4.350 ns│ +0.080 ns│ 0    │
+└──────────┴────────┴──────────┴───────┴─────────┴──────────┴──────────┴──────┘
+```
+
+- **Cells** — `Number of instances` from OpenROAD's floorplan log.
+- **Area** — `Design area … um^2` from `report_design_area`.
+- **WNS Setup / WNS Hold** — `report_worst_slack -max` / `-min`.
+- **DRCs** — non-empty line count of `route.drc.rpt`. Zero == clean route.
+
+## Artefacts
+
+Per-run outputs land under `pnr/<run>/artefacts/`:
+
+| File | Contents |
+|---|---|
+| `pnr.log` | Full OpenROAD log |
+| `pnr.tcl` | Templated Tcl handed to OpenROAD |
+| `<design>.def` | Routed DEF |
+| `<design>.routed.v` | Post-route gate-level netlist |
+| `<design>.routed.sdc` | Post-route SDC |
+| `timing.rpt` | Worst-path timing report (full clock expanded) |
+| `route.drc.rpt` | DRC violations (empty file = clean) |
+| `route.maze.log` | Detail-route maze log |
+
+## Pass/fail detection
+
+A run is PASS when:
+1. `openroad` exits with code 0.
+2. The log has no `[ERROR ...]` lines.
+
+Otherwise FAIL is returned with the exit code or error count in the description. SKIP is returned when the run's `reglvl` is above the `-l` filter or when `tool:` is not `openroad`.
+
+## Out of scope (today)
+
+- GDS streamout (KLayout invocation) and PNG rendering — planned for a `--gds` / `--png` follow-up.
+- Multi-corner signoff.
+- Tape-out-grade PPA tuning. The defaults are calibrated for teaching demos and quick PPA sanity checks.

--- a/docs/concepts/pnr.md
+++ b/docs/concepts/pnr.md
@@ -22,6 +22,29 @@ ln -s /path/to/OpenROAD/build/bin/openroad /usr/local/bin/openroad
 
 See `tools/openroad/BUILD_OSX.md` in the project template for the macOS recipe.
 
+### Version expectations
+
+`rb pnr` probes `openroad -version` and compares it against an internal
+`MIN_OPENROAD_VERSION` (currently `25Q1`). Older builds may still work for
+the basic flow but are unvalidated — a `pnr.openroad_version_below_min`
+warning is emitted and the run continues. The version is also logged at
+INFO as `pnr.openroad_version` so it shows up in `rtl_buddy.log`.
+
+## Installing KLayout (optional)
+
+KLayout is only required when streaming out GDS with `--gds` or rendering
+PNGs with `--png`. The basic P&R flow works without it.
+
+```bash
+brew install --cask klayout            # macOS
+# or download from https://klayout.de
+```
+
+`rb pnr` resolves `klayout` from `PATH` first, then falls back to
+`/Applications/KLayout/klayout.app/Contents/MacOS/klayout` on macOS. If
+KLayout is not present, `--gds`/`--png` logs `pnr.no_klayout` and skips
+streamout/render without failing the run.
+
 ## P&R config: `pnr.yaml`
 
 `pnr.yaml` declares one or more P&R runs. Each entry references an upstream `rb synth` entry by path + name, an SDC, and a `cfg-pnr-platforms` name from `root_config.yaml`:
@@ -102,7 +125,24 @@ rb pnr demo_pnr_nangate45 -c pnr/demo/pnr.yaml -l 1000
 
 # List runs without executing
 rb pnr -c pnr/demo/pnr.yaml --list
+
+# Stream out a routed GDS via KLayout after the run
+rb pnr demo_pnr_nangate45 -c pnr/demo/pnr.yaml --gds
+
+# Render a PNG of the GDS (implies --gds)
+rb pnr demo_pnr_nangate45 -c pnr/demo/pnr.yaml --png
 ```
+
+### `--gds` and `--png`
+
+When `--gds` is requested, `rb pnr` invokes KLayout headlessly after a
+successful OpenROAD run, merging the routed DEF with the PDK's standard
+cell GDS to produce `artefacts/<run>/<design>.gds`. `--png` additionally
+renders a 2048×2048 PNG via the bundled `gds2png.py` helper. Both helpers
+ship inside the wheel under `rtl_buddy/pnr/klayout/` and are copied into
+the artefact dir at run time. KLayout failures emit `pnr.gds_failed` /
+`pnr.png_failed` warnings but do not fail the P&R run — timing/DRC
+metrics remain authoritative.
 
 ## Results table
 
@@ -136,6 +176,10 @@ Per-run outputs land under `pnr/<run>/artefacts/`:
 | `timing.rpt` | Worst-path timing report (full clock expanded) |
 | `route.drc.rpt` | DRC violations (empty file = clean) |
 | `route.maze.log` | Detail-route maze log |
+| `<design>.gds` | Routed GDS — only when `--gds`/`--png` is set |
+| `<design>.png` | Layout render — only when `--png` is set |
+| `klayout.def2stream.log` | KLayout output for the DEF→GDS step (when used) |
+| `klayout.gds2png.log` | KLayout output for the GDS→PNG render (when used) |
 
 ## Pass/fail detection
 
@@ -147,6 +191,5 @@ Otherwise FAIL is returned with the exit code or error count in the description.
 
 ## Out of scope (today)
 
-- GDS streamout (KLayout invocation) and PNG rendering — planned for a `--gds` / `--png` follow-up.
 - Multi-corner signoff.
 - Tape-out-grade PPA tuning. The defaults are calibrated for teaching demos and quick PPA sanity checks.

--- a/docs/concepts/pnr.md
+++ b/docs/concepts/pnr.md
@@ -14,7 +14,10 @@ Today only `openroad` is wired up. The `tool:` field in `pnr.yaml` selects it; t
 
 ## Installing OpenROAD
 
-`openroad` must be on `PATH`. Build from source (no official macOS binaries):
+`openroad` must be on `PATH`, or its absolute path must be configured
+via a `cfg-pnr-tools` entry in `root_config.yaml` (see
+[yaml.md](../reference/yaml.md#root_configyaml)). Build from source (no
+official macOS binaries):
 
 ```bash
 ln -s /path/to/OpenROAD/build/bin/openroad /usr/local/bin/openroad

--- a/docs/concepts/pnr.md
+++ b/docs/concepts/pnr.md
@@ -4,6 +4,14 @@ description: How to run OpenROAD place-and-route with rtl_buddy via the rb pnr c
 
 # Place-and-Route
 
+> **Integration type:** Integrated tool. `rb pnr` is built around OpenROAD today.
+>
+> **External binary required:** `openroad` ≥ `25Q1` — see [Installing OpenROAD](#installing-openroad).
+>
+> **Optional:** `klayout` for `--gds` / `--png` streamout and rendering — see [Installing KLayout](#installing-klayout-optional).
+>
+> See also: [Installation — External tools by feature](../install.md#external-tools-by-feature).
+
 `rb pnr` drives OpenROAD through a templated Tcl flow that consumes the tech-mapped netlist from an upstream `rb synth` run. It produces routed DEF, a post-route netlist + SDC, a timing report, and a DRC report under `pnr/<run>/artefacts/`.
 
 The flow is intentionally compact and config-driven — block-level knobs live in `pnr.yaml`, technology-level knobs live in `cfg-pdks` + `cfg-pnr-platforms` in `root_config.yaml`.

--- a/docs/concepts/pnr.md
+++ b/docs/concepts/pnr.md
@@ -6,7 +6,7 @@ description: How to run OpenROAD place-and-route with rtl_buddy via the rb pnr c
 
 `rb pnr` drives OpenROAD through a templated Tcl flow that consumes the tech-mapped netlist from an upstream `rb synth` run. It produces routed DEF, a post-route netlist + SDC, a timing report, and a DRC report under `pnr/<run>/artefacts/`.
 
-The flow is intentionally compact and config-driven — block-level knobs live in `pnr.yaml`, technology-level knobs live in `cfg-pdk` + `cfg-pnr-platforms` in `root_config.yaml`.
+The flow is intentionally compact and config-driven — block-level knobs live in `pnr.yaml`, technology-level knobs live in `cfg-pdks` + `cfg-pnr-platforms` in `root_config.yaml`.
 
 ## Supported backend
 
@@ -40,10 +40,9 @@ brew install --cask klayout            # macOS
 # or download from https://klayout.de
 ```
 
-`rb pnr` resolves `klayout` from `PATH` first, then falls back to
-`/Applications/KLayout/klayout.app/Contents/MacOS/klayout` on macOS. If
-KLayout is not present, `--gds`/`--png` logs `pnr.no_klayout` and skips
-streamout/render without failing the run.
+`rb pnr` resolves `klayout` from `PATH`. If KLayout is not present,
+`--gds`/`--png` logs `pnr.no_klayout` and skips streamout/render
+without failing the run.
 
 ## P&R config: `pnr.yaml`
 
@@ -87,15 +86,15 @@ runs:
 
 The runner reads the upstream `synth.yaml` to find the tech-mapped netlist at `<synth_dir>/artefacts/<synth_name>/synth_netlist.v`. The top module is taken from the synth entry's `model:` field. The SDC and the PDK Liberty/LEF come from `constraints:` and the selected `cfg-pnr-platforms` entry respectively — no path duplication.
 
-## Root config: `cfg-pdk` and `cfg-pnr-platforms`
+## Root config: `cfg-pdks` and `cfg-pnr-platforms`
 
-PDK assets live in `cfg-pdk` (per-process, corners as sub-fields — see the [synthesis page](synthesis.md#pdk-and-synth-platform-configuration)). `cfg-pnr-platforms` is the P&R-side selector:
+PDK assets live in `cfg-pdks` (per-process, corners as sub-fields — see the [synthesis page](synthesis.md#pdk-and-synth-platform-configuration)). `cfg-pnr-platforms` is the P&R-side selector:
 
 ```yaml
 cfg-pnr-platforms:
   - name: "nangate45_typ"
     pdk: "nangate45"
-    sta-corner: "typ"
+    corner: "typ"
     cts-buffer: "BUF_X4"
     routing-layers:
       signal: "metal2-metal8"
@@ -105,8 +104,8 @@ cfg-pnr-platforms:
 | Field | Description |
 |-------|-------------|
 | `name` | Referenced by `platform:` in `pnr.yaml` |
-| `pdk` | `cfg-pdk` entry name |
-| `sta-corner` | Corner from the PDK used for STA; defaults to the first declared corner |
+| `pdk` | `cfg-pdks` entry name |
+| `corner` | Corner from the PDK used for STA; defaults to the first declared corner |
 | `cts-buffer` | Standard cell name passed to `clock_tree_synthesis -root_buf` / `-buf_list` |
 | `routing-layers.signal` | Layer range for signal routing (e.g. `metal2-metal8`) |
 | `routing-layers.clock` | Layer range for clock routing (typically higher metals) |

--- a/docs/concepts/synthesis.md
+++ b/docs/concepts/synthesis.md
@@ -1,5 +1,5 @@
 ---
-description: How to run synthesis flows with rtl_buddy using synth.yaml, cfg-synth-tools, cfg-synth-libs, and the rb synth command.
+description: How to run synthesis flows with rtl_buddy using synth.yaml, cfg-synth-tools, cfg-pdk + cfg-synth-platforms, and the rb synth command.
 ---
 
 # Synthesis
@@ -74,8 +74,7 @@ syntheses:
     model: "test_module"
     model_path: "../../design/sandbox/models.yaml"
     tool: "yosys"
-    libraries:
-      - "sky130hd_tt"
+    platform: "sky130hd_tt"
     constraints: "constraints.sdc"
     params:
       WIDTH: 8
@@ -92,8 +91,7 @@ syntheses:
     model: "test_module"
     model_path: "../../design/sandbox/models.yaml"
     tool: "openroad"
-    libraries:
-      - "sky130hd_tt"
+    platform: "sky130hd_tt"
     constraints: "constraints.sdc"
     reglvl: 0
 ```
@@ -107,7 +105,7 @@ syntheses:
 | `model` | Model name from `models.yaml`; also used as the synthesis top module |
 | `model_path` | Path to `models.yaml`, resolved relative to the `synth.yaml` directory |
 | `tool` | Synthesis tool name — must match a `cfg-synth-tools` entry in `root_config.yaml` |
-| `libraries` | Optional list of library names from `cfg-synth-libs`; enables technology mapping |
+| `platform` | Optional synth platform name from `cfg-synth-platforms` (which in turn references a `cfg-pdk` entry); enables technology mapping |
 | `constraints` | Optional SDC constraints file, resolved relative to `synth.yaml` |
 | `params` | Optional key-value pairs passed as top-level parameter overrides (`chparam` in Yosys) |
 | `defines` | Optional compile-time Verilog defines passed via `-D KEY=VALUE` |
@@ -162,8 +160,7 @@ syntheses:
     model: "test_module"
     model_path: "../../design/sandbox/models.yaml"
     tool: "openroad"
-    libraries:
-      - "sky130hd_tt"
+    platform: "sky130hd_tt"
     constraints: "constraints.sdc"
     effort: "quick"      # references a cfg-synth-efforts entry
     reglvl: 0
@@ -264,22 +261,29 @@ Running the same DMA design at all three levels (ip_dma, sky130hd_tt, 5-clock SD
 
 The pessimization between `standard` and `accurate` (−1.347 vs −1.172 ns WNS) shows the wire-load model adding parasitic RC; the gate count is unchanged because the Yosys stage runs identically.
 
-### PDK library configuration
+### PDK and synth platform configuration
 
-Liberty files for technology mapping are registered under `cfg-synth-libs`. Paths are resolved relative to `root_config.yaml`:
+PDK assets live under `cfg-pdk` — one entry per process, with corners as sub-fields. Each entry owns *everything* PDK-bound (Liberty per corner, tech-LEF, macro-LEF, cell-GDS, KLayout `.lyt`/`.lyp`, SITE, tie/fill cells); synth and P&R consume what they need.
+
+`cfg-synth-platforms` is a thin selector layer: each entry references a PDK + corner. `synth.yaml` then picks a platform name via `platform:`. All paths are resolved relative to `root_config.yaml`.
 
 ```yaml
-cfg-synth-libs:
+cfg-pdk:
+  - name: "sky130hd"
+    site: "unithd"
+    corners:
+      tt: "pdk/sky130hd/lib/sky130_fd_sc_hd__tt_025C_1v80.lib"
+    tech-lef:  "pdk/sky130hd/lef/sky130_fd_sc_hd.tlef"
+    macro-lef: "pdk/sky130hd/lef/sky130_fd_sc_hd_merged.lef"
+
+cfg-synth-platforms:
   - name: "sky130hd_tt"
-    path: "pdk/sky130hd/lib/sky130_fd_sc_hd__tt_025C_1v80.lib"
-    lef-paths:                                          # required for OpenROAD backend
-      - "pdk/sky130hd/lef/sky130_fd_sc_hd_merged.lef"
+    pdk: "sky130hd"
+    corner: "tt"
 ```
 
-The `libraries` list in `synth.yaml` references entries by name.
-
-- **Yosys backend:** uses `path` (liberty) for `read_liberty` → `dfflibmap` → `abc -liberty` → `write_verilog`. `lef-paths` is ignored.
-- **OpenROAD backend:** requires both `path` (liberty) for timing and `lef-paths` (LEF) for technology loading. Without `lef-paths` the run fails immediately with an actionable error.
+- **Yosys backend:** uses the platform's Liberty for `read_liberty` → `dfflibmap` → `abc -liberty` → `write_verilog`. LEF is ignored.
+- **OpenROAD backend:** requires both Liberty and LEF. The `tech-lef` and `macro-lef` on the PDK are passed through automatically; per-block extras can be added via `lef-paths:` on the `cfg-synth-platforms` entry. A platform with no LEF assets fails immediately with an actionable error.
 
 PDK files are typically large and should be gitignored. Provide a download script:
 

--- a/docs/concepts/synthesis.md
+++ b/docs/concepts/synthesis.md
@@ -1,5 +1,5 @@
 ---
-description: How to run synthesis flows with rtl_buddy using synth.yaml, cfg-synth-tools, cfg-pdk + cfg-synth-platforms, and the rb synth command.
+description: How to run synthesis flows with rtl_buddy using synth.yaml, cfg-synth-tools, cfg-pdks + cfg-synth-platforms, and the rb synth command.
 ---
 
 # Synthesis
@@ -105,7 +105,7 @@ syntheses:
 | `model` | Model name from `models.yaml`; also used as the synthesis top module |
 | `model_path` | Path to `models.yaml`, resolved relative to the `synth.yaml` directory |
 | `tool` | Synthesis tool name — must match a `cfg-synth-tools` entry in `root_config.yaml` |
-| `platform` | Optional synth platform name from `cfg-synth-platforms` (which in turn references a `cfg-pdk` entry); enables technology mapping |
+| `platform` | Optional synth platform name from `cfg-synth-platforms` (which in turn references a `cfg-pdks` entry); enables technology mapping |
 | `constraints` | Optional SDC constraints file, resolved relative to `synth.yaml` |
 | `params` | Optional key-value pairs passed as top-level parameter overrides (`chparam` in Yosys) |
 | `defines` | Optional compile-time Verilog defines passed via `-D KEY=VALUE` |
@@ -263,12 +263,12 @@ The pessimization between `standard` and `accurate` (−1.347 vs −1.172 ns WNS
 
 ### PDK and synth platform configuration
 
-PDK assets live under `cfg-pdk` — one entry per process, with corners as sub-fields. Each entry owns *everything* PDK-bound (Liberty per corner, tech-LEF, macro-LEF, cell-GDS, KLayout `.lyt`/`.lyp`, SITE, tie/fill cells); synth and P&R consume what they need.
+PDK assets live under `cfg-pdks` — one entry per process, with corners as sub-fields. Each entry owns *everything* PDK-bound (Liberty per corner, tech-LEF, macro-LEF, cell-GDS, KLayout `.lyt`/`.lyp`, SITE, tie/fill cells); synth and P&R consume what they need.
 
 `cfg-synth-platforms` is a thin selector layer: each entry references a PDK + corner. `synth.yaml` then picks a platform name via `platform:`. All paths are resolved relative to `root_config.yaml`.
 
 ```yaml
-cfg-pdk:
+cfg-pdks:
   - name: "sky130hd"
     site: "unithd"
     corners:
@@ -283,7 +283,7 @@ cfg-synth-platforms:
 ```
 
 - **Yosys backend:** uses the platform's Liberty for `read_liberty` → `dfflibmap` → `abc -liberty` → `write_verilog`. LEF is ignored.
-- **OpenROAD backend:** requires both Liberty and LEF. The `tech-lef` and `macro-lef` on the PDK are passed through automatically; per-block extras can be added via `lef-paths:` on the `cfg-synth-platforms` entry. A platform with no LEF assets fails immediately with an actionable error.
+- **OpenROAD backend:** requires both Liberty and LEF. The `tech-lef` and `macro-lef` on the PDK are passed through automatically; per-block extras can be added via `lef-paths:` on the `synth.yaml` entry. A platform with no LEF assets fails immediately with an actionable error.
 
 PDK files are typically large and should be gitignored. Provide a download script:
 

--- a/docs/concepts/synthesis.md
+++ b/docs/concepts/synthesis.md
@@ -4,18 +4,26 @@ description: How to run synthesis flows with rtl_buddy using synth.yaml, cfg-syn
 
 # Synthesis
 
+> **Integration type:** Pluggable. `rb synth` selects a synthesis tool via `tool:` in `synth.yaml`; the schema is open for future backends.
+>
+> **Curated tools (`tool:` values):** `yosys` (Yosys-only flow); `openroad` (Yosys + OpenROAD-STA two-stage flow).
+>
+> **External binaries required:** `yosys` (the [rtl-buddy/yosys fork](https://github.com/rtl-buddy/yosys), see [Installing Yosys](#installing-yosys)); plus `openroad` on `PATH` when `tool: openroad` is selected — see [Installing OpenROAD](#installing-openroad).
+>
+> See also: [Installation — External tools by feature](../install.md#external-tools-by-feature).
+
 `rtl_buddy` provides a tool-agnostic synthesis flow that mirrors the simulation workflow. Synthesis runs are described in `synth.yaml` files; tool-specific defaults and PDK library paths live in `root_config.yaml`.
 
 ## Supported backends
 
-`rtl_buddy` ships two synthesis backends selectable via `tool:` in `synth.yaml`:
+`rb synth` ships two backends selectable via `tool:` in `synth.yaml`. Both backends use Yosys to map RTL to a gate-level netlist; they differ in whether OpenROAD is run afterwards for static timing analysis.
 
 | `tool:` | Backend | Multi-clock SDC | Reports |
 |---------|---------|-----------------|---------|
-| `yosys` | Yosys + ABC | Workaround (min period) | Gates, Area, WNS |
+| `yosys` | Yosys + ABC (single stage) | Workaround (min period) | Gates, Area, WNS |
 | `openroad` | Yosys (stage 1) + OpenROAD STA (stage 2) | Native `read_sdc` | Gates, Area, WNS, TNS |
 
-The OpenROAD backend removes the multi-clock SDC workaround: stage 1 maps RTL to a gate-level netlist with Yosys, stage 2 feeds that netlist into OpenROAD which loads the SDC natively and reports WNS (actual worst slack from `report_checks`) and TNS (total negative slack).
+The `openroad` backend removes the multi-clock SDC workaround: stage 1 maps RTL to a gate-level netlist with Yosys, stage 2 feeds that netlist into OpenROAD which loads the SDC natively and reports WNS (actual worst slack from `report_checks`) and TNS (total negative slack).
 
 ## Installing Yosys
 

--- a/docs/concepts/wave.md
+++ b/docs/concepts/wave.md
@@ -4,6 +4,14 @@ description: How rb wave opens Surfer with live signal value annotation in your 
 
 # Waveform Viewer (`rb wave`)
 
+> **Integration type:** Integrated tool. `rb wave` is built around Surfer today; Vaporview / VS Code support is on the roadmap — tracked in [issue #84](https://github.com/rtl-buddy/rtl_buddy/issues/84).
+>
+> **External binary required:** Surfer, built from the [`rtl-buddy/surfer`](https://github.com/rtl-buddy/surfer) fork on the `rtl-buddy` branch. Mainline Surfer works for basic FST viewing but not for WCP signal-value annotation. See [Surfer build](#surfer-build).
+>
+> **Editor integration:** nvim for the full annotation round-trip (declaration jump + live signal values + add-from-editor). Any editor can be configured via `editor-cmd` for one-way "open at line".
+>
+> See also: [Installation — External tools by feature](../install.md#external-tools-by-feature).
+
 `rb wave` opens the [Surfer](https://surfer-project.org/) waveform viewer for a test and connects it to your editor via the **WCP** (Waveform Client Protocol). When you right-click a signal in Surfer and choose **Go to declaration**, rtl-buddy:
 
 1. Resolves the signal to its source file and line number

--- a/docs/install.md
+++ b/docs/install.md
@@ -10,13 +10,45 @@ description: How to install rtl_buddy into a project using uv, including prerequ
 
 - Python 3.11 or later
 - `uv`
-- Simulation tool on `PATH`: Verilator (macOS/Linux) or VCS (Linux)
-- Optional: Verible if you want to use `uv run rb verible ...` — e.g. `brew tap chipsalliance/verible && brew install verible` on macOS, or see [Verible releases](https://github.com/chipsalliance/verible/releases) for other platforms
-- Optional system-level coverage tools:
-  - `lcov` for `.info` export and HTML reports
-  - Antmicro `coverview` for Coverview package generation
 
-`rtl_buddy` can be used with different project-specific tool setups, but the primary supported flows are Verilator and VCS. Basic Verible command integration exists; broader first-class Verible and PeakRDL workflows are on the roadmap.
+Everything else is feature-dependent: which external tools you need is decided by which `rb` commands you use. The matrix below maps each command to its required and optional tools.
+
+## Dependency types
+
+rtl_buddy classifies dependencies into four buckets:
+
+- **Required dependency**: Installed automatically with the `rtl_buddy` wheel; no external setup.
+- **Integrated tool**: A rtl_buddy feature is built around one specific tool; you must install that exact tool to use the feature with no alternatives supported.
+- **Pluggable**: rtl_buddy defines an interface; any tool that fits the interface works. rtl_buddy does not know what the tool specifically is or does — it just hands it the inputs the interface promises and consumes the outputs the interface promises.
+- **Pluggable, curated**: tools that plug into the same plug point as **Pluggable**, but rtl_buddy carries first-class optimizations triggered by the tool name (e.g. coverage merging tuned for a specific simulator, a two-stage flow when a specific synthesis backend is selected). Having curated tools does not prevent non-curated tools from plugging into the same plug points.
+
+## Required dependencies
+
+These are installed automatically when you `uv add rtl_buddy` — no action needed:
+
+- `typer`, `click`, `pyserde[yaml]`, `ruamel.yaml`, `rich` — core CLI and config parsing.
+- `pywellen` — FST/VCD waveform reader. Used by `rb wave` annotation regardless of which waveform viewer is configured; the data layer is viewer-independent, which is why it ships with the wheel rather than as a Surfer-side install step.
+
+## External tools by feature
+
+| Command / feature | Integration type | Curated tools | Sub-deps and notes |
+|---|---|---|---|
+| `rb test`, `rb randtest`, `rb regression` | Pluggable | Verilator, VCS (Icarus on the roadmap) | Install the `lcov` package in your OS for LCOV / HTML coverage export from Verilator runs. |
+| `rb verible` | Integrated tool | Verible | `brew tap chipsalliance/verible && brew install verible` on macOS; or see [Verible releases](https://github.com/chipsalliance/verible/releases). |
+| Coverview packaging (under `rb regression`) | Integrated tool | Antmicro [Coverview](https://github.com/antmicro/coverview) | Install the `info-process` package in your OS via Coverview's own setup for full package generation. |
+| `rb synth`, `rb synth-regression` | Pluggable | `yosys`, `openroad` | `yosys` is required (the [rtl-buddy/yosys fork](https://github.com/rtl-buddy/yosys), see below); `openroad` is required only when `tool: openroad`. See [Synthesis](concepts/synthesis.md). |
+| `rb pnr` | Integrated tool | OpenROAD ≥ `25Q1` | Optional: `klayout` for `--gds` / `--png` streamout and rendering. See [Place-and-Route](concepts/pnr.md). |
+| `rb cdc`, `rb cdc-regression` | Integrated tool | [rtl-buddy-cdc](https://github.com/rtl-buddy/rtl-buddy-cdc) | SpyGlass support is on the roadmap — tracked in [issue #85](https://github.com/rtl-buddy/rtl_buddy/issues/85). |
+| `rb wave` | Integrated tool | Surfer (rtl-buddy fork, `rtl-buddy` branch) | nvim for full annotation round-trip; any editor configurable via `editor-cmd` for one-way "open at line". Vaporview / VS Code support is on the roadmap — tracked in [issue #84](https://github.com/rtl-buddy/rtl_buddy/issues/84). See [Waveform Viewer](concepts/wave.md). |
+
+### Forks required
+
+rtl_buddy currently validates against two forks rather than upstream:
+
+- **Surfer** — required. Use the [`rtl-buddy/surfer`](https://github.com/rtl-buddy/surfer) repo, branch `rtl-buddy`. Mainline Surfer works for basic FST viewing but does not support the WCP signal-value annotation features `rb wave` relies on.
+- **Yosys** — required. Use the [`rtl-buddy/yosys`](https://github.com/rtl-buddy/yosys) repo, which tracks upstream with rtl-buddy-specific patches.
+
+Build instructions live on the respective concept pages: [Surfer build](concepts/wave.md#surfer-build) and [Installing Yosys](concepts/synthesis.md#installing-yosys).
 
 ## Install Into A Project With `uv`
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -51,6 +51,7 @@ Usage: rtl-buddy [OPTIONS] COMMAND [ARGS]...
 │ wave-install-nvim  install nvim plugin for rb wave annotation                        │
 │ synth              run synthesis                                                     │
 │ synth-regression   run synthesis regression                                          │
+│ pnr                run place-and-route                                               │
 │ cdc                run CDC lint                                                      │
 │ cdc-regression     run CDC lint regression                                           │
 │ skill              manage the rtl_buddy agent skill                                  │

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -315,3 +315,59 @@ Usage: rtl-buddy synth-regression [OPTIONS]
 │ --help                         Show this message and exit.                           │
 ╰──────────────────────────────────────────────────────────────────────────────────────╯
 ```
+
+## pnr
+
+```text
+Usage: rtl-buddy pnr [OPTIONS] [PNR_NAME]                                              
+                                                                                        
+ run place-and-route                                                                    
+                                                                                        
+╭─ Arguments ──────────────────────────────────────────────────────────────────────────╮
+│   pnr_name      [PNR_NAME]  name of pnr run                                          │
+│                             [default: (run all entries in the suite)]                │
+╰──────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────────────╮
+│ --pnr-config  -c      TEXT     pnr.yaml to use [default: pnr.yaml]                   │
+│ --list                         list pnr runs in the selected config and exit         │
+│ --reg-level   -l      INTEGER  run only entries with reglvl at or below this value   │
+│                                [default: 0]                                          │
+│ --gds                          stream out GDS via KLayout after a successful P&R     │
+│ --png                          render a PNG of the routed GDS via KLayout (implies   │
+│                                --gds)                                                │
+│ --help                         Show this message and exit.                           │
+╰──────────────────────────────────────────────────────────────────────────────────────╯
+```
+
+## cdc
+
+```text
+Usage: rtl-buddy cdc [OPTIONS] [CDC_NAME]                                              
+                                                                                        
+ run CDC lint                                                                           
+                                                                                        
+╭─ Arguments ──────────────────────────────────────────────────────────────────────────╮
+│   cdc_name      [CDC_NAME]  name of CDC analysis to run                              │
+│                             [default: (run all analyses)]                            │
+╰──────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────────────╮
+│ --cdc-config  -c      TEXT  cdc.yaml to use [default: cdc.yaml]                      │
+│ --list                      list analyses in the selected config and exit            │
+│ --help                      Show this message and exit.                              │
+╰──────────────────────────────────────────────────────────────────────────────────────╯
+```
+
+## cdc-regression
+
+```text
+Usage: rtl-buddy cdc-regression [OPTIONS]                                              
+                                                                                        
+ run CDC lint regression                                                                
+                                                                                        
+╭─ Options ────────────────────────────────────────────────────────────────────────────╮
+│ --reg-config  -c      TEXT     path to cdc_regression.yaml                           │
+│                                [default: (Use ./cdc_regression.yaml if present)]     │
+│ --reg-level   -l      INTEGER  CDC regression level to stop at [default: 0]          │
+│ --help                         Show this message and exit.                           │
+╰──────────────────────────────────────────────────────────────────────────────────────╯
+```

--- a/docs/reference/yaml.md
+++ b/docs/reference/yaml.md
@@ -80,11 +80,33 @@ cfg-synth-tools:
     opts:
       strategy: "AREA"   # AREA | TIMING | TIMING_ANNEAL | TIMING_GENETIC
 
-cfg-synth-libs:
+cfg-pdk:
+  - name: "sky130hd"
+    site: "unithd"
+    corners:
+      tt: "pdk/sky130hd/lib/sky130_fd_sc_hd__tt_025C_1v80.lib"
+    tech-lef:  "pdk/sky130hd/lef/sky130_fd_sc_hd.tlef"
+    macro-lef: "pdk/sky130hd/lef/sky130_fd_sc_hd_merged.lef"
+    cell-gds:      "pdk/sky130hd/gds/sky130_fd_sc_hd.gds"
+    klayout-tech:  "pdk/sky130hd/sky130hd.lyt"
+    klayout-props: "pdk/sky130hd/sky130hd.lyp"
+    tie-hi: "sky130_fd_sc_hd__conb_1/HI"
+    tie-lo: "sky130_fd_sc_hd__conb_1/LO"
+    fill-cells: [sky130_fd_sc_hd__fill_1, sky130_fd_sc_hd__fill_2]
+
+cfg-synth-platforms:
   - name: "sky130hd_tt"
-    path: "pdk/sky130hd/lib/sky130_fd_sc_hd__tt_025C_1v80.lib"
-    lef-paths:           # required for OpenROAD backend
-      - "pdk/sky130hd/lef/sky130_fd_sc_hd_merged.lef"
+    pdk: "sky130hd"
+    corner: "tt"
+
+cfg-pnr-platforms:
+  - name: "sky130hd_tt"
+    pdk: "sky130hd"
+    sta-corner: "tt"
+    cts-buffer: "sky130_fd_sc_hd__clkbuf_4"
+    routing-layers:
+      signal: "met1-met5"
+      clock:  "met3-met5"
 
 cfg-synth-efforts:
   - name: "quick"
@@ -125,7 +147,9 @@ cfg-rtl-reg:
 - `cfg-coverview` is keyed by simulator family. `generate-tables` sets the coverage type for Coverview tables. `config` is a dict of inline Coverview JSON configuration values.
 - `cfg-surfer` configures the Surfer waveform viewer used by `rb wave`. `path` is a bare executable name (resolved via PATH) or a relative/absolute path to the binary. `editor-cmd` supports `%f` (file path) and `%l` (line number) placeholders. `editor-terminal` controls how the editor is launched: `tmux` opens a new tmux window, `iterm2` and `terminal` use AppleScript, empty string runs the command directly (suitable for GUI editors like VS Code). `editor-sock` is an optional Unix socket path that enables nvim remote reuse: rtl-buddy launches nvim with `--listen <sock>` on first use and reconnects for subsequent events. `ctrl-sock` is an optional Unix socket for the wave control server, which lets nvim send signals to Surfer — press `<Space>wa` (or your `<leader>wa`) on a signal name to add it to the waveform view. Install the bundled nvim plugin first with `rb wave-install-nvim`.
 - `cfg-synth-tools` defines synthesis tool entries selected by `synth.yaml` `tool` fields. `tool` is the executable name on `PATH`. For the Yosys backend, `opts.synth-args` are appended to the `synth` command and `opts.abc-args` are used by the unmapped ABC step. For the OpenROAD backend, `opts.strategy` controls optional resynthesis (`AREA` = none, `TIMING`/`TIMING_ANNEAL` = `resynth_annealing`, `TIMING_GENETIC` = `resynth_genetic`).
-- `cfg-synth-libs` defines named Liberty files for technology-mapped synthesis. `path` is resolved relative to `root_config.yaml`. The optional `lef-paths` list specifies LEF files required by the OpenROAD backend for technology loading; ignored by the Yosys backend.
+- `cfg-pdk` defines one entry per process. Each holds *all* PDK-bound assets — Liberty per corner (under `corners:`), `tech-lef` / `macro-lef`, optional `cell-gds`, KLayout `.lyt` / `.lyp` for streamout, `SITE`, and `tie-hi` / `tie-lo` / `fill-cells` for P&R. Paths are resolved relative to `root_config.yaml`. Multiple PDKs can coexist; downstream platform blocks select which one to use.
+- `cfg-synth-platforms` selects a `cfg-pdk` entry + corner for synthesis. Each entry has `name` (referenced by `platform:` in `synth.yaml`), `pdk` (PDK entry name), and `corner` (optional — defaults to the first declared corner). Optional `lef-paths:` adds block-specific LEFs on top of the PDK's tech/macro LEFs.
+- `cfg-pnr-platforms` selects a `cfg-pdk` entry + STA corner for place-and-route. Each entry has `name` (referenced by `platform:` in `pnr.yaml`), `pdk`, optional `sta-corner` (defaults to first corner), `cts-buffer` (clock-tree buffer cell), and `routing-layers` with `signal` / `clock` layer ranges.
 - `cfg-synth-efforts` defines named synthesis effort levels referenced by `synth.yaml` `effort` fields or the `--effort` CLI flag. Each entry has optional `yosys.synth-args` / `yosys.abc-args` (merged into the Yosys stage) and an `openroad` block. When `openroad.run: false`, the runner falls back to the Yosys-only backend even if `tool: openroad` was selected — useful for a fast quick-look path that needs no LEF/STA. `openroad.pre-sta-tcl` is a raw Tcl snippet injected into `synth.tcl` between `read_sdc` and `report_checks`; use it to insert floorplan/placement/parasitic-estimation steps before timing analysis. When no `cfg-synth-efforts` entries are configured or no effort is selected, a built-in `standard` effort with all defaults is used. Precedence for the same knob: per-synthesis `tool_overrides` > `cfg-synth-efforts` > `cfg-synth-tools`.
 - `cfg-cdc-tools` defines CDC tool entries selected by `cdc.yaml` `tool` fields. `tool` is the executable name on `PATH` (or an absolute path). `opts.sync-depth` is forwarded as `--sync-depth N` and controls CDC-002's required synchronizer depth. `opts.extra-args` is appended verbatim to every analyzer invocation.
 - `cfg-rtl-reg.reg-cfg-path` is the fallback regression file for `rtl-buddy regression` when no `./regression.yaml` exists in the cwd.
@@ -344,8 +368,7 @@ syntheses:
     model_path: "../src/models.yaml"
     tool: "yosys"
     constraints: "constraints.sdc"
-    libraries:
-      - "sky130hd_tt"
+    platform: "sky130hd_tt"
     params:
       WIDTH: 32
     defines:
@@ -363,8 +386,7 @@ syntheses:
     model_path: "../src/models.yaml"
     tool: "openroad"
     constraints: "constraints.sdc"
-    libraries:
-      - "sky130hd_tt"
+    platform: "sky130hd_tt"
     effort: "accurate"     # references cfg-synth-efforts entry; overridable via --effort
     reglvl: 0
 ```
@@ -381,7 +403,7 @@ syntheses:
 | `constraints` | string | Optional SDC file path, resolved relative to the `synth.yaml` file |
 | `params` | dict | Optional top-level parameter overrides passed through Yosys `chparam -set` |
 | `defines` | dict | Optional Verilog defines passed to `read_verilog` as `-D KEY=VALUE` |
-| `libraries` | list of strings | Optional Liberty library names from `cfg-synth-libs`; enables technology mapping |
+| `platform` | string | Optional `cfg-synth-platforms` name (which references a `cfg-pdk` entry); enables technology mapping |
 | `reglvl` | int or dict | Regression level; int for all tools, dict for per-tool with `default` |
 | `tool_overrides` | dict | Optional per-tool overrides for `synth_args`, `abc_args`, or `strategy`, keyed by synthesis tool name |
 | `effort` | string | Optional effort name from `cfg-synth-efforts`; controls Yosys synth/abc args and OpenROAD `pre-sta-tcl`. Overridable per invocation with `rtl-buddy synth --effort <name>`. Omitted ⇒ built-in `standard` defaults. |
@@ -389,8 +411,8 @@ syntheses:
 **Runtime effects:**
 
 - `rtl-buddy synth` loads `synth.yaml`, resolves sources via `models.yaml`, and dispatches to the backend selected by `tool`.
-- **Yosys backend** (`tool: "yosys"`): writes `synth.f` and `synth.ys`, runs Yosys, captures output in `synth.log`. Without `libraries`, emits RTLIL; with `libraries`, runs `dfflibmap` + `abc -liberty` and emits `synth_netlist.v`. Reports Gates, Area (lib-mapped only), and WNS (lib-mapped with SDC). Passes when exit code is 0 and `synth.log` has no `ERROR:` lines.
-- **OpenROAD backend** (`tool: "openroad"`): requires `libraries` with `lef-paths` configured in `cfg-synth-libs`. Stage 1 runs Yosys to produce `synth_netlist.v` (logged to `synth_yosys.log`). Stage 2 runs OpenROAD with `synth.tcl` which calls `read_lef`, `read_liberty`, `read_verilog`, `link_design`, `read_sdc` (native multi-clock), and reports area/timing; output in `synth.log`. Reports Gates, Area, WNS (from `report_checks -path_delay max`), and TNS (from `report_tns`). Passes when both stages exit with code 0 and neither log contains errors.
+- **Yosys backend** (`tool: "yosys"`): writes `synth.f` and `synth.ys`, runs Yosys, captures output in `synth.log`. Without `platform`, emits RTLIL; with `platform`, runs `dfflibmap` + `abc -liberty` and emits `synth_netlist.v`. Reports Gates, Area (lib-mapped only), and WNS (lib-mapped with SDC). Passes when exit code is 0 and `synth.log` has no `ERROR:` lines.
+- **OpenROAD backend** (`tool: "openroad"`): requires `platform` pointing at a `cfg-synth-platforms` entry whose PDK has `tech-lef` / `macro-lef` set. Stage 1 runs Yosys to produce `synth_netlist.v` (logged to `synth_yosys.log`). Stage 2 runs OpenROAD with `synth.tcl` which calls `read_lef`, `read_liberty`, `read_verilog`, `link_design`, `read_sdc` (native multi-clock), and reports area/timing; output in `synth.log`. Reports Gates, Area, WNS (from `report_checks -path_delay max`), and TNS (from `report_tns`). Passes when both stages exit with code 0 and neither log contains errors.
 - If `constraints` contains `create_clock` entries, the Yosys backend uses the minimum period as ABC's `-D` constraint (multi-clock workaround). The OpenROAD backend passes the full SDC to `read_sdc` without modification.
 - `effort` selects an entry from `root_config.yaml` `cfg-synth-efforts`. If the selected effort has `openroad.run: false`, a synthesis with `tool: openroad` falls back to the Yosys-only backend (no LEF/STA required) — this is the recommended "quick" path for iteration. The `--effort` CLI flag on `rtl-buddy synth` and `rtl-buddy synth-regression` overrides whatever is set per-synthesis.
 
@@ -418,6 +440,59 @@ synth-configs:
 - `rtl-buddy synth-regression` iterates each listed `synth.yaml` file and filters syntheses by `--reg-level`.
 - Paths in `synth-configs` are resolved relative to the `synth_regression.yaml` file.
 - `synth-regression` changes directory into each synthesis suite directory before executing its entries.
+
+---
+
+## pnr.yaml
+
+**Required keys:**
+
+- `rtl-buddy-filetype: pnr_config`
+- `runs`
+
+**Example:**
+
+```yaml
+rtl-buddy-filetype: pnr_config
+
+runs:
+  - name: "demo_pnr_nangate45"
+    desc: "OpenROAD P&R on Nangate45 typ corner"
+    tool: "openroad"
+    synth: "demo_synth_nangate45"
+    synth-path: "../../synth/demo/synth.yaml"
+    constraints: "../../synth/demo/constraints.sdc"
+    platform: "nangate45_typ"
+    floorplan:
+      utilization: 0.55
+      aspect: 1.0
+      core-margin: 2.0
+    reglvl: 1000
+```
+
+**Field reference:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | P&R run identifier; used on the CLI and in `artefacts/<name>/` |
+| `desc` | string | Human-readable description |
+| `tool` | string | Backend tool — `"openroad"` is the only supported value today |
+| `synth` | string | Name of the upstream `rb synth` entry that produced the netlist |
+| `synth-path` | string | Path to the `synth.yaml` that defines `synth`, resolved relative to `pnr.yaml` |
+| `constraints` | string | Path to the SDC file (required), resolved relative to `pnr.yaml` |
+| `platform` | string | `cfg-pnr-platforms` entry name |
+| `floorplan.utilization` | float | Core utilization (0–1) |
+| `floorplan.aspect` | float | Die aspect ratio |
+| `floorplan.core-margin` | float | Margin between core area and die edge, in microns |
+| `reglvl` | int | Regression level for filtering; same semantics as `synth.yaml` reglvl |
+| `tool_overrides` | dict | Reserved for tool-specific overrides (none consumed today) |
+
+**Runtime effects:**
+
+- `rb pnr` loads `pnr.yaml`, resolves the upstream `synth-path` + `synth` to find `<synth_dir>/artefacts/<synth_name>/synth_netlist.v`, and dispatches to the OpenROAD backend.
+- The backend writes `pnr.tcl` from a bundled template, invokes `openroad -no_init -exit -log artefacts/<name>/pnr.log artefacts/<name>/pnr.tcl`, and produces routed DEF + post-route netlist/SDC + timing/DRC reports under `artefacts/<name>/`.
+- The selected `cfg-pnr-platforms` entry provides Liberty, tech-LEF, macro-LEF, SITE, tie cells, fill cells, CTS buffer, and routing layer ranges via its referenced `cfg-pdk` entry.
+- Pass when OpenROAD exits 0 and the log has no `[ERROR ...]` lines. SKIP when the entry's `reglvl` is above `--reg-level` or `tool:` is not `openroad`.
 
 ---
 

--- a/docs/reference/yaml.md
+++ b/docs/reference/yaml.md
@@ -80,7 +80,7 @@ cfg-synth-tools:
     opts:
       strategy: "AREA"   # AREA | TIMING | TIMING_ANNEAL | TIMING_GENETIC
 
-cfg-pdk:
+cfg-pdks:
   - name: "sky130hd"
     site: "unithd"
     corners:
@@ -102,7 +102,7 @@ cfg-synth-platforms:
 cfg-pnr-platforms:
   - name: "sky130hd_tt"
     pdk: "sky130hd"
-    sta-corner: "tt"
+    corner: "tt"
     cts-buffer: "sky130_fd_sc_hd__clkbuf_4"
     routing-layers:
       signal: "met1-met5"
@@ -127,6 +127,10 @@ cfg-synth-efforts:
         global_placement -density 0.7
         estimate_parasitics -placement
 
+cfg-pnr-tools:
+  - name: "openroad"
+    tool: "openroad"            # bare name → found via PATH; or absolute path
+
 cfg-cdc-tools:
   - name: "rtl-buddy-cdc"
     tool: "rtl-buddy-cdc"
@@ -146,12 +150,13 @@ cfg-rtl-reg:
 - `cfg-coverage` is keyed by simulator family (e.g. `verilator`). `use-lcov: true` enables `.info` export and LCOV HTML generation when `--coverage-html` is used.
 - `cfg-coverview` is keyed by simulator family. `generate-tables` sets the coverage type for Coverview tables. `config` is a dict of inline Coverview JSON configuration values.
 - `cfg-surfer` configures the Surfer waveform viewer used by `rb wave`. `path` is a bare executable name (resolved via PATH) or a relative/absolute path to the binary. `editor-cmd` supports `%f` (file path) and `%l` (line number) placeholders. `editor-terminal` controls how the editor is launched: `tmux` opens a new tmux window, `iterm2` and `terminal` use AppleScript, empty string runs the command directly (suitable for GUI editors like VS Code). `editor-sock` is an optional Unix socket path that enables nvim remote reuse: rtl-buddy launches nvim with `--listen <sock>` on first use and reconnects for subsequent events. `ctrl-sock` is an optional Unix socket for the wave control server, which lets nvim send signals to Surfer — press `<Space>wa` (or your `<leader>wa`) on a signal name to add it to the waveform view. Install the bundled nvim plugin first with `rb wave-install-nvim`.
-- `cfg-synth-tools` defines synthesis tool entries selected by `synth.yaml` `tool` fields. `tool` is the executable name on `PATH`. For the Yosys backend, `opts.synth-args` are appended to the `synth` command and `opts.abc-args` are used by the unmapped ABC step. For the OpenROAD backend, `opts.strategy` controls optional resynthesis (`AREA` = none, `TIMING`/`TIMING_ANNEAL` = `resynth_annealing`, `TIMING_GENETIC` = `resynth_genetic`).
-- `cfg-pdk` defines one entry per process. Each holds *all* PDK-bound assets — Liberty per corner (under `corners:`), `tech-lef` / `macro-lef`, optional `cell-gds`, KLayout `.lyt` / `.lyp` for streamout, `SITE`, and `tie-hi` / `tie-lo` / `fill-cells` for P&R. Paths are resolved relative to `root_config.yaml`. Multiple PDKs can coexist; downstream platform blocks select which one to use.
-- `cfg-synth-platforms` selects a `cfg-pdk` entry + corner for synthesis. Each entry has `name` (referenced by `platform:` in `synth.yaml`), `pdk` (PDK entry name), and `corner` (optional — defaults to the first declared corner). Optional `lef-paths:` adds block-specific LEFs on top of the PDK's tech/macro LEFs.
-- `cfg-pnr-platforms` selects a `cfg-pdk` entry + STA corner for place-and-route. Each entry has `name` (referenced by `platform:` in `pnr.yaml`), `pdk`, optional `sta-corner` (defaults to first corner), `cts-buffer` (clock-tree buffer cell), and `routing-layers` with `signal` / `clock` layer ranges.
+- `cfg-synth-tools` defines synthesis tool entries selected by `synth.yaml` `tool` fields. `tool` is the path to the executable, or a bare name if it is available on `PATH`. For the Yosys backend, `opts.synth-args` are appended to the `synth` command and `opts.abc-args` are used by the unmapped ABC step. For the OpenROAD backend, `opts.strategy` controls optional resynthesis (`AREA` = none, `TIMING`/`TIMING_ANNEAL` = `resynth_annealing`, `TIMING_GENETIC` = `resynth_genetic`).
+- `cfg-pdks` defines one entry per process. Each holds *all* PDK-bound assets — Liberty per corner (under `corners:`), `tech-lef` / `macro-lef`, optional `cell-gds`, KLayout `.lyt` / `.lyp` for streamout, `SITE`, and `tie-hi` / `tie-lo` / `fill-cells` for P&R. Paths are resolved relative to `root_config.yaml`. Multiple PDKs can coexist; downstream platform blocks select which one to use.
+- `cfg-synth-platforms` selects a `cfg-pdks` entry + corner for synthesis. Each entry has `name` (referenced by `platform:` in `synth.yaml`), `pdk` (PDK entry name), and `corner` (optional — defaults to the first declared corner). Block-specific LEFs go on the `synth.yaml` entry (`lef-paths:`) on top of the PDK's tech/macro LEFs.
+- `cfg-pnr-platforms` selects a `cfg-pdks` entry + STA corner for place-and-route. Each entry has `name` (referenced by `platform:` in `pnr.yaml`), `pdk`, optional `corner` (defaults to first corner), `cts-buffer` (clock-tree buffer cell), and `routing-layers` with `signal` / `clock` layer ranges.
 - `cfg-synth-efforts` defines named synthesis effort levels referenced by `synth.yaml` `effort` fields or the `--effort` CLI flag. Each entry has optional `yosys.synth-args` / `yosys.abc-args` (merged into the Yosys stage) and an `openroad` block. When `openroad.run: false`, the runner falls back to the Yosys-only backend even if `tool: openroad` was selected — useful for a fast quick-look path that needs no LEF/STA. `openroad.pre-sta-tcl` is a raw Tcl snippet injected into `synth.tcl` between `read_sdc` and `report_checks`; use it to insert floorplan/placement/parasitic-estimation steps before timing analysis. When no `cfg-synth-efforts` entries are configured or no effort is selected, a built-in `standard` effort with all defaults is used. Precedence for the same knob: per-synthesis `tool_overrides` > `cfg-synth-efforts` > `cfg-synth-tools`.
-- `cfg-cdc-tools` defines CDC tool entries selected by `cdc.yaml` `tool` fields. `tool` is the executable name on `PATH` (or an absolute path). `opts.sync-depth` is forwarded as `--sync-depth N` and controls CDC-002's required synchronizer depth. `opts.extra-args` is appended verbatim to every analyzer invocation.
+- `cfg-pnr-tools` defines P&R tool entries selected by `pnr.yaml` `tool` fields. `tool` is the path to the executable, or a bare name if it is available on `PATH`. When `pnr.yaml` `tool` does not match a `cfg-pnr-tools` entry, the value is used as the executable name directly (bare-name on `PATH` semantics).
+- `cfg-cdc-tools` defines CDC tool entries selected by `cdc.yaml` `tool` fields. `tool` is the path to the executable, or a bare name if it is available on `PATH`. `opts.sync-depth` is forwarded as `--sync-depth N` and controls CDC-002's required synchronizer depth. `opts.extra-args` is appended verbatim to every analyzer invocation.
 - `cfg-rtl-reg.reg-cfg-path` is the fallback regression file for `rtl-buddy regression` when no `./regression.yaml` exists in the cwd.
 - `cfg-verible[].path` is the directory containing Verible executables. Absolute paths are used as-is; relative paths are resolved from the directory containing `root_config.yaml`.
 
@@ -403,7 +408,8 @@ syntheses:
 | `constraints` | string | Optional SDC file path, resolved relative to the `synth.yaml` file |
 | `params` | dict | Optional top-level parameter overrides passed through Yosys `chparam -set` |
 | `defines` | dict | Optional Verilog defines passed to `read_verilog` as `-D KEY=VALUE` |
-| `platform` | string | Optional `cfg-synth-platforms` name (which references a `cfg-pdk` entry); enables technology mapping |
+| `platform` | string | Optional `cfg-synth-platforms` name (which references a `cfg-pdks` entry); enables technology mapping |
+| `lef-paths` | list of strings | Optional block-specific LEF files (paths resolved relative to the `synth.yaml` file); appended after the PDK's tech/macro LEFs for the OpenROAD backend |
 | `reglvl` | int or dict | Regression level; int for all tools, dict for per-tool with `default` |
 | `tool_overrides` | dict | Optional per-tool overrides for `synth_args`, `abc_args`, or `strategy`, keyed by synthesis tool name |
 | `effort` | string | Optional effort name from `cfg-synth-efforts`; controls Yosys synth/abc args and OpenROAD `pre-sta-tcl`. Overridable per invocation with `rtl-buddy synth --effort <name>`. Omitted ⇒ built-in `standard` defaults. |
@@ -484,14 +490,14 @@ runs:
 | `floorplan.utilization` | float | Core utilization (0–1) |
 | `floorplan.aspect` | float | Die aspect ratio |
 | `floorplan.core-margin` | float | Margin between core area and die edge, in microns |
-| `reglvl` | int | Regression level for filtering; same semantics as `synth.yaml` reglvl |
+| `reglvl` | int or dict | Regression level for filtering; same semantics as `synth.yaml` reglvl (int for all tools, dict for per-tool with `default`) |
 | `tool_overrides` | dict | Reserved for tool-specific overrides (none consumed today) |
 
 **Runtime effects:**
 
 - `rb pnr` loads `pnr.yaml`, resolves the upstream `synth-path` + `synth` to find `<synth_dir>/artefacts/<synth_name>/synth_netlist.v`, and dispatches to the OpenROAD backend.
 - The backend writes `pnr.tcl` from a bundled template, invokes `openroad -no_init -exit -log artefacts/<name>/pnr.log artefacts/<name>/pnr.tcl`, and produces routed DEF + post-route netlist/SDC + timing/DRC reports under `artefacts/<name>/`.
-- The selected `cfg-pnr-platforms` entry provides Liberty, tech-LEF, macro-LEF, SITE, tie cells, fill cells, CTS buffer, and routing layer ranges via its referenced `cfg-pdk` entry.
+- The selected `cfg-pnr-platforms` entry provides Liberty, tech-LEF, macro-LEF, SITE, tie cells, fill cells, CTS buffer, and routing layer ranges via its referenced `cfg-pdks` entry.
 - Pass when OpenROAD exits 0 and the log has no `[ERROR ...]` lines. SKIP when the entry's `reglvl` is above `--reg-level` or `tool:` is not `openroad`.
 
 ---

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,6 +45,7 @@ nav:
       - Spec Traceability: concepts/spec-traceability.md
       - Waveform Viewer: concepts/wave.md
       - Synthesis: concepts/synthesis.md
+      - Place-and-Route: concepts/pnr.md
   - Reference:
       - CLI: reference/cli.md
       - YAML Formats: reference/yaml.md

--- a/scripts/gen_cli_reference.py
+++ b/scripts/gen_cli_reference.py
@@ -24,6 +24,9 @@ SUBCOMMANDS = [
     "spec",
     "synth",
     "synth-regression",
+    "pnr",
+    "cdc",
+    "cdc-regression",
 ]
 
 HEADER = """\

--- a/src/rtl_buddy/config/__init__.py
+++ b/src/rtl_buddy/config/__init__.py
@@ -25,6 +25,7 @@ from .synth import (
 )
 from .pdk import PdkConfig
 from .pnr_platform import PnrPlatformConfig
+from .pnr import PnrConfig, PnrSuiteConfig
 
 __all__ = [
     "TestConfig",
@@ -52,4 +53,6 @@ __all__ = [
     "SynthPlatformConfig",
     "PdkConfig",
     "PnrPlatformConfig",
+    "PnrConfig",
+    "PnrSuiteConfig",
 ]

--- a/src/rtl_buddy/config/__init__.py
+++ b/src/rtl_buddy/config/__init__.py
@@ -21,8 +21,10 @@ from .synth import (
     SynthSuiteConfig,
     SynthRegConfig,
     SynthToolConfig,
-    SynthLibConfig,
+    SynthPlatformConfig,
 )
+from .pdk import PdkConfig
+from .pnr_platform import PnrPlatformConfig
 
 __all__ = [
     "TestConfig",
@@ -47,5 +49,7 @@ __all__ = [
     "SynthSuiteConfig",
     "SynthRegConfig",
     "SynthToolConfig",
-    "SynthLibConfig",
+    "SynthPlatformConfig",
+    "PdkConfig",
+    "PnrPlatformConfig",
 ]

--- a/src/rtl_buddy/config/pdk.py
+++ b/src/rtl_buddy/config/pdk.py
@@ -1,0 +1,90 @@
+import logging
+import os
+
+from serde import serde, field
+
+from ..errors import FatalRtlBuddyError
+
+logger = logging.getLogger(__name__)
+
+
+@serde
+class PdkConfigFile:
+    name: str
+    site: str = ""
+    corners: dict[str, str] = field(default_factory=dict)
+    tech_lef: str = field(rename="tech-lef", default="")
+    macro_lef: str = field(rename="macro-lef", default="")
+    cell_gds: str = field(rename="cell-gds", default="")
+    klayout_tech: str = field(rename="klayout-tech", default="")
+    klayout_props: str = field(rename="klayout-props", default="")
+    tie_hi: str = field(rename="tie-hi", default="")
+    tie_lo: str = field(rename="tie-lo", default="")
+    fill_cells: list[str] = field(rename="fill-cells", default_factory=list)
+
+
+class PdkConfig:
+    def __init__(self, cfg: PdkConfigFile, root_cfg_path: str):
+        cfg_dir = os.path.dirname(root_cfg_path)
+
+        def _resolve(p: str) -> str:
+            return os.path.normpath(os.path.join(cfg_dir, p)) if p else ""
+
+        self._name = cfg.name
+        self._site = cfg.site
+        self._corners = {k: _resolve(v) for k, v in (cfg.corners or {}).items()}
+        self._tech_lef = _resolve(cfg.tech_lef)
+        self._macro_lef = _resolve(cfg.macro_lef)
+        self._cell_gds = _resolve(cfg.cell_gds)
+        self._klayout_tech = _resolve(cfg.klayout_tech)
+        self._klayout_props = _resolve(cfg.klayout_props)
+        self._tie_hi = cfg.tie_hi
+        self._tie_lo = cfg.tie_lo
+        self._fill_cells = list(cfg.fill_cells)
+
+    def get_name(self) -> str:
+        return self._name
+
+    def get_site(self) -> str:
+        return self._site
+
+    def get_corners(self) -> list[str]:
+        return list(self._corners.keys())
+
+    def get_corner_path(self, corner: str) -> str:
+        path = self._corners.get(corner)
+        if path is None:
+            raise FatalRtlBuddyError(
+                f"PDK '{self._name}' has no corner '{corner}'; "
+                f"available: {sorted(self._corners)}"
+            )
+        return path
+
+    def get_default_corner(self) -> str:
+        if not self._corners:
+            raise FatalRtlBuddyError(f"PDK '{self._name}' declares no corners")
+        return next(iter(self._corners))
+
+    def get_tech_lef(self) -> str:
+        return self._tech_lef
+
+    def get_macro_lef(self) -> str:
+        return self._macro_lef
+
+    def get_cell_gds(self) -> str:
+        return self._cell_gds
+
+    def get_klayout_tech(self) -> str:
+        return self._klayout_tech
+
+    def get_klayout_props(self) -> str:
+        return self._klayout_props
+
+    def get_tie_hi(self) -> str:
+        return self._tie_hi
+
+    def get_tie_lo(self) -> str:
+        return self._tie_lo
+
+    def get_fill_cells(self) -> list[str]:
+        return list(self._fill_cells)

--- a/src/rtl_buddy/config/pnr.py
+++ b/src/rtl_buddy/config/pnr.py
@@ -15,6 +15,23 @@ logger = logging.getLogger(__name__)
 
 
 @serde
+class PnrToolConfigFile:
+    name: str
+    tool: str
+
+
+class PnrToolConfig:
+    def __init__(self, cfg: PnrToolConfigFile):
+        self._cfg = cfg
+
+    def get_name(self) -> str:
+        return self._cfg.name
+
+    def get_executable(self) -> str:
+        return self._cfg.tool
+
+
+@serde
 class PnrFloorplanFile:
     utilization: float = 0.55
     aspect: float = 1.0
@@ -38,7 +55,7 @@ class PnrConfigFile:
     constraints: str | None = None
     platform: str = ""
     floorplan: PnrFloorplanFile = field(default_factory=PnrFloorplanFile)
-    reglvl: int | None = field(rename="reglvl", default=None)
+    reglvl: int | dict | None = field(rename="reglvl", default=None)
     tool_overrides: dict | None = None
 
     def initialise(self, config_dir: str) -> "PnrConfig":
@@ -91,7 +108,7 @@ class PnrConfig:
     constraints: str | None
     platform: str
     floorplan: PnrFloorplan
-    _reglvl: int | None
+    _reglvl: int | dict | None
     tool_overrides: dict | None
 
     def get_name(self) -> str:
@@ -118,8 +135,27 @@ class PnrConfig:
     def get_floorplan(self) -> PnrFloorplan:
         return self.floorplan
 
-    def get_reglvl(self) -> int:
-        return self._reglvl if self._reglvl is not None else 0
+    def get_reglvl(self, tool_name: str) -> int:
+        match self._reglvl:
+            case int() as lvl:
+                return lvl
+            case dict() if tool_name in self._reglvl:
+                return self._reglvl[tool_name]
+            case dict() if "default" in self._reglvl:
+                return self._reglvl["default"]
+            case None:
+                return 0
+            case _:
+                log_event(
+                    logger,
+                    logging.ERROR,
+                    "pnr_config.reglvl_malformed",
+                    pnr=self.name,
+                    tool=tool_name,
+                )
+                raise FatalRtlBuddyError(
+                    f"Malformed pnr.yaml, specify reglvl for {self.name} with {tool_name} or default"
+                )
 
     def get_tool_overrides(self) -> dict | None:
         return self.tool_overrides

--- a/src/rtl_buddy/config/pnr.py
+++ b/src/rtl_buddy/config/pnr.py
@@ -1,0 +1,197 @@
+import logging
+import os
+import pprint
+from dataclasses import dataclass
+from typing import Literal
+
+from serde import field, serde
+from serde.yaml import from_yaml
+
+from ..errors import FatalRtlBuddyError
+from ..logging_utils import log_event
+from .synth import SynthSuiteConfig
+
+logger = logging.getLogger(__name__)
+
+
+@serde
+class PnrFloorplanFile:
+    utilization: float = 0.55
+    aspect: float = 1.0
+    core_margin: float = field(rename="core-margin", default=2.0)
+
+
+@dataclass
+class PnrFloorplan:
+    utilization: float
+    aspect: float
+    core_margin: float
+
+
+@serde
+class PnrConfigFile:
+    name: str
+    desc: str
+    tool: str = "openroad"
+    synth: str = ""
+    synth_path: str = field(rename="synth-path", default="")
+    constraints: str | None = None
+    platform: str = ""
+    floorplan: PnrFloorplanFile = field(default_factory=PnrFloorplanFile)
+    reglvl: int | None = field(rename="reglvl", default=None)
+    tool_overrides: dict | None = None
+
+    def initialise(self, config_dir: str) -> "PnrConfig":
+        if not self.synth:
+            raise FatalRtlBuddyError(
+                f"pnr run '{self.name}': missing 'synth' (name of upstream rb synth entry)"
+            )
+        if not self.synth_path:
+            raise FatalRtlBuddyError(
+                f"pnr run '{self.name}': missing 'synth-path' "
+                "(path to the synth.yaml that defines the synth entry)"
+            )
+        if not self.platform:
+            raise FatalRtlBuddyError(
+                f"pnr run '{self.name}': missing 'platform' "
+                "(name of a cfg-pnr-platforms entry)"
+            )
+
+        synth_path_abs = os.path.normpath(os.path.join(config_dir, self.synth_path))
+        constraints = (
+            os.path.normpath(os.path.join(config_dir, self.constraints))
+            if self.constraints is not None
+            else None
+        )
+        return PnrConfig(
+            name=self.name,
+            desc=self.desc,
+            tool=self.tool,
+            synth_name=self.synth,
+            synth_suite_path=synth_path_abs,
+            constraints=constraints,
+            platform=self.platform,
+            floorplan=PnrFloorplan(
+                utilization=self.floorplan.utilization,
+                aspect=self.floorplan.aspect,
+                core_margin=self.floorplan.core_margin,
+            ),
+            _reglvl=self.reglvl,
+            tool_overrides=self.tool_overrides,
+        )
+
+
+@dataclass
+class PnrConfig:
+    name: str
+    desc: str
+    tool: str
+    synth_name: str
+    synth_suite_path: str
+    constraints: str | None
+    platform: str
+    floorplan: PnrFloorplan
+    _reglvl: int | None
+    tool_overrides: dict | None
+
+    def get_name(self) -> str:
+        return self.name
+
+    def get_desc(self) -> str:
+        return self.desc
+
+    def get_tool_name(self) -> str:
+        return self.tool
+
+    def get_synth_name(self) -> str:
+        return self.synth_name
+
+    def get_synth_suite_path(self) -> str:
+        return self.synth_suite_path
+
+    def get_constraints(self) -> str | None:
+        return self.constraints
+
+    def get_platform(self) -> str:
+        return self.platform
+
+    def get_floorplan(self) -> PnrFloorplan:
+        return self.floorplan
+
+    def get_reglvl(self) -> int:
+        return self._reglvl if self._reglvl is not None else 0
+
+    def get_tool_overrides(self) -> dict | None:
+        return self.tool_overrides
+
+    def resolve_synth_cfg(self):
+        """Load the upstream synth.yaml and return the referenced entry."""
+        suite = SynthSuiteConfig(self.synth_suite_path)
+        return suite.get_syntheses(self.synth_name)[0]
+
+    def __str__(self):
+        return pprint.pformat(self)
+
+
+@serde
+class PnrSuiteConfigFile:
+    filetype: Literal["pnr_config"] = field(rename="rtl-buddy-filetype")
+    runs: list[PnrConfigFile]
+
+
+class PnrSuiteConfig:
+    def __init__(self, path: str):
+        self.path = path
+        self.runs: dict[str, PnrConfig] = {}
+        try:
+            with open(path, "r") as f:
+                data = from_yaml(PnrSuiteConfigFile, f.read())
+        except Exception as e:
+            log_event(
+                logger,
+                logging.ERROR,
+                "pnr_suite_config.load_failed",
+                path=path,
+                error=e,
+            )
+            raise FatalRtlBuddyError(f'failed to load "{path}"') from e
+
+        config_dir = os.path.dirname(os.path.abspath(path))
+        try:
+            self.runs = {r.name: r.initialise(config_dir) for r in data.runs}
+        except FatalRtlBuddyError:
+            raise
+        except Exception as e:
+            log_event(
+                logger,
+                logging.ERROR,
+                "pnr_suite_config.runs_malformed",
+                path=path,
+                error=e,
+            )
+            raise FatalRtlBuddyError(f"{path}: runs section malformed") from e
+
+    def get_runs(self, name: str | None = None) -> list[PnrConfig]:
+        if name is not None:
+            if name not in self.runs:
+                log_event(
+                    logger,
+                    logging.ERROR,
+                    "pnr_suite_config.run_missing",
+                    path=self.path,
+                    run=name,
+                )
+                raise FatalRtlBuddyError(
+                    f"pnr run '{name}' not found in suite {self.path}"
+                )
+            return [self.runs[name]]
+        return list(self.runs.values())
+
+    def get_run_names(self) -> list[str]:
+        return list(self.runs.keys())
+
+    def get_path(self) -> str:
+        return self.path
+
+    def __str__(self):
+        return pprint.pformat(self)

--- a/src/rtl_buddy/config/pnr_platform.py
+++ b/src/rtl_buddy/config/pnr_platform.py
@@ -17,7 +17,7 @@ class PnrRoutingLayersFile:
 class PnrPlatformConfigFile:
     name: str
     pdk: str
-    sta_corner: str = field(rename="sta-corner", default="")
+    sta_corner: str = field(rename="corner", default="")
     cts_buffer: str = field(rename="cts-buffer", default="")
     routing_layers: PnrRoutingLayersFile = field(
         rename="routing-layers", default_factory=PnrRoutingLayersFile

--- a/src/rtl_buddy/config/pnr_platform.py
+++ b/src/rtl_buddy/config/pnr_platform.py
@@ -1,0 +1,72 @@
+import logging
+
+from serde import serde, field
+
+from ..errors import FatalRtlBuddyError
+
+logger = logging.getLogger(__name__)
+
+
+@serde
+class PnrRoutingLayersFile:
+    signal: str = ""
+    clock: str = ""
+
+
+@serde
+class PnrPlatformConfigFile:
+    name: str
+    pdk: str
+    sta_corner: str = field(rename="sta-corner", default="")
+    cts_buffer: str = field(rename="cts-buffer", default="")
+    routing_layers: PnrRoutingLayersFile = field(
+        rename="routing-layers", default_factory=PnrRoutingLayersFile
+    )
+
+
+class PnrPlatformConfig:
+    """A P&R-side view of a PDK + STA corner selection.
+
+    Wraps a PdkConfig with P&R-specific knobs (CTS buffer, routing
+    layer ranges). Floorplan-level details like die size / utilization
+    live on the per-run pnr.yaml, not here.
+    """
+
+    def __init__(self, cfg: PnrPlatformConfigFile, pdk_lookup):
+        self._name = cfg.name
+        self._pdk_name = cfg.pdk
+        self._pdk = pdk_lookup(cfg.pdk)
+        self._sta_corner = cfg.sta_corner or self._pdk.get_default_corner()
+        if self._sta_corner not in self._pdk.get_corners():
+            raise FatalRtlBuddyError(
+                f"pnr platform '{self._name}': PDK '{self._pdk_name}' "
+                f"has no corner '{self._sta_corner}'; "
+                f"available: {self._pdk.get_corners()}"
+            )
+        self._cts_buffer = cfg.cts_buffer
+        self._signal_layers = cfg.routing_layers.signal
+        self._clock_layers = cfg.routing_layers.clock
+
+    def get_name(self) -> str:
+        return self._name
+
+    def get_pdk(self):
+        return self._pdk
+
+    def get_pdk_name(self) -> str:
+        return self._pdk_name
+
+    def get_sta_corner(self) -> str:
+        return self._sta_corner
+
+    def get_sta_lib_path(self) -> str:
+        return self._pdk.get_corner_path(self._sta_corner)
+
+    def get_cts_buffer(self) -> str:
+        return self._cts_buffer
+
+    def get_signal_layers(self) -> str:
+        return self._signal_layers
+
+    def get_clock_layers(self) -> str:
+        return self._clock_layers

--- a/src/rtl_buddy/config/root.py
+++ b/src/rtl_buddy/config/root.py
@@ -27,6 +27,7 @@ from .synth import (
     default_effort_config,
 )
 from .pdk import PdkConfig, PdkConfigFile
+from .pnr import PnrToolConfig, PnrToolConfigFile
 from .pnr_platform import PnrPlatformConfig, PnrPlatformConfigFile
 from .cdc import CdcToolConfig, CdcToolConfigFile
 from ..errors import FatalRtlBuddyError
@@ -109,12 +110,15 @@ class RootConfigFile:
     synth_tools: list[SynthToolConfigFile] = field(
         rename="cfg-synth-tools", default_factory=list
     )
-    pdks: list[PdkConfigFile] = field(rename="cfg-pdk", default_factory=list)
+    pdks: list[PdkConfigFile] = field(rename="cfg-pdks", default_factory=list)
     synth_platforms: list[SynthPlatformConfigFile] = field(
         rename="cfg-synth-platforms", default_factory=list
     )
     pnr_platforms: list[PnrPlatformConfigFile] = field(
         rename="cfg-pnr-platforms", default_factory=list
+    )
+    pnr_tools: list[PnrToolConfigFile] = field(
+        rename="cfg-pnr-tools", default_factory=list
     )
     cdc_tools: list[CdcToolConfigFile] = field(
         rename="cfg-cdc-tools", default_factory=list
@@ -168,6 +172,7 @@ class RootConfig:
         self.pdk_cfgs: dict = {}
         self.synth_platform_cfgs: dict = {}
         self.pnr_platform_cfgs: dict = {}
+        self.pnr_tool_cfgs: dict = {}
         self.cdc_tool_cfgs: dict = {}
         self.synth_effort_cfgs: dict = {}
         self.platform_cfg = None
@@ -223,14 +228,14 @@ class RootConfig:
                 pdk = self.pdk_cfgs.get(name)
                 if pdk is None:
                     raise FatalRtlBuddyError(
-                        f"PDK '{name}' not found in cfg-pdk; "
+                        f"PDK '{name}' not found in cfg-pdks; "
                         f"available: {sorted(self.pdk_cfgs)}"
                     )
                 return pdk
 
             # Populate synth platform configs (referencing PDKs by name)
             self.synth_platform_cfgs = {
-                cfg.name: SynthPlatformConfig(cfg, self.root_cfg_path, _pdk_lookup)
+                cfg.name: SynthPlatformConfig(cfg, _pdk_lookup)
                 for cfg in data.synth_platforms
             }
 
@@ -238,6 +243,11 @@ class RootConfig:
             self.pnr_platform_cfgs = {
                 cfg.name: PnrPlatformConfig(cfg, _pdk_lookup)
                 for cfg in data.pnr_platforms
+            }
+
+            # Populate P&R tool configs
+            self.pnr_tool_cfgs = {
+                cfg.name: PnrToolConfig(cfg) for cfg in data.pnr_tools
             }
 
             # Populate CDC tool configs
@@ -448,6 +458,19 @@ class RootConfig:
             )
         return cfg
 
+    def get_pnr_tool_cfg(self, name: str):
+        """
+        Get P&R tool configuration by name.
+
+        Args:
+          name (str): Tool name as defined in cfg-pnr-tools.
+        Returns:
+          cfg (PnrToolConfig|None): Matching P&R tool configuration, or
+            None if no entry with that name is configured. Callers fall
+            back to the bare tool name on PATH when None is returned.
+        """
+        return self.pnr_tool_cfgs.get(name)
+
     def get_cdc_tool_cfg(self, name: str):
         """
         Get CDC tool configuration by name.
@@ -465,11 +488,11 @@ class RootConfig:
         return cfg
 
     def get_pdk_cfg(self, name: str) -> PdkConfig:
-        """Get a PDK configuration by name (cfg-pdk entry)."""
+        """Get a PDK configuration by name (cfg-pdks entry)."""
         cfg = self.pdk_cfgs.get(name)
         if cfg is None:
             raise FatalRtlBuddyError(
-                f"PDK '{name}' not found in cfg-pdk; available: {sorted(self.pdk_cfgs)}"
+                f"PDK '{name}' not found in cfg-pdks; available: {sorted(self.pdk_cfgs)}"
             )
         return cfg
 

--- a/src/rtl_buddy/config/root.py
+++ b/src/rtl_buddy/config/root.py
@@ -20,12 +20,14 @@ from .surfer import SurferConfig, SurferConfigFile
 from .synth import (
     SynthToolConfig,
     SynthToolConfigFile,
-    SynthLibConfig,
-    SynthLibConfigFile,
+    SynthPlatformConfig,
+    SynthPlatformConfigFile,
     SynthEffortConfig,
     SynthEffortConfigFile,
     default_effort_config,
 )
+from .pdk import PdkConfig, PdkConfigFile
+from .pnr_platform import PnrPlatformConfig, PnrPlatformConfigFile
 from .cdc import CdcToolConfig, CdcToolConfigFile
 from ..errors import FatalRtlBuddyError
 from ..logging_utils import log_event
@@ -107,8 +109,12 @@ class RootConfigFile:
     synth_tools: list[SynthToolConfigFile] = field(
         rename="cfg-synth-tools", default_factory=list
     )
-    synth_libs: list[SynthLibConfigFile] = field(
-        rename="cfg-synth-libs", default_factory=list
+    pdks: list[PdkConfigFile] = field(rename="cfg-pdk", default_factory=list)
+    synth_platforms: list[SynthPlatformConfigFile] = field(
+        rename="cfg-synth-platforms", default_factory=list
+    )
+    pnr_platforms: list[PnrPlatformConfigFile] = field(
+        rename="cfg-pnr-platforms", default_factory=list
     )
     cdc_tools: list[CdcToolConfigFile] = field(
         rename="cfg-cdc-tools", default_factory=list
@@ -159,7 +165,9 @@ class RootConfig:
         self.coverview_cfgs = dict()
         self.surfer_cfgs: dict = {}
         self.synth_tool_cfgs = dict()
-        self.synth_lib_cfgs = dict()
+        self.pdk_cfgs: dict = {}
+        self.synth_platform_cfgs: dict = {}
+        self.pnr_platform_cfgs: dict = {}
         self.cdc_tool_cfgs: dict = {}
         self.synth_effort_cfgs: dict = {}
         self.platform_cfg = None
@@ -206,10 +214,30 @@ class RootConfig:
                 cfg.name: SynthToolConfig(cfg) for cfg in data.synth_tools
             }
 
-            # Populate synth lib configs
-            self.synth_lib_cfgs = {
-                cfg.name: SynthLibConfig(cfg, self.root_cfg_path)
-                for cfg in data.synth_libs
+            # Populate PDK configs (referenced by synth + pnr platforms)
+            self.pdk_cfgs = {
+                cfg.name: PdkConfig(cfg, self.root_cfg_path) for cfg in data.pdks
+            }
+
+            def _pdk_lookup(name: str) -> PdkConfig:
+                pdk = self.pdk_cfgs.get(name)
+                if pdk is None:
+                    raise FatalRtlBuddyError(
+                        f"PDK '{name}' not found in cfg-pdk; "
+                        f"available: {sorted(self.pdk_cfgs)}"
+                    )
+                return pdk
+
+            # Populate synth platform configs (referencing PDKs by name)
+            self.synth_platform_cfgs = {
+                cfg.name: SynthPlatformConfig(cfg, self.root_cfg_path, _pdk_lookup)
+                for cfg in data.synth_platforms
+            }
+
+            # Populate P&R platform configs
+            self.pnr_platform_cfgs = {
+                cfg.name: PnrPlatformConfig(cfg, _pdk_lookup)
+                for cfg in data.pnr_platforms
             }
 
             # Populate CDC tool configs
@@ -436,21 +464,42 @@ class RootConfig:
             raise FatalRtlBuddyError(f"CDC tool '{name}' not found in cfg-cdc-tools")
         return cfg
 
-    def get_synth_lib_cfg(self, name: str):
-        """
-        Get synthesis library configuration by name.
-
-        Args:
-          name (str): Library name as defined in cfg-synth-libs.
-        Returns:
-          cfg (SynthLibConfig): Matching synthesis library configuration.
-        Raises:
-          FatalRtlBuddyError: If no library with that name is configured.
-        """
-        cfg = self.synth_lib_cfgs.get(name)
+    def get_pdk_cfg(self, name: str) -> PdkConfig:
+        """Get a PDK configuration by name (cfg-pdk entry)."""
+        cfg = self.pdk_cfgs.get(name)
         if cfg is None:
             raise FatalRtlBuddyError(
-                f"synthesis library '{name}' not found in cfg-synth-libs"
+                f"PDK '{name}' not found in cfg-pdk; "
+                f"available: {sorted(self.pdk_cfgs)}"
+            )
+        return cfg
+
+    def get_synth_platform_cfg(self, name: str) -> SynthPlatformConfig:
+        """
+        Get a synthesis platform configuration by name.
+
+        Args:
+          name (str): Platform name as defined in cfg-synth-platforms.
+        Returns:
+          cfg (SynthPlatformConfig): Matching synth platform configuration.
+        Raises:
+          FatalRtlBuddyError: If no platform with that name is configured.
+        """
+        cfg = self.synth_platform_cfgs.get(name)
+        if cfg is None:
+            raise FatalRtlBuddyError(
+                f"synth platform '{name}' not found in cfg-synth-platforms; "
+                f"available: {sorted(self.synth_platform_cfgs)}"
+            )
+        return cfg
+
+    def get_pnr_platform_cfg(self, name: str) -> PnrPlatformConfig:
+        """Get a P&R platform configuration by name (cfg-pnr-platforms entry)."""
+        cfg = self.pnr_platform_cfgs.get(name)
+        if cfg is None:
+            raise FatalRtlBuddyError(
+                f"pnr platform '{name}' not found in cfg-pnr-platforms; "
+                f"available: {sorted(self.pnr_platform_cfgs)}"
             )
         return cfg
 

--- a/src/rtl_buddy/config/root.py
+++ b/src/rtl_buddy/config/root.py
@@ -469,8 +469,7 @@ class RootConfig:
         cfg = self.pdk_cfgs.get(name)
         if cfg is None:
             raise FatalRtlBuddyError(
-                f"PDK '{name}' not found in cfg-pdk; "
-                f"available: {sorted(self.pdk_cfgs)}"
+                f"PDK '{name}' not found in cfg-pdk; available: {sorted(self.pdk_cfgs)}"
             )
         return cfg
 

--- a/src/rtl_buddy/config/synth.py
+++ b/src/rtl_buddy/config/synth.py
@@ -1,7 +1,7 @@
 import logging
 import os
 import pprint
-from dataclasses import dataclass
+from dataclasses import dataclass, field as dc_field
 
 from serde import serde, field
 from serde.yaml import from_yaml
@@ -19,29 +19,24 @@ class SynthPlatformConfigFile:
     name: str
     pdk: str
     corner: str = ""
-    lef_paths: list[str] = field(rename="lef-paths", default_factory=list)
 
 
 class SynthPlatformConfig:
     """A synthesis-side view of a PDK + corner selection.
 
     Backends consume `get_path()` (Liberty for STA / tech mapping) and
-    `get_lef_paths()` (cell + tech LEF, plus any block-specific extras).
+    `get_lef_paths()` (tech + macro LEF from the PDK). Block-specific
+    LEFs live on the per-run synth.yaml (`SynthConfig.get_lef_paths()`).
     """
 
-    def __init__(self, cfg: SynthPlatformConfigFile, root_cfg_path: str, pdk_lookup):
+    def __init__(self, cfg: SynthPlatformConfigFile, pdk_lookup):
         self._name = cfg.name
         self._pdk_name = cfg.pdk
-        cfg_dir = os.path.dirname(root_cfg_path)
-        self._extra_lefs = [
-            os.path.normpath(os.path.join(cfg_dir, p)) for p in cfg.lef_paths
-        ]
 
         pdk = pdk_lookup(cfg.pdk)
         self._corner = cfg.corner or pdk.get_default_corner()
         self._lib_path = pdk.get_corner_path(self._corner)
-        pdk_lefs = [p for p in (pdk.get_tech_lef(), pdk.get_macro_lef()) if p]
-        self._lef_paths = pdk_lefs + self._extra_lefs
+        self._lef_paths = [p for p in (pdk.get_tech_lef(), pdk.get_macro_lef()) if p]
 
     def get_name(self) -> str:
         return self._name
@@ -161,6 +156,7 @@ class SynthConfigFile:
     params: dict | None = None
     defines: dict | None = None
     platform: str | None = None
+    lef_paths: list[str] = field(rename="lef-paths", default_factory=list)
     reglvl: int | dict | None = field(rename="reglvl", default=None)
     tool_overrides: dict | None = None
     effort: str | None = None
@@ -174,6 +170,9 @@ class SynthConfigFile:
             if self.constraints is not None
             else None
         )
+        lef_paths = [
+            os.path.normpath(os.path.join(config_dir, p)) for p in self.lef_paths
+        ]
         return SynthConfig(
             name=self.name,
             desc=self.desc,
@@ -183,6 +182,7 @@ class SynthConfigFile:
             params=self.params,
             defines=self.defines,
             platform=self.platform,
+            lef_paths=lef_paths,
             _reglvl=self.reglvl,
             tool_overrides=self.tool_overrides,
             effort=self.effort,
@@ -202,6 +202,7 @@ class SynthConfig:
     _reglvl: int | dict | None
     tool_overrides: dict | None
     effort: str | None = None
+    lef_paths: list[str] = dc_field(default_factory=list)
 
     def get_effort_name(self) -> str | None:
         return self.effort
@@ -226,6 +227,9 @@ class SynthConfig:
 
     def get_platform(self) -> str | None:
         return self.platform
+
+    def get_lef_paths(self) -> list[str]:
+        return list(self.lef_paths)
 
     def get_tool_name(self) -> str:
         return self.tool

--- a/src/rtl_buddy/config/synth.py
+++ b/src/rtl_buddy/config/synth.py
@@ -15,29 +15,48 @@ logger = logging.getLogger(__name__)
 
 
 @serde
-class SynthLibConfigFile:
+class SynthPlatformConfigFile:
     name: str
-    path: str
+    pdk: str
+    corner: str = ""
     lef_paths: list[str] = field(rename="lef-paths", default_factory=list)
 
 
-class SynthLibConfig:
-    def __init__(self, cfg: SynthLibConfigFile, root_cfg_path: str):
+class SynthPlatformConfig:
+    """A synthesis-side view of a PDK + corner selection.
+
+    Backends consume `get_path()` (Liberty for STA / tech mapping) and
+    `get_lef_paths()` (cell + tech LEF, plus any block-specific extras).
+    """
+
+    def __init__(self, cfg: SynthPlatformConfigFile, root_cfg_path: str, pdk_lookup):
         self._name = cfg.name
-        _cfg_dir = os.path.dirname(root_cfg_path)
-        self._path = os.path.normpath(os.path.join(_cfg_dir, cfg.path))
-        self._lef_paths = [
-            os.path.normpath(os.path.join(_cfg_dir, p)) for p in cfg.lef_paths
+        self._pdk_name = cfg.pdk
+        cfg_dir = os.path.dirname(root_cfg_path)
+        self._extra_lefs = [
+            os.path.normpath(os.path.join(cfg_dir, p)) for p in cfg.lef_paths
         ]
+
+        pdk = pdk_lookup(cfg.pdk)
+        self._corner = cfg.corner or pdk.get_default_corner()
+        self._lib_path = pdk.get_corner_path(self._corner)
+        pdk_lefs = [p for p in (pdk.get_tech_lef(), pdk.get_macro_lef()) if p]
+        self._lef_paths = pdk_lefs + self._extra_lefs
 
     def get_name(self) -> str:
         return self._name
 
+    def get_pdk_name(self) -> str:
+        return self._pdk_name
+
+    def get_corner(self) -> str:
+        return self._corner
+
     def get_path(self) -> str:
-        return self._path
+        return self._lib_path
 
     def get_lef_paths(self) -> list[str]:
-        return self._lef_paths
+        return list(self._lef_paths)
 
 
 @dataclass
@@ -141,7 +160,7 @@ class SynthConfigFile:
     constraints: str | None = None
     params: dict | None = None
     defines: dict | None = None
-    libraries: list[str] | None = None
+    platform: str | None = None
     reglvl: int | dict | None = field(rename="reglvl", default=None)
     tool_overrides: dict | None = None
     effort: str | None = None
@@ -163,7 +182,7 @@ class SynthConfigFile:
             constraints=constraints,
             params=self.params,
             defines=self.defines,
-            libraries=self.libraries,
+            platform=self.platform,
             _reglvl=self.reglvl,
             tool_overrides=self.tool_overrides,
             effort=self.effort,
@@ -179,7 +198,7 @@ class SynthConfig:
     constraints: str | None
     params: dict | None
     defines: dict | None
-    libraries: list[str] | None
+    platform: str | None
     _reglvl: int | dict | None
     tool_overrides: dict | None
     effort: str | None = None
@@ -205,8 +224,8 @@ class SynthConfig:
     def get_defines(self) -> dict | None:
         return self.defines
 
-    def get_libraries(self) -> list[str] | None:
-        return self.libraries
+    def get_platform(self) -> str | None:
+        return self.platform
 
     def get_tool_name(self) -> str:
         return self.tool

--- a/src/rtl_buddy/logging_utils.py
+++ b/src/rtl_buddy/logging_utils.py
@@ -343,14 +343,14 @@ def _human_message(event: str, fields: Mapping[str, Any]) -> str:
         case "synth.openroad.no_lef":
             return (
                 f'OpenROAD synthesis "{fields.get("synth")}" requires LEF files; '
-                "set tech-lef / macro-lef on the referenced cfg-pdk entry "
-                "or lef-paths on the cfg-synth-platforms entry"
+                "set tech-lef / macro-lef on the referenced cfg-pdks entry "
+                "or lef-paths on the synth.yaml entry"
             )
         case "synth.openroad.no_library":
             return (
                 f'OpenROAD synthesis "{fields.get("synth")}" requires a mapped library; '
                 "set platform: <name> in synth.yaml and define a cfg-synth-platforms "
-                "entry pointing at a cfg-pdk corner"
+                "entry pointing at a cfg-pdks corner"
             )
         case "coverage.metric.failed":
             return (

--- a/src/rtl_buddy/logging_utils.py
+++ b/src/rtl_buddy/logging_utils.py
@@ -342,13 +342,15 @@ def _human_message(event: str, fields: Mapping[str, Any]) -> str:
             return f'no create_clock found in SDC "{fields.get("sdc")}"; abc runs unconstrained'
         case "synth.openroad.no_lef":
             return (
-                f'OpenROAD synthesis "{fields.get("synth")}" requires lef-paths in cfg-synth-libs; '
-                "add LEF files for the technology library"
+                f'OpenROAD synthesis "{fields.get("synth")}" requires LEF files; '
+                "set tech-lef / macro-lef on the referenced cfg-pdk entry "
+                "or lef-paths on the cfg-synth-platforms entry"
             )
         case "synth.openroad.no_library":
             return (
                 f'OpenROAD synthesis "{fields.get("synth")}" requires a mapped library; '
-                "add libraries: [...] and lef-paths: [...] to cfg-synth-libs"
+                "set platform: <name> in synth.yaml and define a cfg-synth-platforms "
+                "entry pointing at a cfg-pdk corner"
             )
         case "coverage.metric.failed":
             return (

--- a/src/rtl_buddy/pnr/__init__.py
+++ b/src/rtl_buddy/pnr/__init__.py
@@ -1,0 +1,1 @@
+# rtl-buddy pnr — bundled OpenROAD Tcl templates and helpers.

--- a/src/rtl_buddy/pnr/flow.tcl.template
+++ b/src/rtl_buddy/pnr/flow.tcl.template
@@ -1,0 +1,110 @@
+# OpenROAD P&R flow — templated by rb pnr.
+#
+# Placeholders are substituted by Python before invoking openroad; no
+# user-edits should be required. Stage order:
+#   read -> floorplan -> pins -> tie cells -> global place -> resize ->
+#   legalize -> CTS -> detail place -> route -> fill -> reports.
+
+set DESIGN          {{ design }}
+set NETLIST         {{ netlist }}
+set SDC_FILE        {{ sdc }}
+
+set LIBERTY         {{ liberty }}
+set TECH_LEF        {{ tech_lef }}
+set MACRO_LEF       {{ macro_lef }}
+
+set SITE            {{ site }}
+set CORE_UTIL_PCT   {{ util_pct }}
+set CORE_ASPECT     {{ aspect }}
+set CORE_MARGIN     {{ core_margin }}
+
+set TIEHI_CELL_PORT {{ tie_hi }}
+set TIELO_CELL_PORT {{ tie_lo }}
+set CTS_BUF         {{ cts_buf }}
+set SIGNAL_LAYERS   {{ signal_layers }}
+set CLOCK_LAYERS    {{ clock_layers }}
+
+set FILL_CELLS      [list {{ fill_cells }}]
+
+set OUT_DIR         {{ out_dir }}
+file mkdir $OUT_DIR
+
+puts ">>> Reading Liberty + LEF"
+read_liberty $LIBERTY
+read_lef     $TECH_LEF
+read_lef     $MACRO_LEF
+
+puts ">>> Reading netlist"
+read_verilog $NETLIST
+link_design  $DESIGN
+
+puts ">>> Reading SDC"
+read_sdc $SDC_FILE
+
+puts ">>> Initializing floorplan"
+initialize_floorplan \
+    -site         $SITE \
+    -utilization  $CORE_UTIL_PCT \
+    -aspect_ratio $CORE_ASPECT \
+    -core_space   $CORE_MARGIN
+make_tracks
+
+puts ">>> IO pin placement"
+place_pins -hor_layers metal3 -ver_layers metal2
+
+puts ">>> Tie cells"
+if {[string length $TIEHI_CELL_PORT] > 0} { insert_tiecells $TIEHI_CELL_PORT }
+if {[string length $TIELO_CELL_PORT] > 0} { insert_tiecells $TIELO_CELL_PORT }
+
+puts ">>> Global placement"
+global_placement -density 0.7 -pad_left 1 -pad_right 1
+
+puts ">>> Resize"
+estimate_parasitics -placement
+repair_design
+
+puts ">>> Detail placement (legalize)"
+detailed_placement
+
+puts ">>> Clock tree synthesis"
+set_propagated_clock [all_clocks]
+clock_tree_synthesis \
+    -root_buf $CTS_BUF \
+    -buf_list $CTS_BUF \
+    -sink_clustering_enable
+
+puts ">>> Detail placement (post-CTS)"
+detailed_placement
+
+puts ">>> Post-CTS timing repair"
+estimate_parasitics -placement
+repair_timing -hold
+
+puts ">>> Global route"
+set_routing_layers -signal $SIGNAL_LAYERS -clock $CLOCK_LAYERS
+global_route -congestion_iterations 20
+
+puts ">>> Detail route"
+detailed_route \
+    -output_drc  $OUT_DIR/route.drc.rpt \
+    -output_maze $OUT_DIR/route.maze.log \
+    -verbose 0
+
+puts ">>> Fill insertion"
+filler_placement $FILL_CELLS
+
+puts ">>> Final reports"
+estimate_parasitics -global_routing
+report_design_area
+report_worst_slack -max
+report_worst_slack -min
+report_tns
+report_checks -path_delay max -fields {slew cap input nets fanout} -format full_clock_expanded > $OUT_DIR/timing.rpt
+
+puts ">>> Write outputs"
+write_def     $OUT_DIR/${DESIGN}.def
+write_verilog $OUT_DIR/${DESIGN}.routed.v
+write_sdc     $OUT_DIR/${DESIGN}.routed.sdc
+
+puts ">>> DONE"
+exit 0

--- a/src/rtl_buddy/pnr/klayout/def2stream.py
+++ b/src/rtl_buddy/pnr/klayout/def2stream.py
@@ -1,0 +1,151 @@
+try:
+    import pya
+except ImportError:
+    pya = None
+
+import re
+import sys
+import os
+
+
+def merge_gds(
+    pya_mod,
+    tech_file,
+    layer_map,
+    in_def,
+    design_name,
+    in_files,
+    seal_file,
+    out_file,
+    allow_empty="",
+):
+    """Merge DEF and GDS/OAS files into a single stream file.
+
+    Args:
+        pya_mod: The pya module (klayout Python API).
+        tech_file: Path to klayout technology file.
+        layer_map: Path to layer map file (empty string if none).
+        in_def: Path to input DEF file.
+        design_name: Top-level design name.
+        in_files: Space-separated string of GDS/OAS files to merge.
+        seal_file: Path to seal ring GDS/OAS file (empty string if none).
+        out_file: Path to output GDS/OAS file.
+        allow_empty: Regex pattern for cells allowed to be empty.
+
+    Returns:
+        Number of errors encountered.
+    """
+    errors = 0
+
+    # Load technology file
+    tech = pya_mod.Technology()
+    tech.load(tech_file)
+    layout_options = tech.load_layout_options
+    if len(layer_map) > 0:
+        layout_options.lefdef_config.map_file = layer_map
+
+    # Load def file
+    main_layout = pya_mod.Layout()
+    print("[INFO] Reporting cells prior to loading DEF ...")
+    for i in main_layout.each_cell():
+        print("[INFO] '{0}'".format(i.name))
+
+    main_layout.read(in_def, layout_options)
+
+    # Clear cells
+    top_cell_index = main_layout.cell(design_name).cell_index()
+
+    # remove orphan cell BUT preserve cell with VIA_
+    #  - KLayout is prepending VIA_ when reading DEF that instantiates LEF's via
+    for i in main_layout.each_cell():
+        if i.cell_index() != top_cell_index:
+            if not i.name.startswith("VIA_") and not i.name.endswith("_DEF_FILL"):
+                i.clear()
+
+    # Load in the gds to merge
+    for fil in in_files.split():
+        print("\t{0}".format(fil))
+        main_layout.read(fil)
+
+    # Copy the top level only to a new layout
+    top_only_layout = pya_mod.Layout()
+    top_only_layout.dbu = main_layout.dbu
+    top = top_only_layout.create_cell(design_name)
+    top.copy_tree(main_layout.cell(design_name))
+
+    missing_cell = False
+    regex = re.compile(allow_empty) if allow_empty else None
+
+    if allow_empty:
+        print(f"[INFO] GDS_ALLOW_EMPTY={allow_empty}")
+
+    for i in top_only_layout.each_cell():
+        if i.is_empty():
+            missing_cell = True
+            if regex is not None and regex.match(i.name):
+                print(
+                    "[WARNING] LEF Cell '{0}' ignored. Matches GDS_ALLOW_EMPTY.".format(
+                        i.name
+                    )
+                )
+            else:
+                print(
+                    "[ERROR] LEF Cell '{0}' has no matching GDS/OAS cell."
+                    " Cell will be empty.".format(i.name)
+                )
+                errors += 1
+
+    if not missing_cell:
+        print("[INFO] All LEF cells have matching GDS/OAS cells")
+
+    orphan_cell = False
+    for i in top_only_layout.each_cell():
+        if i.name != design_name and i.parent_cells() == 0:
+            orphan_cell = True
+            print("[ERROR] Found orphan cell '{0}'".format(i.name))
+            errors += 1
+
+    if not orphan_cell:
+        print("[INFO] No orphan cells in the final layout")
+
+    if seal_file:
+        top_cell = top_only_layout.top_cell()
+
+        top_only_layout.read(seal_file)
+
+        for cell in top_only_layout.top_cells():
+            if cell != top_cell:
+                print(
+                    "[INFO] Merging '{0}' as child of '{1}'".format(
+                        cell.name, top_cell.name
+                    )
+                )
+                top.insert(pya_mod.CellInstArray(cell.cell_index(), pya_mod.Trans()))
+
+    # Write out the GDS
+    top_only_layout.write(out_file)
+
+    return errors
+
+
+# When run via klayout -r, globals tech_file, layer_map, in_def, etc.
+# are set by klayout's -rd mechanism.
+if pya is not None:
+    try:
+        # These globals are set by klayout -rd flags
+        sys.exit(
+            merge_gds(
+                pya_mod=pya,
+                tech_file=tech_file,  # noqa: F821 - set by klayout -rd
+                layer_map=layer_map,  # noqa: F821
+                in_def=in_def,  # noqa: F821
+                design_name=design_name,  # noqa: F821
+                in_files=in_files,  # noqa: F821
+                seal_file=seal_file,  # noqa: F821
+                out_file=out_file,  # noqa: F821
+                allow_empty=os.environ.get("GDS_ALLOW_EMPTY", ""),
+            )
+        )
+    except NameError:
+        # Not running under klayout -r, pya available but no -rd globals
+        pass

--- a/src/rtl_buddy/pnr/klayout/gds2png.py
+++ b/src/rtl_buddy/pnr/klayout/gds2png.py
@@ -1,0 +1,19 @@
+# Headless GDS -> PNG renderer driven by KLayout.
+#
+# Invoked as:
+#   klayout -zz -nc \
+#     -rd in_gds=... -rd lyp_file=... \
+#     -rd out_png=... -rd width=2048 -rd height=2048 \
+#     -r tools/openroad/gds2png.py
+#
+# All inputs come in via klayout `-rd` globals; pya is the klayout
+# Python API, only available inside a klayout invocation.
+import pya  # noqa: F401 - provided by klayout -r runtime
+
+lv = pya.LayoutView()
+lv.load_layout(in_gds, 0)  # noqa: F821 - set by klayout -rd
+if lyp_file:  # noqa: F821
+    lv.load_layer_props(lyp_file)  # noqa: F821
+lv.max_hier()
+lv.zoom_fit()
+lv.save_image(out_png, int(width), int(height))  # noqa: F821

--- a/src/rtl_buddy/rtl_buddy.py
+++ b/src/rtl_buddy/rtl_buddy.py
@@ -1525,7 +1525,9 @@ class RtlBuddy:
         ] = None,
         list_runs: Annotated[
             bool,
-            typer.Option("--list", help="list pnr runs in the selected config and exit"),
+            typer.Option(
+                "--list", help="list pnr runs in the selected config and exit"
+            ),
         ] = False,
         reg_level: Annotated[
             int,
@@ -1551,13 +1553,9 @@ class RtlBuddy:
             emit_console_text("  ".join(suite_cfg.get_run_names()), stream="stdout")
             raise typer.Exit(0)
 
-        results = self._do_pnr_suite(
-            suite_cfg, pnr_name=pnr_name, reg_level=reg_level
-        )
+        results = self._do_pnr_suite(suite_cfg, pnr_name=pnr_name, reg_level=reg_level)
         self._render_pnr_summary("P&R Results Summary", results)
-        raise typer.Exit(
-            0 if all(r["results"].is_pass() for r in results) else 1
-        )
+        raise typer.Exit(0 if all(r["results"].is_pass() for r in results) else 1)
 
     def _do_pnr_suite(self, suite_cfg, *, pnr_name=None, reg_level=0):
         root_cfg = RootConfig(name="pnr")
@@ -1580,9 +1578,7 @@ class RtlBuddy:
                         "pnr_name": run.get_name(),
                         "results": PnrSkipResults(
                             name=f"{run.get_name()}/results",
-                            desc=(
-                                f"reglvl {run.get_reglvl()} above {reg_level}"
-                            ),
+                            desc=(f"reglvl {run.get_reglvl()} above {reg_level}"),
                         ),
                     }
                 )
@@ -1594,9 +1590,7 @@ class RtlBuddy:
                 suite_dir=suite_dir,
                 reglvl_filter=reg_level if reg_level else None,
             )
-            results.append(
-                {"pnr_name": run.get_name(), "results": runner.run()}
-            )
+            results.append({"pnr_name": run.get_name(), "results": runner.run()})
         return results
 
     def _render_pnr_summary(self, title, pnr_results, *, metadata=None):

--- a/src/rtl_buddy/rtl_buddy.py
+++ b/src/rtl_buddy/rtl_buddy.py
@@ -1593,14 +1593,15 @@ class RtlBuddy:
         suite_dir = str(Path(suite_cfg.get_path()).resolve().parent)
         results = []
         for run in runs:
-            if reg_level is not None and run.get_reglvl() > reg_level:
+            pnr_level = run.get_reglvl(run.get_tool_name())
+            if reg_level is not None and pnr_level > reg_level:
                 log_event(
                     logger,
                     logging.INFO,
                     "pnr_suite.skip",
                     pnr=run.get_name(),
                     reason="above_regression_level",
-                    pnr_level=run.get_reglvl(),
+                    pnr_level=pnr_level,
                     reg_level=reg_level,
                 )
                 results.append(
@@ -1608,7 +1609,7 @@ class RtlBuddy:
                         "pnr_name": run.get_name(),
                         "results": PnrSkipResults(
                             name=f"{run.get_name()}/results",
-                            desc=(f"reglvl {run.get_reglvl()} above {reg_level}"),
+                            desc=(f"reglvl {pnr_level} above {reg_level}"),
                         ),
                     }
                 )

--- a/src/rtl_buddy/rtl_buddy.py
+++ b/src/rtl_buddy/rtl_buddy.py
@@ -17,6 +17,7 @@ import click
 from .config import RegConfig, RootConfig, SuiteConfig, TestConfig
 from .config.cdc import CdcRegConfig, CdcSuiteConfig
 from .config.model import ModelConfigLoader
+from .config.pnr import PnrSuiteConfig
 from .config.synth import SynthRegConfig, SynthSuiteConfig
 from .docs_access import get_page, get_section, list_pages
 from .errors import FatalRtlBuddyError, FilelistError
@@ -31,6 +32,8 @@ from .runner.cdc_runner import CdcRunner
 from .runner.cdc_results import CdcSkipResults
 from .runner.test_results import SetupFailResults, SkipResults
 from .runner.test_runner import RunDepth, TestRunner
+from .runner.pnr_runner import PnrRunner
+from .runner.pnr_results import PnrSkipResults
 from .runner.synth_runner import SynthRunner
 from .runner.synth_results import SynthSkipResults
 from .seed_mode import SeedMode
@@ -120,6 +123,7 @@ class RtlBuddy:
         self.app.command("synth-regression", help="run synthesis regression")(
             self.do_synth_regression
         )
+        self.app.command("pnr", help="run place-and-route")(self.do_cmd_pnr)
         self.app.command("cdc", help="run CDC lint")(self.do_cmd_cdc)
         self.app.command("cdc-regression", help="run CDC lint regression")(
             self.do_cdc_regression
@@ -1506,6 +1510,157 @@ class RtlBuddy:
         )
         self._render_synth_summary("Synthesis Results Summary", synth_results)
         raise typer.Exit(self._exit_code_from_synth_results(synth_results))
+
+    def do_cmd_pnr(
+        self,
+        pnr_config: Annotated[
+            str,
+            typer.Option("-c", "--pnr-config", help="pnr.yaml to use"),
+        ] = "pnr.yaml",
+        pnr_name: Annotated[
+            str,
+            typer.Argument(
+                help="name of pnr run", show_default="run all entries in the suite"
+            ),
+        ] = None,
+        list_runs: Annotated[
+            bool,
+            typer.Option("--list", help="list pnr runs in the selected config and exit"),
+        ] = False,
+        reg_level: Annotated[
+            int,
+            typer.Option(
+                "-l",
+                "--reg-level",
+                help="run only entries with reglvl at or below this value",
+            ),
+        ] = 0,
+    ):
+        """run place-and-route"""
+        suite_cfg = PnrSuiteConfig(path=pnr_config)
+        log_event(
+            logger,
+            logging.INFO,
+            "command.pnr",
+            command="pnr",
+            pnr=pnr_name or "all",
+            pnr_config=pnr_config,
+        )
+
+        if list_runs:
+            emit_console_text("  ".join(suite_cfg.get_run_names()), stream="stdout")
+            raise typer.Exit(0)
+
+        results = self._do_pnr_suite(
+            suite_cfg, pnr_name=pnr_name, reg_level=reg_level
+        )
+        self._render_pnr_summary("P&R Results Summary", results)
+        raise typer.Exit(
+            0 if all(r["results"].is_pass() for r in results) else 1
+        )
+
+    def _do_pnr_suite(self, suite_cfg, *, pnr_name=None, reg_level=0):
+        root_cfg = RootConfig(name="pnr")
+        runs = suite_cfg.get_runs(pnr_name)
+        suite_dir = str(Path(suite_cfg.get_path()).resolve().parent)
+        results = []
+        for run in runs:
+            if reg_level is not None and run.get_reglvl() > reg_level:
+                log_event(
+                    logger,
+                    logging.INFO,
+                    "pnr_suite.skip",
+                    pnr=run.get_name(),
+                    reason="above_regression_level",
+                    pnr_level=run.get_reglvl(),
+                    reg_level=reg_level,
+                )
+                results.append(
+                    {
+                        "pnr_name": run.get_name(),
+                        "results": PnrSkipResults(
+                            name=f"{run.get_name()}/results",
+                            desc=(
+                                f"reglvl {run.get_reglvl()} above {reg_level}"
+                            ),
+                        ),
+                    }
+                )
+                continue
+            runner = PnrRunner(
+                name=run.get_name(),
+                root_cfg=root_cfg,
+                pnr_cfg=run,
+                suite_dir=suite_dir,
+                reglvl_filter=reg_level if reg_level else None,
+            )
+            results.append(
+                {"pnr_name": run.get_name(), "results": runner.run()}
+            )
+        return results
+
+    def _render_pnr_summary(self, title, pnr_results, *, metadata=None):
+        has_cells = any("cell_count" in r["results"].results for r in pnr_results)
+        has_area = any("area_um2" in r["results"].results for r in pnr_results)
+        has_setup = any("wns_setup_ps" in r["results"].results for r in pnr_results)
+        has_hold = any("wns_hold_ps" in r["results"].results for r in pnr_results)
+        has_drcs = any("drc_count" in r["results"].results for r in pnr_results)
+        rows = []
+        for r in pnr_results:
+            res = r["results"].results
+            row = {
+                "pnr_name": r["pnr_name"],
+                "result": res["result"],
+                "desc": res["desc"],
+            }
+            if has_cells:
+                row["cells"] = (
+                    str(res["cell_count"]) if res.get("cell_count") is not None else "-"
+                )
+            if has_area:
+                area = res.get("area_um2")
+                row["area"] = f"{area:.2f} µm²" if area is not None else "-"
+            if has_setup:
+                wns = res.get("wns_setup_ps")
+                row["wns_setup"] = (
+                    f"{'+' if wns >= 0 else ''}{wns / 1000:.3f} ns"
+                    if wns is not None
+                    else "-"
+                )
+            if has_hold:
+                wns = res.get("wns_hold_ps")
+                row["wns_hold"] = (
+                    f"{'+' if wns >= 0 else ''}{wns / 1000:.3f} ns"
+                    if wns is not None
+                    else "-"
+                )
+            if has_drcs:
+                drcs = res.get("drc_count")
+                row["drcs"] = str(drcs) if drcs is not None else "-"
+            rows.append(row)
+
+        columns = [
+            ("pnr_name", "P&R Run"),
+            ("result", "Result"),
+            ("desc", "Description"),
+        ]
+        if has_cells:
+            columns.append(("cells", "Cells"))
+        if has_area:
+            columns.append(("area", "Area"))
+        if has_setup:
+            columns.append(("wns_setup", "WNS Setup"))
+        if has_hold:
+            columns.append(("wns_hold", "WNS Hold"))
+        if has_drcs:
+            columns.append(("drcs", "DRCs"))
+        render_summary(
+            title=title,
+            columns=columns,
+            rows=rows,
+            logger=logger,
+            metadata=metadata,
+        )
 
     def do_synth_regression(
         self,

--- a/src/rtl_buddy/rtl_buddy.py
+++ b/src/rtl_buddy/rtl_buddy.py
@@ -1537,9 +1537,25 @@ class RtlBuddy:
                 help="run only entries with reglvl at or below this value",
             ),
         ] = 0,
+        emit_gds: Annotated[
+            bool,
+            typer.Option(
+                "--gds",
+                help="stream out GDS via KLayout after a successful P&R",
+            ),
+        ] = False,
+        emit_png: Annotated[
+            bool,
+            typer.Option(
+                "--png",
+                help="render a PNG of the routed GDS via KLayout (implies --gds)",
+            ),
+        ] = False,
     ):
         """run place-and-route"""
         suite_cfg = PnrSuiteConfig(path=pnr_config)
+        if emit_png:
+            emit_gds = True
         log_event(
             logger,
             logging.INFO,
@@ -1553,11 +1569,25 @@ class RtlBuddy:
             emit_console_text("  ".join(suite_cfg.get_run_names()), stream="stdout")
             raise typer.Exit(0)
 
-        results = self._do_pnr_suite(suite_cfg, pnr_name=pnr_name, reg_level=reg_level)
+        results = self._do_pnr_suite(
+            suite_cfg,
+            pnr_name=pnr_name,
+            reg_level=reg_level,
+            emit_gds=emit_gds,
+            emit_png=emit_png,
+        )
         self._render_pnr_summary("P&R Results Summary", results)
         raise typer.Exit(0 if all(r["results"].is_pass() for r in results) else 1)
 
-    def _do_pnr_suite(self, suite_cfg, *, pnr_name=None, reg_level=0):
+    def _do_pnr_suite(
+        self,
+        suite_cfg,
+        *,
+        pnr_name=None,
+        reg_level=0,
+        emit_gds: bool = False,
+        emit_png: bool = False,
+    ):
         root_cfg = RootConfig(name="pnr")
         runs = suite_cfg.get_runs(pnr_name)
         suite_dir = str(Path(suite_cfg.get_path()).resolve().parent)
@@ -1589,6 +1619,8 @@ class RtlBuddy:
                 pnr_cfg=run,
                 suite_dir=suite_dir,
                 reglvl_filter=reg_level if reg_level else None,
+                emit_gds=emit_gds,
+                emit_png=emit_png,
             )
             results.append({"pnr_name": run.get_name(), "results": runner.run()})
         return results
@@ -1599,6 +1631,10 @@ class RtlBuddy:
         has_setup = any("wns_setup_ps" in r["results"].results for r in pnr_results)
         has_hold = any("wns_hold_ps" in r["results"].results for r in pnr_results)
         has_drcs = any("drc_count" in r["results"].results for r in pnr_results)
+        has_outputs = any(
+            "gds_path" in r["results"].results or "png_path" in r["results"].results
+            for r in pnr_results
+        )
         rows = []
         for r in pnr_results:
             res = r["results"].results
@@ -1631,6 +1667,13 @@ class RtlBuddy:
             if has_drcs:
                 drcs = res.get("drc_count")
                 row["drcs"] = str(drcs) if drcs is not None else "-"
+            if has_outputs:
+                tags = []
+                if res.get("gds_path"):
+                    tags.append("gds")
+                if res.get("png_path"):
+                    tags.append("png")
+                row["outputs"] = "+".join(tags) if tags else "-"
             rows.append(row)
 
         columns = [
@@ -1648,6 +1691,8 @@ class RtlBuddy:
             columns.append(("wns_hold", "WNS Hold"))
         if has_drcs:
             columns.append(("drcs", "DRCs"))
+        if has_outputs:
+            columns.append(("outputs", "Outputs"))
         render_summary(
             title=title,
             columns=columns,

--- a/src/rtl_buddy/runner/pnr_results.py
+++ b/src/rtl_buddy/runner/pnr_results.py
@@ -30,6 +30,8 @@ class PnrPassResults(PnrResults):
         wns_hold_ps: float | None = None,
         tns_ps: float | None = None,
         drc_count: int | None = None,
+        gds_path: str | None = None,
+        png_path: str | None = None,
     ):
         super().__init__(
             name=name,
@@ -47,6 +49,10 @@ class PnrPassResults(PnrResults):
             self.results["tns_ps"] = tns_ps
         if drc_count is not None:
             self.results["drc_count"] = drc_count
+        if gds_path is not None:
+            self.results["gds_path"] = gds_path
+        if png_path is not None:
+            self.results["png_path"] = png_path
 
 
 class PnrFailResults(PnrResults):

--- a/src/rtl_buddy/runner/pnr_results.py
+++ b/src/rtl_buddy/runner/pnr_results.py
@@ -1,0 +1,65 @@
+import pprint
+
+
+class PnrResults:
+    def __init__(self, name, results=None):
+        if results is None:
+            results = {"result": "NA", "desc": "NA"}
+        self.name = name
+        self.results = results
+        if "result" not in results:
+            results["result"] = "NA"
+        if "desc" not in results:
+            results["desc"] = "NA"
+
+    def is_pass(self):
+        return self.results["result"] in ("PASS", "SKIP")
+
+    def __str__(self):
+        return "pnr_results: " + pprint.pformat(self.results)
+
+
+class PnrPassResults(PnrResults):
+    def __init__(
+        self,
+        name,
+        *,
+        area_um2: float | None = None,
+        cell_count: int | None = None,
+        wns_setup_ps: float | None = None,
+        wns_hold_ps: float | None = None,
+        tns_ps: float | None = None,
+        drc_count: int | None = None,
+    ):
+        super().__init__(
+            name=name,
+            results={"result": "PASS", "name": name, "desc": "P&R passed"},
+        )
+        if area_um2 is not None:
+            self.results["area_um2"] = area_um2
+        if cell_count is not None:
+            self.results["cell_count"] = cell_count
+        if wns_setup_ps is not None:
+            self.results["wns_setup_ps"] = wns_setup_ps
+        if wns_hold_ps is not None:
+            self.results["wns_hold_ps"] = wns_hold_ps
+        if tns_ps is not None:
+            self.results["tns_ps"] = tns_ps
+        if drc_count is not None:
+            self.results["drc_count"] = drc_count
+
+
+class PnrFailResults(PnrResults):
+    def __init__(self, name, desc):
+        super().__init__(
+            name=name,
+            results={"result": "FAIL", "name": name, "desc": desc},
+        )
+
+
+class PnrSkipResults(PnrResults):
+    def __init__(self, name, desc):
+        super().__init__(
+            name=name,
+            results={"result": "SKIP", "name": name, "desc": desc},
+        )

--- a/src/rtl_buddy/runner/pnr_runner.py
+++ b/src/rtl_buddy/runner/pnr_runner.py
@@ -1,0 +1,58 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+from ..config.pnr import PnrConfig
+from ..logging_utils import log_event
+from ..runner.pnr_results import PnrResults, PnrSkipResults
+from ..tools.pnr_openroad import OpenRoadPnr
+
+
+class PnrRunner:
+    def __init__(
+        self,
+        name: str,
+        root_cfg,
+        pnr_cfg: PnrConfig,
+        suite_dir: str,
+        reglvl_filter: int | None = None,
+    ):
+        self.name = name
+        self.root_cfg = root_cfg
+        self.pnr_cfg = pnr_cfg
+        self.suite_dir = suite_dir
+        self.reglvl_filter = reglvl_filter
+
+    def run(self) -> PnrResults:
+        log_event(
+            logger,
+            logging.DEBUG,
+            "pnr_runner.start",
+            runner=self.name,
+            pnr=self.pnr_cfg.get_name(),
+        )
+
+        if self.reglvl_filter is not None:
+            cfg_reglvl = self.pnr_cfg.get_reglvl()
+            if cfg_reglvl > self.reglvl_filter:
+                return PnrSkipResults(
+                    name=self.name + "/results",
+                    desc=(
+                        f"reglvl {cfg_reglvl} above filter {self.reglvl_filter}"
+                    ),
+                )
+
+        tool_name = self.pnr_cfg.get_tool_name()
+        if tool_name != "openroad":
+            return PnrSkipResults(
+                name=self.name + "/results",
+                desc=f"unsupported pnr tool '{tool_name}' (only 'openroad' today)",
+            )
+
+        backend = OpenRoadPnr(
+            name=self.name + "/openroad",
+            pnr_cfg=self.pnr_cfg,
+            suite_dir=self.suite_dir,
+            root_cfg=self.root_cfg,
+        )
+        return backend.run()

--- a/src/rtl_buddy/runner/pnr_runner.py
+++ b/src/rtl_buddy/runner/pnr_runner.py
@@ -37,7 +37,7 @@ class PnrRunner:
         )
 
         if self.reglvl_filter is not None:
-            cfg_reglvl = self.pnr_cfg.get_reglvl()
+            cfg_reglvl = self.pnr_cfg.get_reglvl(self.pnr_cfg.get_tool_name())
             if cfg_reglvl > self.reglvl_filter:
                 return PnrSkipResults(
                     name=self.name + "/results",
@@ -45,6 +45,12 @@ class PnrRunner:
                 )
 
         tool_name = self.pnr_cfg.get_tool_name()
+        tool_cfg = (
+            self.root_cfg.get_pnr_tool_cfg(tool_name)
+            if self.root_cfg is not None
+            else None
+        )
+        executable = tool_cfg.get_executable() if tool_cfg is not None else tool_name
         if tool_name != "openroad":
             return PnrSkipResults(
                 name=self.name + "/results",
@@ -56,6 +62,7 @@ class PnrRunner:
             pnr_cfg=self.pnr_cfg,
             suite_dir=self.suite_dir,
             root_cfg=self.root_cfg,
+            openroad_executable=executable,
             emit_gds=self.emit_gds,
             emit_png=self.emit_png,
         )

--- a/src/rtl_buddy/runner/pnr_runner.py
+++ b/src/rtl_buddy/runner/pnr_runner.py
@@ -37,9 +37,7 @@ class PnrRunner:
             if cfg_reglvl > self.reglvl_filter:
                 return PnrSkipResults(
                     name=self.name + "/results",
-                    desc=(
-                        f"reglvl {cfg_reglvl} above filter {self.reglvl_filter}"
-                    ),
+                    desc=(f"reglvl {cfg_reglvl} above filter {self.reglvl_filter}"),
                 )
 
         tool_name = self.pnr_cfg.get_tool_name()

--- a/src/rtl_buddy/runner/pnr_runner.py
+++ b/src/rtl_buddy/runner/pnr_runner.py
@@ -16,12 +16,16 @@ class PnrRunner:
         pnr_cfg: PnrConfig,
         suite_dir: str,
         reglvl_filter: int | None = None,
+        emit_gds: bool = False,
+        emit_png: bool = False,
     ):
         self.name = name
         self.root_cfg = root_cfg
         self.pnr_cfg = pnr_cfg
         self.suite_dir = suite_dir
         self.reglvl_filter = reglvl_filter
+        self.emit_gds = emit_gds
+        self.emit_png = emit_png
 
     def run(self) -> PnrResults:
         log_event(
@@ -52,5 +56,7 @@ class PnrRunner:
             pnr_cfg=self.pnr_cfg,
             suite_dir=self.suite_dir,
             root_cfg=self.root_cfg,
+            emit_gds=self.emit_gds,
+            emit_png=self.emit_png,
         )
         return backend.run()

--- a/src/rtl_buddy/skill/SKILL.md
+++ b/src/rtl_buddy/skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rtl-buddy
-description: Use rtl_buddy to orchestrate SystemVerilog compile/sim workflows, randomized tests, regressions, synthesis flows, filelist generation, and verible checks. Trigger this skill when asked to run or debug rtl_buddy commands or interpret root_config.yaml, tests.yaml, models.yaml, regression.yaml, synth.yaml, or synth_regression.yaml.
+description: Use rtl_buddy to orchestrate SystemVerilog compile/sim workflows, randomized tests, regressions, synthesis, place-and-route, filelist generation, and verible checks. Trigger this skill when asked to run or debug rtl_buddy commands or interpret root_config.yaml, tests.yaml, models.yaml, regression.yaml, synth.yaml, synth_regression.yaml, or pnr.yaml.
 ---
 
 # rtl_buddy
@@ -26,12 +26,13 @@ This skill ships with the CLI, so its content matches the installed major. Surfa
 
 Use `rtl-buddy --machine docs show reference/yaml` for exact schemas.
 
-- **`root_config.yaml`** — project root, platform/build defaults, regression default path, synthesis tool defaults (`cfg-synth-tools`).
+- **`root_config.yaml`** — project root, platform/build defaults, regression default path, synthesis tool defaults (`cfg-synth-tools`), PDK assets (`cfg-pdk`), synth/P&R platforms (`cfg-synth-platforms`, `cfg-pnr-platforms`).
 - **`regression.yaml`** — repo-level suite list for `regression`.
 - **`tests.yaml`** — suite-level tests/testbenches; run `test` and `randtest` from this directory.
 - **`models.yaml`** — design source filelists referenced by `tests.yaml` and `synth.yaml`.
 - **`synth.yaml`** — synthesis runs; `model` name is the top; `tool` selects `cfg-synth-tools` entry; `params`/`defines`/`tool_overrides` for per-run customization.
 - **`synth_regression.yaml`** — repo-level synthesis suite list for `synth-regression`.
+- **`pnr.yaml`** — P&R runs that consume an upstream `rb synth` artefact; each entry names `synth`/`synth-path`, `platform` (a `cfg-pnr-platforms` entry), and `constraints` (SDC). Only `tool: openroad` today.
 - **`specs.yaml`** — spec traceability data; consumed by `rtl-buddy spec`.
 
 ## Pass/fail detection
@@ -58,6 +59,13 @@ Use `rtl-buddy --machine docs show reference/yaml` for exact schemas.
 - Symlinks `test.log`, `test.err`, `test.randseed` at the suite root point at the latest run.
 - For multi-suite runs, each suite directory has its own `rtl_buddy.log` and `artefacts/`; report logs per suite.
 - Next docs: `rtl-buddy docs show reference/cli`, `rtl-buddy docs show reference/yaml`, `rtl-buddy docs show known-issues`
+
+## Synthesis and P&R
+
+- `rb synth -c synth.yaml [name]` runs synthesis; artefacts land at `<suite>/artefacts/<run>/synth_netlist.v`.
+- `rb pnr -c pnr.yaml [name]` runs OpenROAD P&R against the upstream synth netlist; pass `--gds` for KLayout streamout and `--png` for a layout render (implies `--gds`). KLayout is optional — missing KLayout emits `pnr.no_klayout` and skips streamout, the P&R run still passes.
+- OpenROAD version is logged as `pnr.openroad_version`; below-min builds warn via `pnr.openroad_version_below_min` but still run.
+- See `rtl-buddy docs show concepts/synthesis` and `rtl-buddy docs show concepts/pnr`.
 
 ## Waveform viewing
 

--- a/src/rtl_buddy/skill/SKILL.md
+++ b/src/rtl_buddy/skill/SKILL.md
@@ -7,7 +7,7 @@ description: Use rtl_buddy to orchestrate SystemVerilog compile/sim workflows, r
 
 You are running rtl_buddy a Verilog/SV build and regression helper configured with YAML.
 
-This skill covers agent-specific conventions. Use bundled docs first:
+This skill covers agent-specific conventions. For CLI usage, `rb --help` and `rb <subcommand> --help` are the first stop, then bundled docs:
 `rtl-buddy docs list`, `rtl-buddy docs show agents`, `rtl-buddy --machine docs show reference/yaml`.
 Use <https://rtl-buddy.github.io/rtl_buddy/> only as a fallback reference.
 
@@ -59,13 +59,6 @@ Use `rtl-buddy --machine docs show reference/yaml` for exact schemas.
 - Symlinks `test.log`, `test.err`, `test.randseed` at the suite root point at the latest run.
 - For multi-suite runs, each suite directory has its own `rtl_buddy.log` and `artefacts/`; report logs per suite.
 - Next docs: `rtl-buddy docs show reference/cli`, `rtl-buddy docs show reference/yaml`, `rtl-buddy docs show known-issues`
-
-## Synthesis and P&R
-
-- `rb synth -c synth.yaml [name]` runs synthesis; artefacts land at `<suite>/artefacts/<run>/synth_netlist.v`.
-- `rb pnr -c pnr.yaml [name]` runs OpenROAD P&R against the upstream synth netlist; pass `--gds` for KLayout streamout and `--png` for a layout render (implies `--gds`). KLayout is optional — missing KLayout emits `pnr.no_klayout` and skips streamout, the P&R run still passes.
-- OpenROAD version is logged as `pnr.openroad_version`; below-min builds warn via `pnr.openroad_version_below_min` but still run.
-- See `rtl-buddy docs show concepts/synthesis` and `rtl-buddy docs show concepts/pnr`.
 
 ## Waveform viewing
 

--- a/src/rtl_buddy/skill/SKILL.md
+++ b/src/rtl_buddy/skill/SKILL.md
@@ -26,7 +26,7 @@ This skill ships with the CLI, so its content matches the installed major. Surfa
 
 Use `rtl-buddy --machine docs show reference/yaml` for exact schemas.
 
-- **`root_config.yaml`** — project root, platform/build defaults, regression default path, synthesis tool defaults (`cfg-synth-tools`), PDK assets (`cfg-pdk`), synth/P&R platforms (`cfg-synth-platforms`, `cfg-pnr-platforms`).
+- **`root_config.yaml`** — project root, platform/build defaults, regression default path, synthesis tool defaults (`cfg-synth-tools`), PDK assets (`cfg-pdks`), synth/P&R platforms (`cfg-synth-platforms`, `cfg-pnr-platforms`).
 - **`regression.yaml`** — repo-level suite list for `regression`.
 - **`tests.yaml`** — suite-level tests/testbenches; run `test` and `randtest` from this directory.
 - **`models.yaml`** — design source filelists referenced by `tests.yaml` and `synth.yaml`.

--- a/src/rtl_buddy/tools/pnr_openroad.py
+++ b/src/rtl_buddy/tools/pnr_openroad.py
@@ -15,6 +15,42 @@ from ..runner.pnr_results import PnrFailResults, PnrPassResults, PnrResults
 
 _TEMPLATE_PACKAGE = "rtl_buddy.pnr"
 _TEMPLATE_FILE = "flow.tcl.template"
+_KLAYOUT_PACKAGE = "rtl_buddy.pnr.klayout"
+
+# Minimum OpenROAD release we test against. Older builds may still work for
+# the basic flow but are not validated — we warn rather than refuse.
+MIN_OPENROAD_VERSION = "25Q1"
+
+# Common macOS install locations for KLayout's `klayout` binary when the
+# cask doesn't add itself to PATH.
+_KLAYOUT_FALLBACK_PATHS = (
+    "/Applications/KLayout/klayout.app/Contents/MacOS/klayout",
+    "/Applications/klayout.app/Contents/MacOS/klayout",
+)
+
+
+def _parse_version_token(version: str) -> tuple:
+    """Extract a comparable tuple from an OpenROAD version string.
+
+    Handles `26Q2-911-g...`, `v2.0-1234-g...`, plain `v2.0`. Falls back to
+    the raw string so unknown formats just sort consistently.
+    """
+    m = re.match(r"^v?(\d+)(?:[.Qq](\d+))?", version.strip())
+    if not m:
+        return (version,)
+    major = int(m.group(1))
+    minor = int(m.group(2)) if m.group(2) else 0
+    return (major, minor)
+
+
+def _resolve_klayout_exe() -> str | None:
+    exe = shutil.which("klayout")
+    if exe:
+        return exe
+    for candidate in _KLAYOUT_FALLBACK_PATHS:
+        if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+            return candidate
+    return None
 
 
 class OpenRoadPnr:
@@ -33,11 +69,21 @@ class OpenRoadPnr:
         suite_dir: str,
         root_cfg,
         openroad_executable: str = "openroad",
+        emit_gds: bool = False,
+        emit_png: bool = False,
+        klayout_executable: str = "klayout",
+        png_width: int = 2048,
+        png_height: int = 2048,
     ):
         self.name = name
         self.pnr_cfg = pnr_cfg
         self.root_cfg = root_cfg
         self.openroad_executable = openroad_executable
+        self.emit_gds = emit_gds or emit_png
+        self.emit_png = emit_png
+        self.klayout_executable = klayout_executable
+        self.png_width = png_width
+        self.png_height = png_height
 
         artefact_root = Path(suite_dir) / "artefacts" / pnr_cfg.get_name()
         artefact_root.mkdir(parents=True, exist_ok=True)
@@ -141,6 +187,53 @@ class OpenRoadPnr:
         m = re.search(r"^tns\s+(?:max|min)?\s*([-\d.]+)", log_text, re.MULTILINE)
         return float(m.group(1)) if m else None
 
+    # ------------------------------------------------------------------
+    # Version + feature probes
+    # ------------------------------------------------------------------
+
+    def _probe_openroad_version(self) -> str | None:
+        try:
+            r = subprocess.run(
+                [self.openroad_executable, "-version"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                check=False,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return None
+        out = (r.stdout or r.stderr).strip()
+        return out.splitlines()[0] if out else None
+
+    def _version_below_min(self, version: str) -> bool:
+        return _parse_version_token(version) < _parse_version_token(
+            MIN_OPENROAD_VERSION
+        )
+
+    def _has_tcl_command(self, command: str) -> bool:
+        """Probe whether the OpenROAD build exposes a Tcl command.
+
+        Used as a feature-detect for things like `write_gds`. Returns False
+        if we cannot determine availability (treated as missing).
+        """
+        probe = (
+            f'if {{[info commands {command}] eq ""}} '
+            f'{{ puts "RB_HAS_CMD:{command}:no" }} '
+            f'else {{ puts "RB_HAS_CMD:{command}:yes" }}\nexit\n'
+        )
+        try:
+            r = subprocess.run(
+                [self.openroad_executable, "-no_init", "-exit"],
+                input=probe,
+                capture_output=True,
+                text=True,
+                timeout=15,
+                check=False,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return False
+        return f"RB_HAS_CMD:{command}:yes" in (r.stdout or "")
+
     def _count_drcs(self) -> int:
         drc_path = os.path.join(self.artefact_dir, "route.drc.rpt")
         if not os.path.isfile(drc_path):
@@ -150,6 +243,123 @@ class OpenRoadPnr:
                 return sum(1 for line in f if line.strip())
         except OSError:
             return 0
+
+    # ------------------------------------------------------------------
+    # KLayout streamout / render
+    # ------------------------------------------------------------------
+
+    def _klayout_script_path(self, name: str) -> str:
+        """Materialize a bundled KLayout helper to the artefact dir.
+
+        KLayout's `-r` flag wants a real path on disk; reading from
+        importlib.resources isn't enough since some packagers expose the
+        module via a zipfile loader. Always copy to the artefact dir.
+        """
+        target = Path(self.artefact_dir) / name
+        target.write_text(files(_KLAYOUT_PACKAGE).joinpath(name).read_text())
+        return str(target)
+
+    def _run_def2stream(self, platform, design: str) -> str | None:
+        pdk = platform.get_pdk()
+        tech = pdk.get_klayout_tech()
+        if not tech:
+            log_event(
+                logger,
+                logging.WARNING,
+                "pnr.gds_no_klayout_tech",
+                pnr=self.pnr_cfg.get_name(),
+                pdk=pdk.get_name(),
+            )
+            return None
+        klayout = _resolve_klayout_exe()
+        if not klayout:
+            log_event(
+                logger,
+                logging.WARNING,
+                "pnr.no_klayout",
+                pnr=self.pnr_cfg.get_name(),
+            )
+            return None
+        in_def = os.path.join(self.artefact_dir, f"{design}.def")
+        out_gds = os.path.join(self.artefact_dir, f"{design}.gds")
+        cell_gds = pdk.get_cell_gds()
+        script = self._klayout_script_path("def2stream.py")
+        cmd = [
+            klayout,
+            "-zz",
+            "-nc",
+            "-rd",
+            f"tech_file={tech}",
+            "-rd",
+            "layer_map=",
+            "-rd",
+            f"in_def={in_def}",
+            "-rd",
+            f"design_name={design}",
+            "-rd",
+            f"in_files={cell_gds}",
+            "-rd",
+            "seal_file=",
+            "-rd",
+            f"out_file={out_gds}",
+            "-r",
+            script,
+        ]
+        log_path = os.path.join(self.artefact_dir, "klayout.def2stream.log")
+        with task_status(f"pnr {self.pnr_cfg.get_name()} [klayout gds]"):
+            r = subprocess.run(cmd, capture_output=True, text=True, check=False)
+        Path(log_path).write_text((r.stdout or "") + (r.stderr or ""))
+        if r.returncode != 0 or not os.path.isfile(out_gds):
+            log_event(
+                logger,
+                logging.WARNING,
+                "pnr.gds_failed",
+                pnr=self.pnr_cfg.get_name(),
+                returncode=r.returncode,
+                log=log_path,
+            )
+            return None
+        return out_gds
+
+    def _run_gds2png(self, platform, gds_path: str, design: str) -> str | None:
+        klayout = _resolve_klayout_exe()
+        if not klayout:
+            return None
+        lyp = platform.get_pdk().get_klayout_props()
+        out_png = os.path.join(self.artefact_dir, f"{design}.png")
+        script = self._klayout_script_path("gds2png.py")
+        cmd = [
+            klayout,
+            "-zz",
+            "-nc",
+            "-rd",
+            f"in_gds={gds_path}",
+            "-rd",
+            f"lyp_file={lyp}",
+            "-rd",
+            f"out_png={out_png}",
+            "-rd",
+            f"width={self.png_width}",
+            "-rd",
+            f"height={self.png_height}",
+            "-r",
+            script,
+        ]
+        log_path = os.path.join(self.artefact_dir, "klayout.gds2png.log")
+        with task_status(f"pnr {self.pnr_cfg.get_name()} [klayout png]"):
+            r = subprocess.run(cmd, capture_output=True, text=True, check=False)
+        Path(log_path).write_text((r.stdout or "") + (r.stderr or ""))
+        if r.returncode != 0 or not os.path.isfile(out_png):
+            log_event(
+                logger,
+                logging.WARNING,
+                "pnr.png_failed",
+                pnr=self.pnr_cfg.get_name(),
+                returncode=r.returncode,
+                log=log_path,
+            )
+            return None
+        return out_png
 
     # ------------------------------------------------------------------
     # Entry point
@@ -176,6 +386,26 @@ class OpenRoadPnr:
                 name=self.name + "/results",
                 desc=f"{self.openroad_executable!r} not found on PATH",
             )
+
+        version = self._probe_openroad_version()
+        if version:
+            log_event(
+                logger,
+                logging.INFO,
+                "pnr.openroad_version",
+                pnr=self.pnr_cfg.get_name(),
+                version=version,
+                min_version=MIN_OPENROAD_VERSION,
+            )
+            if self._version_below_min(version):
+                log_event(
+                    logger,
+                    logging.WARNING,
+                    "pnr.openroad_version_below_min",
+                    pnr=self.pnr_cfg.get_name(),
+                    version=version,
+                    min_version=MIN_OPENROAD_VERSION,
+                )
 
         try:
             platform = self.root_cfg.get_pnr_platform_cfg(self.pnr_cfg.get_platform())
@@ -260,6 +490,14 @@ class OpenRoadPnr:
         tns = self._parse_tns(log_text)
         drcs = self._count_drcs()
 
+        gds_path: str | None = None
+        png_path: str | None = None
+        if self.emit_gds:
+            design = self.pnr_cfg.resolve_synth_cfg().get_top()
+            gds_path = self._run_def2stream(platform, design)
+            if gds_path and self.emit_png:
+                png_path = self._run_gds2png(platform, gds_path, design)
+
         log_event(
             logger,
             logging.INFO,
@@ -281,4 +519,6 @@ class OpenRoadPnr:
             wns_hold_ps=wns_hold * 1000.0 if wns_hold is not None else None,
             tns_ps=tns * 1000.0 if tns is not None else None,
             drc_count=drcs,
+            gds_path=gds_path,
+            png_path=png_path,
         )

--- a/src/rtl_buddy/tools/pnr_openroad.py
+++ b/src/rtl_buddy/tools/pnr_openroad.py
@@ -21,14 +21,6 @@ _KLAYOUT_PACKAGE = "rtl_buddy.pnr.klayout"
 # the basic flow but are not validated — we warn rather than refuse.
 MIN_OPENROAD_VERSION = "25Q1"
 
-# Common macOS install locations for KLayout's `klayout` binary when the
-# cask doesn't add itself to PATH.
-_KLAYOUT_FALLBACK_PATHS = (
-    "/Applications/KLayout/klayout.app/Contents/MacOS/klayout",
-    "/Applications/klayout.app/Contents/MacOS/klayout",
-)
-
-
 def _parse_version_token(version: str) -> tuple:
     """Extract a comparable tuple from an OpenROAD version string.
 
@@ -44,13 +36,7 @@ def _parse_version_token(version: str) -> tuple:
 
 
 def _resolve_klayout_exe() -> str | None:
-    exe = shutil.which("klayout")
-    if exe:
-        return exe
-    for candidate in _KLAYOUT_FALLBACK_PATHS:
-        if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
-            return candidate
-    return None
+    return shutil.which("klayout")
 
 
 class OpenRoadPnr:
@@ -384,7 +370,7 @@ class OpenRoadPnr:
             )
             return PnrFailResults(
                 name=self.name + "/results",
-                desc=f"{self.openroad_executable!r} not found on PATH",
+                desc=f"{self.openroad_executable!r} not found",
             )
 
         version = self._probe_openroad_version()

--- a/src/rtl_buddy/tools/pnr_openroad.py
+++ b/src/rtl_buddy/tools/pnr_openroad.py
@@ -21,6 +21,7 @@ _KLAYOUT_PACKAGE = "rtl_buddy.pnr.klayout"
 # the basic flow but are not validated — we warn rather than refuse.
 MIN_OPENROAD_VERSION = "25Q1"
 
+
 def _parse_version_token(version: str) -> tuple:
     """Extract a comparable tuple from an OpenROAD version string.
 

--- a/src/rtl_buddy/tools/pnr_openroad.py
+++ b/src/rtl_buddy/tools/pnr_openroad.py
@@ -1,0 +1,284 @@
+import logging
+import os
+import re
+import shutil
+import subprocess
+from importlib.resources import files
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+from ..config.pnr import PnrConfig
+from ..logging_utils import log_event, task_status
+from ..runner.pnr_results import PnrFailResults, PnrPassResults, PnrResults
+
+
+_TEMPLATE_PACKAGE = "rtl_buddy.pnr"
+_TEMPLATE_FILE = "flow.tcl.template"
+
+
+class OpenRoadPnr:
+    """OpenROAD-driven P&R backend.
+
+    Reads the upstream `rb synth` artefact (tech-mapped netlist), runs a
+    floorplan → place → CTS → route → fill pipeline against a Nangate45-
+    style PDK via a templated Tcl flow, and reports area, WNS
+    setup/hold, TNS, and DRC count.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        pnr_cfg: PnrConfig,
+        suite_dir: str,
+        root_cfg,
+        openroad_executable: str = "openroad",
+    ):
+        self.name = name
+        self.pnr_cfg = pnr_cfg
+        self.root_cfg = root_cfg
+        self.openroad_executable = openroad_executable
+
+        artefact_root = Path(suite_dir) / "artefacts" / pnr_cfg.get_name()
+        artefact_root.mkdir(parents=True, exist_ok=True)
+        self.artefact_dir = str(artefact_root)
+
+    # ------------------------------------------------------------------
+    # Artefact paths
+    # ------------------------------------------------------------------
+
+    def _script_path(self) -> str:
+        return os.path.join(self.artefact_dir, "pnr.tcl")
+
+    def _log_path(self) -> str:
+        return os.path.join(self.artefact_dir, "pnr.log")
+
+    # ------------------------------------------------------------------
+    # Inputs resolution
+    # ------------------------------------------------------------------
+
+    def _resolve_netlist_path(self) -> str:
+        """Locate the upstream synth run's tech-mapped netlist."""
+        synth_cfg = self.pnr_cfg.resolve_synth_cfg()
+        suite_dir = os.path.dirname(self.pnr_cfg.get_synth_suite_path())
+        return os.path.join(
+            suite_dir, "artefacts", synth_cfg.get_name(), "synth_netlist.v"
+        )
+
+    # ------------------------------------------------------------------
+    # Tcl templating
+    # ------------------------------------------------------------------
+
+    def _load_template(self) -> str:
+        return files(_TEMPLATE_PACKAGE).joinpath(_TEMPLATE_FILE).read_text()
+
+    def _write_script(self, platform, fp) -> str:
+        pdk = platform.get_pdk()
+        netlist = self._resolve_netlist_path()
+        sdc = self.pnr_cfg.get_constraints()
+        if not sdc:
+            raise RuntimeError(
+                f"pnr run '{self.pnr_cfg.get_name()}': "
+                "constraints (SDC path) is required"
+            )
+
+        fill_cells = " ".join(pdk.get_fill_cells())
+
+        substitutions = {
+            "design": self.pnr_cfg.resolve_synth_cfg().get_top(),
+            "netlist": netlist,
+            "sdc": sdc,
+            "liberty": platform.get_sta_lib_path(),
+            "tech_lef": pdk.get_tech_lef(),
+            "macro_lef": pdk.get_macro_lef(),
+            "site": pdk.get_site(),
+            "util_pct": f"{fp.utilization * 100:.2f}",
+            "aspect": f"{fp.aspect:.2f}",
+            "core_margin": f"{fp.core_margin:.2f}",
+            "tie_hi": pdk.get_tie_hi(),
+            "tie_lo": pdk.get_tie_lo(),
+            "cts_buf": platform.get_cts_buffer(),
+            "signal_layers": platform.get_signal_layers(),
+            "clock_layers": platform.get_clock_layers(),
+            "fill_cells": fill_cells,
+            "out_dir": self.artefact_dir,
+        }
+
+        template = self._load_template()
+        script = template
+        for key, value in substitutions.items():
+            script = script.replace("{{ " + key + " }}", str(value))
+
+        # Surface any unsubstituted placeholders early.
+        leftover = re.findall(r"\{\{\s*[\w]+\s*\}\}", script)
+        if leftover:
+            raise RuntimeError(
+                f"pnr flow template has unsubstituted placeholders: {leftover}"
+            )
+
+        script_path = self._script_path()
+        with open(script_path, "w") as f:
+            f.write(script)
+        return script_path
+
+    # ------------------------------------------------------------------
+    # Log parsing
+    # ------------------------------------------------------------------
+
+    def _parse_area_um2(self, log_text: str) -> float | None:
+        m = re.search(r"^Design area\s+([\d.]+)\s+um\^2", log_text, re.MULTILINE)
+        return float(m.group(1)) if m else None
+
+    def _parse_cell_count(self, log_text: str) -> int | None:
+        m = re.search(r"Number of instances:\s+(\d+)", log_text)
+        return int(m.group(1)) if m else None
+
+    def _parse_wns(self, log_text: str, kind: str) -> float | None:
+        m = re.search(rf"^worst slack {kind}\s+([-\d.]+)", log_text, re.MULTILINE)
+        return float(m.group(1)) if m else None
+
+    def _parse_tns(self, log_text: str) -> float | None:
+        m = re.search(r"^tns\s+(?:max|min)?\s*([-\d.]+)", log_text, re.MULTILINE)
+        return float(m.group(1)) if m else None
+
+    def _count_drcs(self) -> int:
+        drc_path = os.path.join(self.artefact_dir, "route.drc.rpt")
+        if not os.path.isfile(drc_path):
+            return 0
+        try:
+            with open(drc_path) as f:
+                return sum(1 for line in f if line.strip())
+        except OSError:
+            return 0
+
+    # ------------------------------------------------------------------
+    # Entry point
+    # ------------------------------------------------------------------
+
+    def run(self) -> PnrResults:
+        log_event(
+            logger,
+            logging.INFO,
+            "pnr.start",
+            pnr=self.pnr_cfg.get_name(),
+            tool=self.openroad_executable,
+        )
+
+        if not shutil.which(self.openroad_executable):
+            log_event(
+                logger,
+                logging.WARNING,
+                "pnr.no_openroad",
+                pnr=self.pnr_cfg.get_name(),
+                exe=self.openroad_executable,
+            )
+            return PnrFailResults(
+                name=self.name + "/results",
+                desc=f"{self.openroad_executable!r} not found on PATH",
+            )
+
+        try:
+            platform = self.root_cfg.get_pnr_platform_cfg(self.pnr_cfg.get_platform())
+        except Exception as e:
+            return PnrFailResults(
+                name=self.name + "/results", desc=f"platform lookup failed: {e}"
+            )
+
+        try:
+            script_path = self._write_script(platform, self.pnr_cfg.get_floorplan())
+        except Exception as e:
+            log_event(
+                logger,
+                logging.ERROR,
+                "pnr.template_failed",
+                pnr=self.pnr_cfg.get_name(),
+                error=str(e),
+            )
+            return PnrFailResults(
+                name=self.name + "/results", desc=f"template error: {e}"
+            )
+
+        log_path = self._log_path()
+        env = os.environ.copy()
+        env.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
+
+        cmd = [
+            self.openroad_executable,
+            "-no_init",
+            "-exit",
+            "-log",
+            log_path,
+            script_path,
+        ]
+        log_event(
+            logger,
+            logging.DEBUG,
+            "pnr.run_cmd",
+            pnr=self.pnr_cfg.get_name(),
+            cmd=" ".join(cmd),
+        )
+
+        with task_status(f"pnr {self.pnr_cfg.get_name()} [openroad]"):
+            result = subprocess.run(
+                cmd,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.STDOUT,
+                check=False,
+                env=env,
+            )
+
+        if result.returncode != 0:
+            log_event(
+                logger,
+                logging.WARNING,
+                "pnr.failed",
+                pnr=self.pnr_cfg.get_name(),
+                returncode=result.returncode,
+                log=log_path,
+            )
+            return PnrFailResults(
+                name=self.name + "/results",
+                desc=f"OpenROAD exited with code {result.returncode}",
+            )
+
+        try:
+            log_text = Path(log_path).read_text()
+        except OSError:
+            log_text = ""
+
+        error_lines = [ln for ln in log_text.splitlines() if ln.startswith("[ERROR ")]
+        if error_lines:
+            return PnrFailResults(
+                name=self.name + "/results",
+                desc=f"{len(error_lines)} ERROR(s) in OpenROAD log",
+            )
+
+        area = self._parse_area_um2(log_text)
+        cells = self._parse_cell_count(log_text)
+        wns_setup = self._parse_wns(log_text, "max")
+        wns_hold = self._parse_wns(log_text, "min")
+        tns = self._parse_tns(log_text)
+        drcs = self._count_drcs()
+
+        log_event(
+            logger,
+            logging.INFO,
+            "pnr.passed",
+            pnr=self.pnr_cfg.get_name(),
+            area_um2=area,
+            cell_count=cells,
+            wns_setup_ps=wns_setup * 1000.0 if wns_setup is not None else None,
+            wns_hold_ps=wns_hold * 1000.0 if wns_hold is not None else None,
+            tns_ps=tns * 1000.0 if tns is not None else None,
+            drc_count=drcs,
+            log=log_path,
+        )
+        return PnrPassResults(
+            name=self.name + "/results",
+            area_um2=area,
+            cell_count=cells,
+            wns_setup_ps=wns_setup * 1000.0 if wns_setup is not None else None,
+            wns_hold_ps=wns_hold * 1000.0 if wns_hold is not None else None,
+            tns_ps=tns * 1000.0 if tns is not None else None,
+            drc_count=drcs,
+        )

--- a/src/rtl_buddy/tools/synth_openroad.py
+++ b/src/rtl_buddy/tools/synth_openroad.py
@@ -107,9 +107,7 @@ class OpenRoadSynth:
         platform = self.synth_cfg.get_platform()
         if not platform or self.root_cfg is None:
             return []
-        return list(
-            self.root_cfg.get_synth_platform_cfg(platform).get_lef_paths()
-        )
+        return list(self.root_cfg.get_synth_platform_cfg(platform).get_lef_paths())
 
     # ------------------------------------------------------------------
     # Stage 1: Yosys — RTL to technology-mapped gate-level netlist

--- a/src/rtl_buddy/tools/synth_openroad.py
+++ b/src/rtl_buddy/tools/synth_openroad.py
@@ -98,19 +98,18 @@ class OpenRoadSynth:
         return paths
 
     def _resolve_lib_paths(self) -> list[str]:
-        libraries = self.synth_cfg.get_libraries()
-        if not libraries or self.root_cfg is None:
+        platform = self.synth_cfg.get_platform()
+        if not platform or self.root_cfg is None:
             return []
-        return [self.root_cfg.get_synth_lib_cfg(name).get_path() for name in libraries]
+        return [self.root_cfg.get_synth_platform_cfg(platform).get_path()]
 
     def _resolve_lef_paths(self) -> list[str]:
-        libraries = self.synth_cfg.get_libraries()
-        if not libraries or self.root_cfg is None:
+        platform = self.synth_cfg.get_platform()
+        if not platform or self.root_cfg is None:
             return []
-        paths: list[str] = []
-        for name in libraries:
-            paths.extend(self.root_cfg.get_synth_lib_cfg(name).get_lef_paths())
-        return paths
+        return list(
+            self.root_cfg.get_synth_platform_cfg(platform).get_lef_paths()
+        )
 
     # ------------------------------------------------------------------
     # Stage 1: Yosys — RTL to technology-mapped gate-level netlist

--- a/src/rtl_buddy/tools/synth_openroad.py
+++ b/src/rtl_buddy/tools/synth_openroad.py
@@ -105,9 +105,11 @@ class OpenRoadSynth:
 
     def _resolve_lef_paths(self) -> list[str]:
         platform = self.synth_cfg.get_platform()
+        extras = list(self.synth_cfg.get_lef_paths())
         if not platform or self.root_cfg is None:
-            return []
-        return list(self.root_cfg.get_synth_platform_cfg(platform).get_lef_paths())
+            return extras
+        platform_lefs = self.root_cfg.get_synth_platform_cfg(platform).get_lef_paths()
+        return list(platform_lefs) + extras
 
     # ------------------------------------------------------------------
     # Stage 1: Yosys — RTL to technology-mapped gate-level netlist

--- a/src/rtl_buddy/tools/synth_yosys.py
+++ b/src/rtl_buddy/tools/synth_yosys.py
@@ -123,10 +123,10 @@ class YosysSynth:
         return int(min(periods) * 1000)
 
     def _resolve_lib_paths(self) -> list[str]:
-        libraries = self.synth_cfg.get_libraries()
-        if not libraries or self.root_cfg is None:
+        platform = self.synth_cfg.get_platform()
+        if not platform or self.root_cfg is None:
             return []
-        return [self.root_cfg.get_synth_lib_cfg(name).get_path() for name in libraries]
+        return [self.root_cfg.get_synth_platform_cfg(platform).get_path()]
 
     def _parse_area_um2(self, log_text: str) -> float | None:
         m = re.search(r"Chip area for module[^:]*:\s*([\d.]+)", log_text)

--- a/tests/test_pnr.py
+++ b/tests/test_pnr.py
@@ -330,3 +330,65 @@ def test_pnr_fail_is_not_pass():
     r = PnrFailResults(name="demo/results", desc="OpenROAD exited with code 1")
     assert not r.is_pass()
     assert r.results["result"] == "FAIL"
+
+
+# ---------------------------------------------------------------------------
+# OpenROAD version probe + KLayout helpers
+# ---------------------------------------------------------------------------
+
+
+def test_parse_version_token_handles_yyqn_and_semver():
+    from rtl_buddy.tools.pnr_openroad import _parse_version_token
+
+    assert _parse_version_token("26Q2-911-g731f") == (26, 2)
+    assert _parse_version_token("v2.0-1234-gabcd") == (2, 0)
+    assert _parse_version_token("25Q1") == (25, 1)
+    # Comparison: 26Q2 ranks above 25Q1
+    assert _parse_version_token("26Q2") > _parse_version_token("25Q1")
+    # Unparseable falls back to a string tuple
+    assert _parse_version_token("nightly-build") == ("nightly-build",)
+
+
+def test_resolve_klayout_exe_uses_path_first(monkeypatch):
+    from rtl_buddy.tools import pnr_openroad
+
+    monkeypatch.setattr(pnr_openroad.shutil, "which", lambda _name: "/opt/klayout")
+    assert pnr_openroad._resolve_klayout_exe() == "/opt/klayout"
+
+
+def test_resolve_klayout_exe_returns_none_when_missing(monkeypatch):
+    from rtl_buddy.tools import pnr_openroad
+
+    monkeypatch.setattr(pnr_openroad.shutil, "which", lambda _name: None)
+    monkeypatch.setattr(pnr_openroad, "_KLAYOUT_FALLBACK_PATHS", ())
+    assert pnr_openroad._resolve_klayout_exe() is None
+
+
+def test_pnr_pass_result_carries_gds_and_png_paths():
+    r = PnrPassResults(
+        name="demo/results",
+        area_um2=100.0,
+        gds_path="/tmp/demo.gds",
+        png_path="/tmp/demo.png",
+    )
+    assert r.results["gds_path"] == "/tmp/demo.gds"
+    assert r.results["png_path"] == "/tmp/demo.png"
+
+
+def test_openroad_pnr_png_implies_gds():
+    """`--png` without `--gds` should still trigger GDS streamout."""
+    from rtl_buddy.tools.pnr_openroad import OpenRoadPnr
+
+    backend = OpenRoadPnr.__new__(OpenRoadPnr)
+    # Mimic __init__ for just the gds-implication knob.
+    OpenRoadPnr.__init__(
+        backend,
+        name="demo",
+        pnr_cfg=MagicMock(get_name=MagicMock(return_value="demo")),
+        suite_dir=str(__import__("tempfile").mkdtemp()),
+        root_cfg=MagicMock(),
+        emit_gds=False,
+        emit_png=True,
+    )
+    assert backend.emit_gds is True
+    assert backend.emit_png is True

--- a/tests/test_pnr.py
+++ b/tests/test_pnr.py
@@ -75,7 +75,6 @@ def test_synth_platform_defaults_to_first_corner(tmp_path):
     pdk = _make_pdk_cfg(tmp_path)
     cfg = SynthPlatformConfig(
         SynthPlatformConfigFile(name="nangate45_typ", pdk="nangate45"),
-        str(tmp_path / "root_config.yaml"),
         lambda _name: pdk,
     )
     assert cfg.get_corner() == "typ"
@@ -86,26 +85,21 @@ def test_synth_platform_explicit_corner(tmp_path):
     pdk = _make_pdk_cfg(tmp_path)
     cfg = SynthPlatformConfig(
         SynthPlatformConfigFile(name="nangate45_slow", pdk="nangate45", corner="slow"),
-        str(tmp_path / "root_config.yaml"),
         lambda _name: pdk,
     )
     assert cfg.get_corner() == "slow"
     assert cfg.get_path().endswith("slow.lib")
 
 
-def test_synth_platform_lef_paths_compose_pdk_and_extras(tmp_path):
+def test_synth_platform_lef_paths_are_pdk_lefs_only(tmp_path):
     pdk = _make_pdk_cfg(tmp_path)
     cfg = SynthPlatformConfig(
-        SynthPlatformConfigFile(
-            name="nangate45_typ", pdk="nangate45", lef_paths=["pdk/lef/extra.lef"]
-        ),
-        str(tmp_path / "root_config.yaml"),
+        SynthPlatformConfigFile(name="nangate45_typ", pdk="nangate45"),
         lambda _name: pdk,
     )
     assert cfg.get_lef_paths() == [
         str(tmp_path / "pdk" / "lef" / "tech.lef"),
         str(tmp_path / "pdk" / "lef" / "cells.lef"),
-        str(tmp_path / "pdk" / "lef" / "extra.lef"),
     ]
 
 
@@ -169,7 +163,7 @@ def test_pnr_suite_loads_runs(tmp_path):
     assert run.get_platform() == "nangate45_typ"
     assert run.get_floorplan().utilization == pytest.approx(0.6)
     assert run.get_floorplan().core_margin == pytest.approx(3.0)
-    assert run.get_reglvl() == 1000
+    assert run.get_reglvl("openroad") == 1000
     # synth-path and constraints are resolved relative to pnr.yaml
     assert run.get_synth_suite_path() == str(tmp_path.parent / "synth" / "synth.yaml")
     assert run.get_constraints() == str(tmp_path.parent / "synth" / "constraints.sdc")
@@ -241,6 +235,54 @@ def _make_pnr_cfg(tmp_path):
     )
 
 
+def test_pnr_runner_resolves_executable_from_cfg_pnr_tools(tmp_path):
+    """PnrRunner should resolve the executable via cfg-pnr-tools when present."""
+    from rtl_buddy.config.pnr import PnrToolConfig, PnrToolConfigFile
+    from rtl_buddy.runner.pnr_runner import PnrRunner
+
+    tool_cfg = PnrToolConfig(
+        PnrToolConfigFile(name="openroad", tool="/opt/openroad/bin/openroad")
+    )
+    root_cfg = MagicMock()
+    root_cfg.get_pnr_tool_cfg.return_value = tool_cfg
+    runner = PnrRunner(
+        name="demo",
+        root_cfg=root_cfg,
+        pnr_cfg=_make_pnr_cfg(tmp_path),
+        suite_dir=str(tmp_path),
+        reglvl_filter=1000,
+    )
+    with patch("rtl_buddy.runner.pnr_runner.OpenRoadPnr") as mock_backend:
+        mock_backend.return_value.run.return_value = PnrSkipResults(
+            name="demo/results", desc="stub"
+        )
+        runner.run()
+    _, kwargs = mock_backend.call_args
+    assert kwargs["openroad_executable"] == "/opt/openroad/bin/openroad"
+
+
+def test_pnr_runner_falls_back_to_bare_tool_name_when_no_cfg(tmp_path):
+    """Without a matching cfg-pnr-tools entry, the bare tool name is used."""
+    from rtl_buddy.runner.pnr_runner import PnrRunner
+
+    root_cfg = MagicMock()
+    root_cfg.get_pnr_tool_cfg.return_value = None
+    runner = PnrRunner(
+        name="demo",
+        root_cfg=root_cfg,
+        pnr_cfg=_make_pnr_cfg(tmp_path),
+        suite_dir=str(tmp_path),
+        reglvl_filter=1000,
+    )
+    with patch("rtl_buddy.runner.pnr_runner.OpenRoadPnr") as mock_backend:
+        mock_backend.return_value.run.return_value = PnrSkipResults(
+            name="demo/results", desc="stub"
+        )
+        runner.run()
+    _, kwargs = mock_backend.call_args
+    assert kwargs["openroad_executable"] == "openroad"
+
+
 def test_openroad_pnr_skips_when_executable_missing(tmp_path):
     from rtl_buddy.tools.pnr_openroad import OpenRoadPnr
 
@@ -254,7 +296,7 @@ def test_openroad_pnr_skips_when_executable_missing(tmp_path):
     with patch("shutil.which", return_value=None):
         result = backend.run()
     assert isinstance(result, PnrFailResults)
-    assert "not found on PATH" in result.results["desc"]
+    assert "not found" in result.results["desc"]
 
 
 def test_openroad_pnr_template_substitutes_all_placeholders(tmp_path):
@@ -360,7 +402,6 @@ def test_resolve_klayout_exe_returns_none_when_missing(monkeypatch):
     from rtl_buddy.tools import pnr_openroad
 
     monkeypatch.setattr(pnr_openroad.shutil, "which", lambda _name: None)
-    monkeypatch.setattr(pnr_openroad, "_KLAYOUT_FALLBACK_PATHS", ())
     assert pnr_openroad._resolve_klayout_exe() is None
 
 

--- a/tests/test_pnr.py
+++ b/tests/test_pnr.py
@@ -1,0 +1,332 @@
+"""Tests for the P&R config schema, OpenRoadPnr backend, and rb pnr wiring."""
+
+from pathlib import Path
+from textwrap import dedent
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from rtl_buddy.config.pdk import PdkConfig, PdkConfigFile
+from rtl_buddy.config.pnr import PnrConfig, PnrSuiteConfig
+from rtl_buddy.config.pnr_platform import PnrPlatformConfig, PnrPlatformConfigFile
+from rtl_buddy.config.synth import SynthPlatformConfig, SynthPlatformConfigFile
+from rtl_buddy.errors import FatalRtlBuddyError
+from rtl_buddy.runner.pnr_results import (
+    PnrFailResults,
+    PnrPassResults,
+    PnrSkipResults,
+)
+
+
+# ---------------------------------------------------------------------------
+# PdkConfig
+# ---------------------------------------------------------------------------
+
+
+def _make_pdk_cfg(tmp_path, **overrides):
+    base = dict(
+        name="nangate45",
+        site="FreePDK45_38x28_10R_NP_162NW_34O",
+        corners={"typ": "pdk/lib/typ.lib", "slow": "pdk/lib/slow.lib"},
+        tech_lef="pdk/lef/tech.lef",
+        macro_lef="pdk/lef/cells.lef",
+        tie_hi="LOGIC1_X1/Z",
+        tie_lo="LOGIC0_X1/Z",
+        fill_cells=["FILLCELL_X1", "FILLCELL_X2"],
+    )
+    base.update(overrides)
+    return PdkConfig(PdkConfigFile(**base), str(tmp_path / "root_config.yaml"))
+
+
+def test_pdk_resolves_corner_paths(tmp_path):
+    pdk = _make_pdk_cfg(tmp_path)
+    assert pdk.get_corner_path("typ") == str(tmp_path / "pdk" / "lib" / "typ.lib")
+    assert pdk.get_corner_path("slow") == str(tmp_path / "pdk" / "lib" / "slow.lib")
+    assert pdk.get_corners() == ["typ", "slow"]
+    assert pdk.get_default_corner() == "typ"
+
+
+def test_pdk_unknown_corner_raises(tmp_path):
+    pdk = _make_pdk_cfg(tmp_path)
+    with pytest.raises(FatalRtlBuddyError, match="has no corner 'fast'"):
+        pdk.get_corner_path("fast")
+
+
+def test_pdk_no_corners_raises(tmp_path):
+    pdk = _make_pdk_cfg(tmp_path, corners={})
+    with pytest.raises(FatalRtlBuddyError, match="declares no corners"):
+        pdk.get_default_corner()
+
+
+def test_pdk_exposes_site_tie_and_fill(tmp_path):
+    pdk = _make_pdk_cfg(tmp_path)
+    assert pdk.get_site() == "FreePDK45_38x28_10R_NP_162NW_34O"
+    assert pdk.get_tie_hi() == "LOGIC1_X1/Z"
+    assert pdk.get_tie_lo() == "LOGIC0_X1/Z"
+    assert pdk.get_fill_cells() == ["FILLCELL_X1", "FILLCELL_X2"]
+
+
+# ---------------------------------------------------------------------------
+# SynthPlatformConfig — pdk lookup, corner resolution, lef composition
+# ---------------------------------------------------------------------------
+
+
+def test_synth_platform_defaults_to_first_corner(tmp_path):
+    pdk = _make_pdk_cfg(tmp_path)
+    cfg = SynthPlatformConfig(
+        SynthPlatformConfigFile(name="nangate45_typ", pdk="nangate45"),
+        str(tmp_path / "root_config.yaml"),
+        lambda _name: pdk,
+    )
+    assert cfg.get_corner() == "typ"
+    assert cfg.get_path().endswith("typ.lib")
+
+
+def test_synth_platform_explicit_corner(tmp_path):
+    pdk = _make_pdk_cfg(tmp_path)
+    cfg = SynthPlatformConfig(
+        SynthPlatformConfigFile(name="nangate45_slow", pdk="nangate45", corner="slow"),
+        str(tmp_path / "root_config.yaml"),
+        lambda _name: pdk,
+    )
+    assert cfg.get_corner() == "slow"
+    assert cfg.get_path().endswith("slow.lib")
+
+
+def test_synth_platform_lef_paths_compose_pdk_and_extras(tmp_path):
+    pdk = _make_pdk_cfg(tmp_path)
+    cfg = SynthPlatformConfig(
+        SynthPlatformConfigFile(
+            name="nangate45_typ", pdk="nangate45", lef_paths=["pdk/lef/extra.lef"]
+        ),
+        str(tmp_path / "root_config.yaml"),
+        lambda _name: pdk,
+    )
+    assert cfg.get_lef_paths() == [
+        str(tmp_path / "pdk" / "lef" / "tech.lef"),
+        str(tmp_path / "pdk" / "lef" / "cells.lef"),
+        str(tmp_path / "pdk" / "lef" / "extra.lef"),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# PnrPlatformConfig — pdk + sta corner
+# ---------------------------------------------------------------------------
+
+
+def test_pnr_platform_defaults_to_first_corner(tmp_path):
+    pdk = _make_pdk_cfg(tmp_path)
+    cfg = PnrPlatformConfig(
+        PnrPlatformConfigFile(name="nangate45_typ", pdk="nangate45"),
+        lambda _name: pdk,
+    )
+    assert cfg.get_sta_corner() == "typ"
+    assert cfg.get_sta_lib_path().endswith("typ.lib")
+
+
+def test_pnr_platform_unknown_sta_corner_raises(tmp_path):
+    pdk = _make_pdk_cfg(tmp_path)
+    with pytest.raises(FatalRtlBuddyError, match="has no corner 'fast'"):
+        PnrPlatformConfig(
+            PnrPlatformConfigFile(
+                name="nangate45_fast", pdk="nangate45", sta_corner="fast"
+            ),
+            lambda _name: pdk,
+        )
+
+
+# ---------------------------------------------------------------------------
+# PnrSuiteConfig — YAML loading + initialise
+# ---------------------------------------------------------------------------
+
+
+_PNR_YAML = dedent("""\
+    rtl-buddy-filetype: pnr_config
+
+    runs:
+      - name: "demo_pnr"
+        desc: "Demo run"
+        tool: "openroad"
+        synth: "demo_synth_nangate45"
+        synth-path: "../synth/synth.yaml"
+        constraints: "../synth/constraints.sdc"
+        platform: "nangate45_typ"
+        floorplan:
+          utilization: 0.6
+          aspect: 1.0
+          core-margin: 3.0
+        reglvl: 1000
+""")
+
+
+def test_pnr_suite_loads_runs(tmp_path):
+    pnr_yaml = tmp_path / "pnr.yaml"
+    pnr_yaml.write_text(_PNR_YAML)
+    suite = PnrSuiteConfig(str(pnr_yaml))
+    assert suite.get_run_names() == ["demo_pnr"]
+    run = suite.get_runs("demo_pnr")[0]
+    assert run.get_name() == "demo_pnr"
+    assert run.get_platform() == "nangate45_typ"
+    assert run.get_floorplan().utilization == pytest.approx(0.6)
+    assert run.get_floorplan().core_margin == pytest.approx(3.0)
+    assert run.get_reglvl() == 1000
+    # synth-path and constraints are resolved relative to pnr.yaml
+    assert run.get_synth_suite_path() == str(tmp_path.parent / "synth" / "synth.yaml")
+    assert run.get_constraints() == str(tmp_path.parent / "synth" / "constraints.sdc")
+
+
+def test_pnr_suite_missing_synth_raises(tmp_path):
+    pnr_yaml = tmp_path / "pnr.yaml"
+    pnr_yaml.write_text(
+        dedent("""\
+            rtl-buddy-filetype: pnr_config
+            runs:
+              - name: "demo_pnr"
+                desc: "Demo run"
+                tool: "openroad"
+                synth-path: "../synth/synth.yaml"
+                constraints: "../synth/constraints.sdc"
+                platform: "nangate45_typ"
+        """)
+    )
+    with pytest.raises(FatalRtlBuddyError, match="missing 'synth'"):
+        PnrSuiteConfig(str(pnr_yaml))
+
+
+def test_pnr_suite_missing_platform_raises(tmp_path):
+    pnr_yaml = tmp_path / "pnr.yaml"
+    pnr_yaml.write_text(
+        dedent("""\
+            rtl-buddy-filetype: pnr_config
+            runs:
+              - name: "demo_pnr"
+                desc: "Demo run"
+                tool: "openroad"
+                synth: "demo_synth_nangate45"
+                synth-path: "../synth/synth.yaml"
+                constraints: "../synth/constraints.sdc"
+        """)
+    )
+    with pytest.raises(FatalRtlBuddyError, match="missing 'platform'"):
+        PnrSuiteConfig(str(pnr_yaml))
+
+
+def test_pnr_suite_unknown_run_raises(tmp_path):
+    pnr_yaml = tmp_path / "pnr.yaml"
+    pnr_yaml.write_text(_PNR_YAML)
+    suite = PnrSuiteConfig(str(pnr_yaml))
+    with pytest.raises(FatalRtlBuddyError, match="not found in suite"):
+        suite.get_runs("does_not_exist")
+
+
+# ---------------------------------------------------------------------------
+# OpenRoadPnr — backend skip / template render (without invoking openroad)
+# ---------------------------------------------------------------------------
+
+
+def _make_pnr_cfg(tmp_path):
+    from rtl_buddy.config.pnr import PnrFloorplan
+
+    return PnrConfig(
+        name="demo_pnr",
+        desc="demo",
+        tool="openroad",
+        synth_name="demo_synth",
+        synth_suite_path=str(tmp_path / "synth.yaml"),
+        constraints=str(tmp_path / "constraints.sdc"),
+        platform="nangate45_typ",
+        floorplan=PnrFloorplan(utilization=0.55, aspect=1.0, core_margin=2.0),
+        _reglvl=1000,
+        tool_overrides=None,
+    )
+
+
+def test_openroad_pnr_skips_when_executable_missing(tmp_path):
+    from rtl_buddy.tools.pnr_openroad import OpenRoadPnr
+
+    backend = OpenRoadPnr(
+        name="demo/openroad",
+        pnr_cfg=_make_pnr_cfg(tmp_path),
+        suite_dir=str(tmp_path),
+        root_cfg=MagicMock(),
+        openroad_executable="this-binary-does-not-exist-xyz",
+    )
+    with patch("shutil.which", return_value=None):
+        result = backend.run()
+    assert isinstance(result, PnrFailResults)
+    assert "not found on PATH" in result.results["desc"]
+
+
+def test_openroad_pnr_template_substitutes_all_placeholders(tmp_path):
+    """Templating should resolve every `{{ key }}` placeholder."""
+    from rtl_buddy.tools.pnr_openroad import OpenRoadPnr
+
+    pdk = _make_pdk_cfg(tmp_path)
+    platform = PnrPlatformConfig(
+        PnrPlatformConfigFile(
+            name="nangate45_typ",
+            pdk="nangate45",
+            cts_buffer="BUF_X4",
+        ),
+        lambda _name: pdk,
+    )
+    # routing-layers default empty strings → still substitute, just produce empty values.
+
+    pnr_cfg = _make_pnr_cfg(tmp_path)
+    # Stub the synth-side resolution so we don't have to materialize a synth.yaml.
+    resolved_synth = MagicMock()
+    resolved_synth.get_top.return_value = "demo_top"
+    resolved_synth.get_name.return_value = "demo_synth"
+    pnr_cfg.resolve_synth_cfg = MagicMock(return_value=resolved_synth)
+
+    backend = OpenRoadPnr(
+        name="demo/openroad",
+        pnr_cfg=pnr_cfg,
+        suite_dir=str(tmp_path),
+        root_cfg=MagicMock(),
+    )
+    script_path = backend._write_script(platform, pnr_cfg.get_floorplan())
+    text = Path(script_path).read_text()
+
+    assert "set DESIGN          demo_top" in text
+    assert "set SITE            FreePDK45_38x28_10R_NP_162NW_34O" in text
+    assert "set CORE_UTIL_PCT   55.00" in text
+    assert "set TIEHI_CELL_PORT LOGIC1_X1/Z" in text
+    assert "set CTS_BUF         BUF_X4" in text
+    # No leftover placeholders
+    assert "{{" not in text
+    assert "}}" not in text
+
+
+# ---------------------------------------------------------------------------
+# PnrResults shapes
+# ---------------------------------------------------------------------------
+
+
+def test_pnr_pass_result_carries_metrics():
+    r = PnrPassResults(
+        name="demo/results",
+        area_um2=3213.0,
+        cell_count=1392,
+        wns_setup_ps=4350.0,
+        wns_hold_ps=80.0,
+        tns_ps=0.0,
+        drc_count=0,
+    )
+    assert r.is_pass()
+    assert r.results["area_um2"] == 3213.0
+    assert r.results["cell_count"] == 1392
+    assert r.results["wns_setup_ps"] == 4350.0
+    assert r.results["drc_count"] == 0
+
+
+def test_pnr_skip_is_pass():
+    r = PnrSkipResults(name="demo/results", desc="reglvl above filter")
+    assert r.is_pass()
+    assert r.results["result"] == "SKIP"
+
+
+def test_pnr_fail_is_not_pass():
+    r = PnrFailResults(name="demo/results", desc="OpenROAD exited with code 1")
+    assert not r.is_pass()
+    assert r.results["result"] == "FAIL"

--- a/tests/test_synth.py
+++ b/tests/test_synth.py
@@ -885,21 +885,20 @@ def _make_pdk(name, root_cfg_path, *, tech_lef="", macro_lef="", corners=None):
     )
 
 
-def test_synth_platform_config_lef_paths_empty_by_default(tmp_path):
+def test_synth_platform_config_lef_paths_empty_when_pdk_has_no_lef(tmp_path):
     from rtl_buddy.config.synth import SynthPlatformConfigFile, SynthPlatformConfig
 
     root_cfg_path = str(tmp_path / "root_config.yaml")
     pdk = _make_pdk("nangate45", root_cfg_path)
     cfg = SynthPlatformConfig(
         SynthPlatformConfigFile(name="nangate45_typ", pdk="nangate45"),
-        root_cfg_path,
         lambda _name: pdk,
     )
     assert cfg.get_lef_paths() == []
     assert cfg.get_path() == str(tmp_path / "lib" / "cells.lib")
 
 
-def test_synth_platform_config_lef_paths_resolved(tmp_path):
+def test_synth_platform_config_lef_paths_from_pdk(tmp_path):
     from rtl_buddy.config.synth import SynthPlatformConfigFile, SynthPlatformConfig
 
     root_cfg_path = str(tmp_path / "root_config.yaml")
@@ -910,16 +909,12 @@ def test_synth_platform_config_lef_paths_resolved(tmp_path):
         macro_lef="lef/cells.lef",
     )
     cfg = SynthPlatformConfig(
-        SynthPlatformConfigFile(
-            name="nangate45_typ", pdk="nangate45", lef_paths=["lef/extra.lef"]
-        ),
-        root_cfg_path,
+        SynthPlatformConfigFile(name="nangate45_typ", pdk="nangate45"),
         lambda _name: pdk,
     )
     assert cfg.get_lef_paths() == [
         str(tmp_path / "lef" / "tech.lef"),
         str(tmp_path / "lef" / "cells.lef"),
-        str(tmp_path / "lef" / "extra.lef"),
     ]
 
 

--- a/tests/test_synth.py
+++ b/tests/test_synth.py
@@ -1057,9 +1057,7 @@ def test_openroad_or_script_no_sdc_omits_timing_reports(tmp_path):
     )
     or_synth = _make_openroad(
         tmp_path,
-        synth_cfg=_make_synth_cfg(
-            model_name="top", platform="mylib", constraints=None
-        ),
+        synth_cfg=_make_synth_cfg(model_name="top", platform="mylib", constraints=None),
         root_cfg=root_cfg,
     )
     script = Path(or_synth._write_or_script([str(lef)], [str(lib)])).read_text()

--- a/tests/test_synth.py
+++ b/tests/test_synth.py
@@ -53,7 +53,7 @@ def _make_synth_cfg(
     constraints=None,
     params=None,
     defines=None,
-    libraries=None,
+    platform=None,
     reglvl=None,
     tool_overrides=None,
 ):
@@ -68,7 +68,7 @@ def _make_synth_cfg(
         constraints=constraints,
         params=params,
         defines=defines,
-        libraries=libraries,
+        platform=platform,
         _reglvl=reglvl,
         tool_overrides=tool_overrides,
     )
@@ -505,7 +505,7 @@ def test_run_returns_pass_on_clean_exit(tmp_path, monkeypatch):
         constraints=None,
         params=None,
         defines=None,
-        libraries=None,
+        platform=None,
         _reglvl=None,
         tool_overrides=None,
     )
@@ -532,7 +532,7 @@ def test_run_returns_fail_on_nonzero_exit(tmp_path, monkeypatch):
         constraints=None,
         params=None,
         defines=None,
-        libraries=None,
+        platform=None,
         _reglvl=None,
         tool_overrides=None,
     )
@@ -560,7 +560,7 @@ def test_run_returns_fail_on_error_in_log(tmp_path, monkeypatch):
         constraints=None,
         params=None,
         defines=None,
-        libraries=None,
+        platform=None,
         _reglvl=None,
         tool_overrides=None,
     )
@@ -590,7 +590,7 @@ def test_run_uses_managed_process_for_yosys(tmp_path, monkeypatch):
         constraints=None,
         params=None,
         defines=None,
-        libraries=None,
+        platform=None,
         _reglvl=None,
         tool_overrides=None,
     )
@@ -619,7 +619,7 @@ def test_run_uses_managed_process_for_yosys(tmp_path, monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-class _FakeLibCfg:
+class _FakePlatformCfg:
     def __init__(self, path):
         self._path = path
 
@@ -631,12 +631,12 @@ class _FakeRootCfg:
     def __init__(self, lib_map):
         self._lib_map = lib_map
 
-    def get_synth_lib_cfg(self, name):
+    def get_synth_platform_cfg(self, name):
         from rtl_buddy.errors import FatalRtlBuddyError
 
         if name not in self._lib_map:
             raise FatalRtlBuddyError(f"synthesis library '{name}' not found")
-        return _FakeLibCfg(self._lib_map[name])
+        return _FakePlatformCfg(self._lib_map[name])
 
 
 def test_write_script_lib_flow_emits_read_liberty_and_mapping(tmp_path):
@@ -650,7 +650,7 @@ def test_write_script_lib_flow_emits_read_liberty_and_mapping(tmp_path):
     root_cfg = _FakeRootCfg({"mylib": str(lib)})
     ys = _make_yosys(
         tmp_path,
-        synth_cfg=_make_synth_cfg(libraries=["mylib"]),
+        synth_cfg=_make_synth_cfg(platform="mylib"),
         root_cfg=root_cfg,
     )
     script = Path(ys._write_script(str(fl))).read_text()
@@ -673,7 +673,7 @@ def test_write_script_lib_flow_no_standalone_abc(tmp_path):
     root_cfg = _FakeRootCfg({"mylib": str(lib)})
     ys = _make_yosys(
         tmp_path,
-        synth_cfg=_make_synth_cfg(libraries=["mylib"]),
+        synth_cfg=_make_synth_cfg(platform="mylib"),
         tool_cfg=_tool_cfg(abc_args="-fast"),
         root_cfg=root_cfg,
     )
@@ -687,7 +687,7 @@ def test_write_script_no_lib_flow_unchanged(tmp_path):
     fl = tmp_path / "synth.f"
     fl.write_text(f"-v {sv}\n")
 
-    ys = _make_yosys(tmp_path, synth_cfg=_make_synth_cfg(libraries=None))
+    ys = _make_yosys(tmp_path, synth_cfg=_make_synth_cfg(platform=None))
     script = Path(ys._write_script(str(fl))).read_text()
 
     assert "read_liberty" not in script
@@ -702,7 +702,7 @@ def test_resolve_lib_paths_unknown_name_raises(tmp_path):
     root_cfg = _FakeRootCfg({})
     ys = _make_yosys(
         tmp_path,
-        synth_cfg=_make_synth_cfg(libraries=["unknown_lib"]),
+        synth_cfg=_make_synth_cfg(platform="unknown_lib"),
         root_cfg=root_cfg,
     )
     with pytest.raises(FatalRtlBuddyError, match="not found"):
@@ -763,7 +763,7 @@ def test_write_script_lib_flow_with_sdc_adds_D_flag(tmp_path):
     root_cfg = _FakeRootCfg({"mylib": str(lib)})
     ys = _make_yosys(
         tmp_path,
-        synth_cfg=_make_synth_cfg(libraries=["mylib"], constraints=str(sdc)),
+        synth_cfg=_make_synth_cfg(platform="mylib", constraints=str(sdc)),
         root_cfg=root_cfg,
     )
     script = Path(ys._write_script(str(fl))).read_text()
@@ -867,28 +867,60 @@ def test_synth_tool_config_strategy_via_override_dict():
 
 
 # ---------------------------------------------------------------------------
-# SynthLibConfig — lef_paths field
+# SynthPlatformConfig — pdk + corner + lef paths
 # ---------------------------------------------------------------------------
 
 
-def test_synth_lib_config_lef_paths_empty_by_default(tmp_path):
-    from rtl_buddy.config.synth import SynthLibConfigFile, SynthLibConfig
+def _make_pdk(name, root_cfg_path, *, tech_lef="", macro_lef="", corners=None):
+    from rtl_buddy.config.pdk import PdkConfig, PdkConfigFile
 
-    root_cfg_path = str(tmp_path / "root_config.yaml")
-    lib_file = SynthLibConfigFile(name="mylib", path="lib/cells.lib", lef_paths=[])
-    cfg = SynthLibConfig(lib_file, root_cfg_path)
-    assert cfg.get_lef_paths() == []
-
-
-def test_synth_lib_config_lef_paths_resolved(tmp_path):
-    from rtl_buddy.config.synth import SynthLibConfigFile, SynthLibConfig
-
-    root_cfg_path = str(tmp_path / "root_config.yaml")
-    lib_file = SynthLibConfigFile(
-        name="mylib", path="lib/cells.lib", lef_paths=["lef/cells.lef"]
+    return PdkConfig(
+        PdkConfigFile(
+            name=name,
+            corners=corners or {"typ": "lib/cells.lib"},
+            tech_lef=tech_lef,
+            macro_lef=macro_lef,
+        ),
+        root_cfg_path,
     )
-    cfg = SynthLibConfig(lib_file, root_cfg_path)
-    assert cfg.get_lef_paths() == [str(tmp_path / "lef" / "cells.lef")]
+
+
+def test_synth_platform_config_lef_paths_empty_by_default(tmp_path):
+    from rtl_buddy.config.synth import SynthPlatformConfigFile, SynthPlatformConfig
+
+    root_cfg_path = str(tmp_path / "root_config.yaml")
+    pdk = _make_pdk("nangate45", root_cfg_path)
+    cfg = SynthPlatformConfig(
+        SynthPlatformConfigFile(name="nangate45_typ", pdk="nangate45"),
+        root_cfg_path,
+        lambda _name: pdk,
+    )
+    assert cfg.get_lef_paths() == []
+    assert cfg.get_path() == str(tmp_path / "lib" / "cells.lib")
+
+
+def test_synth_platform_config_lef_paths_resolved(tmp_path):
+    from rtl_buddy.config.synth import SynthPlatformConfigFile, SynthPlatformConfig
+
+    root_cfg_path = str(tmp_path / "root_config.yaml")
+    pdk = _make_pdk(
+        "nangate45",
+        root_cfg_path,
+        tech_lef="lef/tech.lef",
+        macro_lef="lef/cells.lef",
+    )
+    cfg = SynthPlatformConfig(
+        SynthPlatformConfigFile(
+            name="nangate45_typ", pdk="nangate45", lef_paths=["lef/extra.lef"]
+        ),
+        root_cfg_path,
+        lambda _name: pdk,
+    )
+    assert cfg.get_lef_paths() == [
+        str(tmp_path / "lef" / "tech.lef"),
+        str(tmp_path / "lef" / "cells.lef"),
+        str(tmp_path / "lef" / "extra.lef"),
+    ]
 
 
 # ---------------------------------------------------------------------------
@@ -896,7 +928,7 @@ def test_synth_lib_config_lef_paths_resolved(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-class _FakeLibCfgWithLef:
+class _FakePlatformCfgWithLef:
     def __init__(self, path, lef_paths=None):
         self._path = path
         self._lef_paths = lef_paths or []
@@ -913,13 +945,13 @@ class _FakeRootCfgOR:
         self._lib_map = lib_map
         self._lef_map = lef_map or {}
 
-    def get_synth_lib_cfg(self, name):
+    def get_synth_platform_cfg(self, name):
         from rtl_buddy.errors import FatalRtlBuddyError
 
         if name not in self._lib_map:
             raise FatalRtlBuddyError(f"synthesis library '{name}' not found")
         lef_paths = self._lef_map.get(name, [])
-        return _FakeLibCfgWithLef(self._lib_map[name], lef_paths)
+        return _FakePlatformCfgWithLef(self._lib_map[name], lef_paths)
 
     def get_synth_tool_cfg(self, name):
         from rtl_buddy.errors import FatalRtlBuddyError
@@ -972,7 +1004,7 @@ def test_openroad_yosys_script_has_liberty_and_netlist(tmp_path):
     )
     or_synth = _make_openroad(
         tmp_path,
-        synth_cfg=_make_synth_cfg(model_name="top", libraries=["mylib"]),
+        synth_cfg=_make_synth_cfg(model_name="top", platform="mylib"),
         root_cfg=root_cfg,
     )
     script = Path(or_synth._write_yosys_script(str(fl))).read_text()
@@ -998,7 +1030,7 @@ def test_openroad_or_script_has_lef_liberty_verilog_sdc(tmp_path):
     or_synth = _make_openroad(
         tmp_path,
         synth_cfg=_make_synth_cfg(
-            model_name="top", libraries=["mylib"], constraints=str(sdc)
+            model_name="top", platform="mylib", constraints=str(sdc)
         ),
         root_cfg=root_cfg,
     )
@@ -1026,7 +1058,7 @@ def test_openroad_or_script_no_sdc_omits_timing_reports(tmp_path):
     or_synth = _make_openroad(
         tmp_path,
         synth_cfg=_make_synth_cfg(
-            model_name="top", libraries=["mylib"], constraints=None
+            model_name="top", platform="mylib", constraints=None
         ),
         root_cfg=root_cfg,
     )
@@ -1052,7 +1084,7 @@ def test_openroad_or_script_timing_strategy_adds_resynth(tmp_path):
     or_synth = _make_openroad(
         tmp_path,
         synth_cfg=_make_synth_cfg(
-            model_name="top", libraries=["mylib"], constraints=str(sdc)
+            model_name="top", platform="mylib", constraints=str(sdc)
         ),
         tool_cfg=_make_or_tool_cfg(strategy="TIMING"),
         root_cfg=root_cfg,
@@ -1108,7 +1140,7 @@ def test_openroad_parse_area_missing_returns_none():
 
 def test_openroad_run_fails_without_library(tmp_path, monkeypatch):
 
-    or_synth = _make_openroad(tmp_path, synth_cfg=_make_synth_cfg(libraries=None))
+    or_synth = _make_openroad(tmp_path, synth_cfg=_make_synth_cfg(platform=None))
     result = or_synth.run()
     assert isinstance(result, SynthFailResults)
     assert "library" in result.results["desc"].lower()
@@ -1121,7 +1153,7 @@ def test_openroad_run_fails_without_lef(tmp_path, monkeypatch):
     root_cfg = _FakeRootCfgOR(lib_map={"mylib": str(lib)}, lef_map={})
     or_synth = _make_openroad(
         tmp_path,
-        synth_cfg=_make_synth_cfg(libraries=["mylib"]),
+        synth_cfg=_make_synth_cfg(platform="mylib"),
         root_cfg=root_cfg,
     )
     result = or_synth.run()


### PR DESCRIPTION
Closes #80.

## Summary

Combined PR for issue #80: schema refactor + `rb pnr` subcommand (PR A) **and** the originally deferred `--gds`/`--png` / OpenROAD version probe / skill docs (PR B). Folded into one PR since it's still pre-merge and the additions sit cleanly on top.

## Changes

### Config schema (breaking)

Old:
```yaml
cfg-synth-libs:
  - name: nangate45_typ
    path: pdk/.../typical.lib
    lef-paths: [...]
```

New:
```yaml
cfg-pdk:
  - name: nangate45
    site: FreePDK45_38x28_10R_NP_162NW_34O
    corners: { typ: pdk/.../typical.lib }
    tech-lef:    pdk/.../tech.lef
    macro-lef:   pdk/.../cells.lef
    cell-gds:    pdk/.../cells.gds
    klayout-tech:  pdk/.../FreePDK45.lyt
    klayout-props: pdk/.../FreePDK45.lyp
    tie-hi: "LOGIC1_X1/Z"
    tie-lo: "LOGIC0_X1/Z"
    fill-cells: [FILLCELL_X1, ...]
cfg-synth-platforms:
  - { name: nangate45_typ, pdk: nangate45, corner: typ }
cfg-pnr-platforms:
  - name: nangate45_typ
    pdk: nangate45
    sta-corner: typ
    cts-buffer: BUF_X4
    routing-layers: { signal: metal2-metal8, clock: metal4-metal8 }
```

`synth.yaml`: `libraries: [name]` → `platform: name` (single string).
RootConfig accessors: `get_synth_lib_cfg` → `get_synth_platform_cfg`, plus new `get_pdk_cfg` / `get_pnr_platform_cfg`.

### `rb pnr` subcommand

- `rb pnr <name> -c pnr.yaml` — Typer command mirroring `rb synth`.
- `pnr.yaml` schema: per-run config with `synth` + `synth-path` (references upstream synth.yaml entry), `constraints` (SDC), `platform` (cfg-pnr-platforms name), `floorplan: { utilization, aspect, core-margin }`, `reglvl`.
- `OpenRoadPnr` backend invokes `openroad` against a templated `flow.tcl` shipped under `src/rtl_buddy/pnr/`. Stages: read → floorplan → pins → tie cells → global place → resize → legalize → CTS → detail place → route → fill → reports.
- Outputs routed DEF + post-route netlist + SDC + timing report under `pnr/<run>/artefacts/`. Reports area / cells / WNS setup / WNS hold / DRC count.

### `--gds` / `--png` (KLayout streamout + render)

- `rb pnr ... --gds` runs KLayout headlessly after a successful OpenROAD run to merge routed DEF + cell GDS into `artefacts/<run>/<design>.gds`.
- `rb pnr ... --png` additionally renders a 2048×2048 PNG (`<design>.png`); implies `--gds`.
- `def2stream.py` and `gds2png.py` ship inside the wheel under `rtl_buddy/pnr/klayout/` and are copied to the artefact dir at run time.
- KLayout is resolved from `PATH` then `/Applications/KLayout/klayout.app/...` on macOS. Missing KLayout emits `pnr.no_klayout` and skips streamout without failing the P&R run.
- Summary table grows an **Outputs** column (`gds`, `gds+png`) when artefacts are emitted.

### OpenROAD version probe + feature-detect

- `_probe_openroad_version()` parses `openroad -version` (handles `26Q2-…`, `v2.0-…`, `25Q1`).
- Below `MIN_OPENROAD_VERSION = "25Q1"` emits `pnr.openroad_version_below_min` warning but still runs.
- `_has_tcl_command()` Tcl-side `info commands` probe wired up for future feature detection (e.g. `write_gds` once OpenROAD ships a Tcl binding).

### Skill + docs

- `src/rtl_buddy/skill/SKILL.md` — adds a "Synthesis and P&R" section, lists `pnr.yaml`, mentions `--gds`/`--png` and version events.
- `docs/concepts/pnr.md` — version expectations, optional KLayout install, `--gds`/`--png` usage, new artefacts.
- `docs/reference/cli.md` — regenerated; `scripts/gen_cli_reference.py` now emits per-subcommand sections for `pnr`, `cdc`, `cdc-regression`.

## Test plan

- [x] 253 tests pass; ruff lint + format clean; docs frontmatter check clean; CLI reference up to date.
- [x] End-to-end against `rtl-buddy-project-template` (parallel migration PR rtl-buddy/rtl-buddy-project-template#17): 1392 cells, 3213 µm², WNS setup +4.35 ns, hold +0.08 ns, 0 DRCs.
- [x] `rb pnr ... --png` end-to-end produces 1.2 MB GDS + 1.2 MB PNG; identical timing/DRC to the no-flag run.
- [ ] Reviewer with a different OpenROAD build to confirm reproducibility and version-probe behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)