### PR TITLE
docs: classify integrations and document dependency types

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,14 +63,10 @@ Prerequisites:
 
 - Python 3.11+
 - `uv`
-- A simulator on `PATH`
-  - Verilator is the recommended open-source starting point
-  - VCS is also supported as a first-class flow
-- Optional: the [rtl-buddy fork of Yosys](https://github.com/rtl-buddy/yosys) if you want to use `uv run rb synth ...`
-- Optional: Verible if you want to use `uv run rb verible ...` — e.g. `brew tap chipsalliance/verible && brew install verible` on macOS, or see [Verible releases](https://github.com/chipsalliance/verible/releases) for other platforms
-- Optional system-level coverage tools:
-  - `lcov` for LCOV and HTML coverage export
-  - [Coverview](https://github.com/antmicro/coverview) for Coverview package generation
+
+Beyond Python and `uv`, every other dependency is feature-dependent: which external tools you need depends on which `rb` commands you use. For example, `rb test` needs a simulator (Verilator / VCS), `rb synth` needs the [rtl-buddy/yosys fork](https://github.com/rtl-buddy/yosys), `rb wave` needs the [rtl-buddy/surfer fork](https://github.com/rtl-buddy/surfer).
+
+See the [installation page](https://rtl-buddy.github.io/rtl_buddy/latest/install/) for the full feature-to-dependency matrix, including integration types (Integrated tool vs Pluggable vs Pluggable — curated) and install commands.
 
 ## Documentation
 

--- a/docs/concepts/pnr.md
+++ b/docs/concepts/pnr.md
@@ -4,6 +4,14 @@ description: How to run OpenROAD place-and-route with rtl_buddy via the rb pnr c
 
 # Place-and-Route
 
+> **Integration type:** Integrated tool. `rb pnr` is built around OpenROAD today.
+>
+> **External binary required:** `openroad` ≥ `25Q1` — see [Installing OpenROAD](#installing-openroad).
+>
+> **Optional:** `klayout` for `--gds` / `--png` streamout and rendering — see [Installing KLayout](#installing-klayout-optional).
+>
+> See also: [Installation — External tools by feature](../install.md#external-tools-by-feature).
+
 `rb pnr` drives OpenROAD through a templated Tcl flow that consumes the tech-mapped netlist from an upstream `rb synth` run. It produces routed DEF, a post-route netlist + SDC, a timing report, and a DRC report under `pnr/<run>/artefacts/`.
 
 The flow is intentionally compact and config-driven — block-level knobs live in `pnr.yaml`, technology-level knobs live in `cfg-pdk` + `cfg-pnr-platforms` in `root_config.yaml`.

--- a/docs/concepts/synthesis.md
+++ b/docs/concepts/synthesis.md
@@ -4,18 +4,26 @@ description: How to run synthesis flows with rtl_buddy using synth.yaml, cfg-syn
 
 # Synthesis
 
+> **Integration type:** Pluggable — curated. `rb synth` supports a fixed list of synthesis tools selected by `tool:` in `synth.yaml`. The schema is open for future backends.
+>
+> **Supported `tool:` values:** `yosys` (Yosys-only flow); `openroad` (Yosys + OpenROAD-STA two-stage flow).
+>
+> **External binaries required:** `yosys` (the [rtl-buddy/yosys fork](https://github.com/rtl-buddy/yosys), see [Installing Yosys](#installing-yosys)); plus `openroad` on `PATH` when `tool: openroad` is selected — see [Installing OpenROAD](#installing-openroad).
+>
+> See also: [Installation — External tools by feature](../install.md#external-tools-by-feature).
+
 `rtl_buddy` provides a tool-agnostic synthesis flow that mirrors the simulation workflow. Synthesis runs are described in `synth.yaml` files; tool-specific defaults and PDK library paths live in `root_config.yaml`.
 
 ## Supported backends
 
-`rtl_buddy` ships two synthesis backends selectable via `tool:` in `synth.yaml`:
+`rb synth` ships two backends selectable via `tool:` in `synth.yaml`. Both backends use Yosys to map RTL to a gate-level netlist; they differ in whether OpenROAD is run afterwards for static timing analysis.
 
 | `tool:` | Backend | Multi-clock SDC | Reports |
 |---------|---------|-----------------|---------|
-| `yosys` | Yosys + ABC | Workaround (min period) | Gates, Area, WNS |
+| `yosys` | Yosys + ABC (single stage) | Workaround (min period) | Gates, Area, WNS |
 | `openroad` | Yosys (stage 1) + OpenROAD STA (stage 2) | Native `read_sdc` | Gates, Area, WNS, TNS |
 
-The OpenROAD backend removes the multi-clock SDC workaround: stage 1 maps RTL to a gate-level netlist with Yosys, stage 2 feeds that netlist into OpenROAD which loads the SDC natively and reports WNS (actual worst slack from `report_checks`) and TNS (total negative slack).
+The `openroad` backend removes the multi-clock SDC workaround: stage 1 maps RTL to a gate-level netlist with Yosys, stage 2 feeds that netlist into OpenROAD which loads the SDC natively and reports WNS (actual worst slack from `report_checks`) and TNS (total negative slack).
 
 ## Installing Yosys
 

--- a/docs/concepts/synthesis.md
+++ b/docs/concepts/synthesis.md
@@ -4,9 +4,9 @@ description: How to run synthesis flows with rtl_buddy using synth.yaml, cfg-syn
 
 # Synthesis
 
-> **Integration type:** Pluggable — curated. `rb synth` supports a fixed list of synthesis tools selected by `tool:` in `synth.yaml`. The schema is open for future backends.
+> **Integration type:** Pluggable. `rb synth` selects a synthesis tool via `tool:` in `synth.yaml`; the schema is open for future backends.
 >
-> **Supported `tool:` values:** `yosys` (Yosys-only flow); `openroad` (Yosys + OpenROAD-STA two-stage flow).
+> **Curated tools (`tool:` values):** `yosys` (Yosys-only flow); `openroad` (Yosys + OpenROAD-STA two-stage flow).
 >
 > **External binaries required:** `yosys` (the [rtl-buddy/yosys fork](https://github.com/rtl-buddy/yosys), see [Installing Yosys](#installing-yosys)); plus `openroad` on `PATH` when `tool: openroad` is selected — see [Installing OpenROAD](#installing-openroad).
 >

--- a/docs/concepts/wave.md
+++ b/docs/concepts/wave.md
@@ -4,6 +4,14 @@ description: How rb wave opens Surfer with live signal value annotation in your 
 
 # Waveform Viewer (`rb wave`)
 
+> **Integration type:** Integrated tool. `rb wave` is built around Surfer today; Vaporview / VS Code support is on the roadmap — tracked in [issue #84](https://github.com/rtl-buddy/rtl_buddy/issues/84).
+>
+> **External binary required:** Surfer, built from the [`rtl-buddy/surfer`](https://github.com/rtl-buddy/surfer) fork on the `rtl-buddy` branch. Mainline Surfer works for basic FST viewing but not for WCP signal-value annotation. See [Surfer build](#surfer-build).
+>
+> **Editor integration:** nvim for the full annotation round-trip (declaration jump + live signal values + add-from-editor). Any editor can be configured via `editor-cmd` for one-way "open at line".
+>
+> See also: [Installation — External tools by feature](../install.md#external-tools-by-feature).
+
 `rb wave` opens the [Surfer](https://surfer-project.org/) waveform viewer for a test and connects it to your editor via the **WCP** (Waveform Client Protocol). When you right-click a signal in Surfer and choose **Go to declaration**, rtl-buddy:
 
 1. Resolves the signal to its source file and line number

--- a/docs/install.md
+++ b/docs/install.md
@@ -10,13 +10,47 @@ description: How to install rtl_buddy into a project using uv, including prerequ
 
 - Python 3.11 or later
 - `uv`
-- Simulation tool on `PATH`: Verilator (macOS/Linux) or VCS (Linux)
-- Optional: Verible if you want to use `uv run rb verible ...` — e.g. `brew tap chipsalliance/verible && brew install verible` on macOS, or see [Verible releases](https://github.com/chipsalliance/verible/releases) for other platforms
-- Optional system-level coverage tools:
-  - `lcov` for `.info` export and HTML reports
-  - Antmicro `coverview` for Coverview package generation
 
-`rtl_buddy` can be used with different project-specific tool setups, but the primary supported flows are Verilator and VCS. Basic Verible command integration exists; broader first-class Verible and PeakRDL workflows are on the roadmap.
+Everything else is feature-dependent: which external tools you need is decided by which `rb` commands you use. The matrix below maps each command to its required and optional tools.
+
+## Dependency types
+
+rtl_buddy classifies dependencies into four buckets:
+
+- **Required dependency** — installed automatically with the `rtl_buddy` wheel; no external setup.
+- **Integrated tool** — rtl_buddy is built around one specific tool; you must install that exact tool to use the feature. No alternative is supported today.
+- **Pluggable** — rtl_buddy defines an interface; any tool that fits the interface works. rtl_buddy does not know what the tool specifically is or does — it just hands it the inputs the interface promises and consumes the outputs the interface promises.
+- **Pluggable — curated** — tools plug into the same plug point as **Pluggable**, but rtl_buddy carries first-class optimizations triggered by the tool name (e.g. coverage merging tuned for a specific simulator, a two-stage flow when a specific synthesis backend is selected). Adding a curated tool requires changes inside rtl_buddy; uncurated tools that still fit the interface remain supported.
+
+## Required dependencies
+
+These are installed automatically when you `uv add rtl_buddy` — no action needed:
+
+- `typer`, `click`, `pyserde[yaml]`, `ruamel.yaml`, `rich` — core CLI and config parsing.
+- `pywellen` — FST/VCD waveform reader. Used by `rb wave` annotation regardless of which waveform viewer is configured; the data layer is viewer-independent, which is why it ships with the wheel rather than as a Surfer-side install step.
+
+Plus Python ≥ 3.11 and `uv` itself.
+
+## External tools by feature
+
+| Command / feature | Integration type | Tools | Sub-deps and notes |
+|---|---|---|---|
+| `rb test`, `rb randtest`, `rb regression` | Pluggable — curated | Verilator, VCS (Icarus on the roadmap) | Install the `lcov` package in your OS for LCOV / HTML coverage export from Verilator runs. |
+| `rb verible` | Integrated tool | Verible | `brew tap chipsalliance/verible && brew install verible` on macOS; or see [Verible releases](https://github.com/chipsalliance/verible/releases). |
+| Coverview packaging (under `rb regression`) | Integrated tool | Antmicro [Coverview](https://github.com/antmicro/coverview) | Install the `info-process` package in your OS via Coverview's own setup for full package generation. |
+| `rb synth`, `rb synth-regression` | Pluggable — curated | `yosys`, `openroad` | `yosys` is required (the [rtl-buddy/yosys fork](https://github.com/rtl-buddy/yosys), see below); `openroad` is required only when `tool: openroad`. See [Synthesis](concepts/synthesis.md). |
+| `rb pnr` | Integrated tool | OpenROAD ≥ `25Q1` | Optional: `klayout` for `--gds` / `--png` streamout and rendering. See [Place-and-Route](concepts/pnr.md). |
+| `rb cdc`, `rb cdc-regression` | Integrated tool | [rtl-buddy-cdc](https://github.com/rtl-buddy/rtl-buddy-cdc) | SpyGlass support is on the roadmap — tracked in [issue #85](https://github.com/rtl-buddy/rtl_buddy/issues/85). |
+| `rb wave` | Integrated tool | Surfer (rtl-buddy fork, `rtl-buddy` branch) | nvim for full annotation round-trip; any editor configurable via `editor-cmd` for one-way "open at line". Vaporview / VS Code support is on the roadmap — tracked in [issue #84](https://github.com/rtl-buddy/rtl_buddy/issues/84). See [Waveform Viewer](concepts/wave.md). |
+
+### Forks required
+
+rtl_buddy currently validates against two forks rather than upstream:
+
+- **Surfer** — required. Use the [`rtl-buddy/surfer`](https://github.com/rtl-buddy/surfer) repo, branch `rtl-buddy`. Mainline Surfer works for basic FST viewing but does not support the WCP signal-value annotation features `rb wave` relies on.
+- **Yosys** — required. Use the [`rtl-buddy/yosys`](https://github.com/rtl-buddy/yosys) repo, which tracks upstream with rtl-buddy-specific patches.
+
+Build instructions live on the respective concept pages: [Surfer build](concepts/wave.md#surfer-build) and [Installing Yosys](concepts/synthesis.md#installing-yosys).
 
 ## Install Into A Project With `uv`
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -17,10 +17,10 @@ Everything else is feature-dependent: which external tools you need is decided b
 
 rtl_buddy classifies dependencies into four buckets:
 
-- **Required dependency** — installed automatically with the `rtl_buddy` wheel; no external setup.
-- **Integrated tool** — rtl_buddy is built around one specific tool; you must install that exact tool to use the feature. No alternative is supported today.
-- **Pluggable** — rtl_buddy defines an interface; any tool that fits the interface works. rtl_buddy does not know what the tool specifically is or does — it just hands it the inputs the interface promises and consumes the outputs the interface promises.
-- **Pluggable — curated** — tools plug into the same plug point as **Pluggable**, but rtl_buddy carries first-class optimizations triggered by the tool name (e.g. coverage merging tuned for a specific simulator, a two-stage flow when a specific synthesis backend is selected). Adding a curated tool requires changes inside rtl_buddy; uncurated tools that still fit the interface remain supported.
+- **Required dependency**: Installed automatically with the `rtl_buddy` wheel; no external setup.
+- **Integrated tool**: A rtl_buddy feature is built around one specific tool; you must install that exact tool to use the feature with no alternatives supported.
+- **Pluggable**: rtl_buddy defines an interface; any tool that fits the interface works. rtl_buddy does not know what the tool specifically is or does — it just hands it the inputs the interface promises and consumes the outputs the interface promises.
+- **Pluggable, curated**: tools that plug into the same plug point as **Pluggable**, but rtl_buddy carries first-class optimizations triggered by the tool name (e.g. coverage merging tuned for a specific simulator, a two-stage flow when a specific synthesis backend is selected). Having curated tools does not prevent non-curated tools from plugging into the same plug points.
 
 ## Required dependencies
 
@@ -29,16 +29,14 @@ These are installed automatically when you `uv add rtl_buddy` — no action need
 - `typer`, `click`, `pyserde[yaml]`, `ruamel.yaml`, `rich` — core CLI and config parsing.
 - `pywellen` — FST/VCD waveform reader. Used by `rb wave` annotation regardless of which waveform viewer is configured; the data layer is viewer-independent, which is why it ships with the wheel rather than as a Surfer-side install step.
 
-Plus Python ≥ 3.11 and `uv` itself.
-
 ## External tools by feature
 
-| Command / feature | Integration type | Tools | Sub-deps and notes |
+| Command / feature | Integration type | Curated tools | Sub-deps and notes |
 |---|---|---|---|
-| `rb test`, `rb randtest`, `rb regression` | Pluggable — curated | Verilator, VCS (Icarus on the roadmap) | Install the `lcov` package in your OS for LCOV / HTML coverage export from Verilator runs. |
+| `rb test`, `rb randtest`, `rb regression` | Pluggable | Verilator, VCS (Icarus on the roadmap) | Install the `lcov` package in your OS for LCOV / HTML coverage export from Verilator runs. |
 | `rb verible` | Integrated tool | Verible | `brew tap chipsalliance/verible && brew install verible` on macOS; or see [Verible releases](https://github.com/chipsalliance/verible/releases). |
 | Coverview packaging (under `rb regression`) | Integrated tool | Antmicro [Coverview](https://github.com/antmicro/coverview) | Install the `info-process` package in your OS via Coverview's own setup for full package generation. |
-| `rb synth`, `rb synth-regression` | Pluggable — curated | `yosys`, `openroad` | `yosys` is required (the [rtl-buddy/yosys fork](https://github.com/rtl-buddy/yosys), see below); `openroad` is required only when `tool: openroad`. See [Synthesis](concepts/synthesis.md). |
+| `rb synth`, `rb synth-regression` | Pluggable | `yosys`, `openroad` | `yosys` is required (the [rtl-buddy/yosys fork](https://github.com/rtl-buddy/yosys), see below); `openroad` is required only when `tool: openroad`. See [Synthesis](concepts/synthesis.md). |
 | `rb pnr` | Integrated tool | OpenROAD ≥ `25Q1` | Optional: `klayout` for `--gds` / `--png` streamout and rendering. See [Place-and-Route](concepts/pnr.md). |
 | `rb cdc`, `rb cdc-regression` | Integrated tool | [rtl-buddy-cdc](https://github.com/rtl-buddy/rtl-buddy-cdc) | SpyGlass support is on the roadmap — tracked in [issue #85](https://github.com/rtl-buddy/rtl_buddy/issues/85). |
 | `rb wave` | Integrated tool | Surfer (rtl-buddy fork, `rtl-buddy` branch) | nvim for full annotation round-trip; any editor configurable via `editor-cmd` for one-way "open at line". Vaporview / VS Code support is on the roadmap — tracked in [issue #84](https://github.com/rtl-buddy/rtl_buddy/issues/84). See [Waveform Viewer](concepts/wave.md). |


### PR DESCRIPTION
Introduce a four-bucket taxonomy for external tool dependencies and make each feature's integration shape explicit at the point of use.

- install.md: replace generic Prerequisites with a feature-to-dependency matrix covering rb test, verible, coverview, synth, pnr, cdc, wave. Document the four integration types (Required dependency, Integrated tool, Pluggable, Pluggable -- curated) and list pywellen as the viewer-agnostic FST/VCD reader that ships with the wheel. Surface the Surfer + Yosys forks under a dedicated 'Forks required' section.
- concepts/wave.md, synthesis.md, pnr.md: add an integration-type banner near the top of each page so readers see the dependency expectations before configuration details.
- concepts/synthesis.md: clarify that the yosys/openroad backends are not two alternative synthesizers -- both use Yosys for the actual netlist mapping; they differ in whether OpenROAD STA runs afterwards.
- README.md: trim Prerequisites to Python + uv and point to the install page for the full dependency matrix.

Roadmap items referenced from the new docs:
- issue #84 -- Vaporview/VS Code as a second rb wave backend.
- issue #85 -- SpyGlass as a second rb cdc backend.