### PR TITLE
fix(synth/openroad): consider all WNS reports in the summary, not just the first

### DIFF
--- a/src/rtl_buddy/tools/synth_openroad.py
+++ b/src/rtl_buddy/tools/synth_openroad.py
@@ -292,7 +292,12 @@ class OpenRoadSynth:
 
         lines.append("report_design_area")
         if constraints:
+            # report_checks emits per-group path reports for readability;
+            # report_worst_slack -max emits the single authoritative WNS
+            # across all path groups so the summary table reflects the
+            # true worst, not just whichever group OpenROAD printed first.
             lines.append("report_checks -path_delay max -digits 3")
+            lines.append("report_worst_slack -max -digits 3")
             lines.append("report_tns")
 
         script = "\n".join(lines) + "\n"
@@ -306,12 +311,24 @@ class OpenRoadSynth:
         return float(m.group(1)) if m else None
 
     def _parse_or_wns_ns(self, log_text: str) -> float | None:
-        # report_checks -path_delay max emits the worst slack as the last line of the
-        # timing path report: "   6.754   slack (MET)" or "  -0.123   slack (VIOLATED)"
-        m = re.search(
+        # Prefer the single authoritative line from `report_worst_slack -max`:
+        #     "worst slack max -0.431"
+        # That's the true WNS across every path group OpenROAD checked.
+        m = re.search(r"^worst slack\s+max\s+([-\d.]+)", log_text, re.MULTILINE)
+        if m:
+            return float(m.group(1))
+        # Fallback for legacy logs without report_worst_slack: scan every
+        # path-report summary line and take the minimum.
+        # `report_checks -path_delay max` emits one timing report per group,
+        # each ending with "   6.754   slack (MET)" or "  -0.123   slack (VIOLATED)".
+        # `re.search` would only grab the first; the summary needs the worst,
+        # so collect them all and return the min.
+        matches = re.findall(
             r"^\s+([-\d.]+)\s+slack\s+\((?:MET|VIOLATED)\)", log_text, re.MULTILINE
         )
-        return float(m.group(1)) if m else None
+        if not matches:
+            return None
+        return min(float(s) for s in matches)
 
     def _parse_or_tns_ns(self, log_text: str) -> float | None:
         m = re.search(r"^tns\s+(?:max|min)?\s*([-\d.]+)", log_text, re.MULTILINE)

--- a/tests/test_synth.py
+++ b/tests/test_synth.py
@@ -1038,6 +1038,7 @@ def test_openroad_or_script_has_lef_liberty_verilog_sdc(tmp_path):
     assert f"read_sdc {sdc}" in script
     assert "report_design_area" in script
     assert "report_checks -path_delay max" in script
+    assert "report_worst_slack -max" in script
     assert "report_tns" in script
 
 
@@ -1112,6 +1113,34 @@ def test_openroad_parse_wns_violated():
     assert or_synth._parse_or_wns_ns(
         "           -0.431   slack (VIOLATED)\n"
     ) == pytest.approx(-0.431)
+
+
+def test_openroad_parse_wns_prefers_report_worst_slack():
+    # When `report_worst_slack -max` is present, prefer that authoritative
+    # line over the per-group path summaries (which may appear in any order).
+    log = (
+        "            6.754   slack (MET)\n"
+        "           -0.431   slack (VIOLATED)\n"
+        "worst slack max -2.150\n"
+    )
+    or_synth = _make_openroad(Path("/tmp"))
+    assert or_synth._parse_or_wns_ns(log) == pytest.approx(-2.150)
+
+
+def test_openroad_parse_wns_multi_group_fallback_picks_min():
+    # Legacy log without `report_worst_slack`. The parser must scan every
+    # `slack (...)` line and return the minimum — the historical bug was
+    # to take the first match, which on multi-clock designs is whichever
+    # path group OpenROAD prints first, not the true WNS.
+    log = (
+        "            3.054   slack (MET)\n"
+        "           -2.000   slack (VIOLATED)\n"
+        "          -11.867   slack (VIOLATED)\n"
+        "         -556.494   slack (VIOLATED)\n"
+        "            5.919   slack (MET)\n"
+    )
+    or_synth = _make_openroad(Path("/tmp"))
+    assert or_synth._parse_or_wns_ns(log) == pytest.approx(-556.494)
 
 
 def test_openroad_parse_tns_with_corner():


### PR DESCRIPTION
## Summary

`_parse_or_wns_ns` used `re.search` against the slack lines emitted by
`report_checks -path_delay max -digits 3`. That OpenROAD command prints
**one timing report per path group** on multi-clock designs, each
ending with its own `slack (MET|VIOLATED)` summary line. Because
`re.search` returns the first match, the WNS column reflected whichever
group OpenROAD printed first — on the tiny-NPU shakeout that is the
reset-recovery path from the `rst_n` input pad — and silently hid the
true worst slack across the rest of the design.

## Fix

1. Emit `report_worst_slack -max -digits 3` in the OpenROAD Tcl
   script. That produces one authoritative line
   ```
   worst slack max -2.150
   ```
   covering every path group OpenROAD checks.
2. Parser prefers the `worst slack max` line. As a fallback (for
   legacy logs without `report_worst_slack`), it scans every
   `slack (MET|VIOLATED)` line and returns the minimum — so the
   summary value is always the true worst.

## Tests

- `test_openroad_or_script_with_sdc_includes_timing_reports` asserts
  the new `report_worst_slack -max` line is emitted.
- `test_openroad_parse_wns_prefers_report_worst_slack` covers the
  authoritative path.
- `test_openroad_parse_wns_multi_group_fallback_picks_min` reproduces
  the multi-group log layout that triggered the original bug
  (`+3.054 met, -2.000, -11.867, -556.494 violated, +5.919 met`) and
  pins the parser to `-556.494`.

All 70 `tests/test_synth.py` cases pass.

## Discovered while working

PR https://github.com/expedera-sg/rtl-buddy-ai-project/pull/36 (tiny
NPU pipelining + sync-reset migration). The headline `rb synth` WNS
went from -132 ns to +3 ns after the sync-reset conversion, but a
register-to-register `s_clk` path with -556 ns slack was hiding
further down the same log. The PR description for #36 has the full
context, but the bug is in rtl_buddy itself and worth fixing in
isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)