### PR TITLE
fix(synth,cdc): stop +incdir+ leaking as a synth source (closes #69)

### DIFF
--- a/src/rtl_buddy/tools/cdc_rtl_buddy.py
+++ b/src/rtl_buddy/tools/cdc_rtl_buddy.py
@@ -69,7 +69,7 @@ class RtlBuddyCdc:
             output_path=fl_path,
         )
         vlog_fl.write_output(
-            output_filepath=fl_path, unroll=True, strip=True, deduplicate=True
+            output_filepath=fl_path, unroll=True, strip=False, deduplicate=True
         )
         return fl_path
 

--- a/src/rtl_buddy/tools/synth_openroad.py
+++ b/src/rtl_buddy/tools/synth_openroad.py
@@ -445,7 +445,7 @@ class OpenRoadSynth:
                 output_path=fl_path,
             )
             vlog_fl.write_output(
-                output_filepath=fl_path, unroll=True, strip=True, deduplicate=True
+                output_filepath=fl_path, unroll=True, strip=False, deduplicate=True
             )
         except FilelistError as e:
             log_event(

--- a/src/rtl_buddy/tools/synth_yosys.py
+++ b/src/rtl_buddy/tools/synth_yosys.py
@@ -70,7 +70,7 @@ class YosysSynth:
             output_path=fl_path,
         )
         vlog_fl.write_output(
-            output_filepath=fl_path, unroll=True, strip=True, deduplicate=True
+            output_filepath=fl_path, unroll=True, strip=False, deduplicate=True
         )
         return fl_path
 

--- a/tests/test_synth.py
+++ b/tests/test_synth.py
@@ -354,6 +354,31 @@ def test_source_files_resolves_relative_paths(tmp_path):
     assert paths == [str(sv)]
 
 
+def test_filelist_with_incdir_does_not_leak_directory(tmp_path):
+    # Regression: rtl_buddy#69 — `+incdir+<path>` in the model filelist
+    # leaked into the generated synth.f as a bare directory path because
+    # `strip=True` removed the option prefix, then
+    # `_source_files_from_filelist` couldn't tell it from a source file.
+    sv = tmp_path / "top.sv"
+    sv.write_text("")
+    sub_f = tmp_path / "src.f"
+    sub_f.write_text("+incdir+.\ntop.sv\n")
+    from rtl_buddy.config.model import ModelConfig
+
+    model = ModelConfig(
+        name="m", filelist=[f"-F {sub_f}"], path=str(tmp_path / "models.yaml")
+    )
+    out = tmp_path / "synth.f"
+    VlogFilelist(name="t", model_cfg=model, output_path=str(out)).write_output(
+        output_filepath=str(out), unroll=True, strip=False, deduplicate=True
+    )
+    ys = _make_yosys(tmp_path)
+    paths = ys._source_files_from_filelist(str(out))
+    assert paths == [str(sv)], (
+        f"+incdir+ leaked into source list: {paths!r}; synth.f was:\n{out.read_text()}"
+    )
+
+
 # ---------------------------------------------------------------------------
 # YosysSynth — _write_script
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `synth_yosys._write_filelist`, `synth_openroad`, and `cdc_rtl_buddy` were calling `VlogFilelist.write_output(..., strip=True, ...)`. With `strip=True`, the `+incdir+` / `-v` / `-y` option tags are removed before `synth.f` / `cdc.f` is written. The matching `_source_files_from_filelist` consumers then filter by string prefix — but the prefixes are gone, so a `+incdir+<dir>` line is indistinguishable from a source file and gets emitted as `read_verilog -sv -defer <dir>` in the generated Yosys script.
- The three call sites now pass `strip=False`. The artefact files become proper Verilog filelists; the existing prefix-based filter works as designed; no public API changes.
- Adds a round-trip regression test (`VlogFilelist.write_output` → `_source_files_from_filelist`) that includes a `+incdir+` entry — the existing direct-input tests covered the consumer in isolation but never exercised the actual write→read path that was broken.

Closes #69.

## Test plan

- [x] `uv run pytest -q` — 256 passed (was 255 before; +1 new regression test)
- [x] `uv run ruff check` — clean
- [x] End-to-end against `rtl-buddy-project-template` with this branch via `uv run --with-editable ../rtl_buddy rb synth-regression -c synth_regression.yaml` — all entries PASS, including a new `demo_synth_incdir` regression block (PR in rtl-buddy-project-template wires that up).
- [x] Generated `synth.ys` confirmed to no longer contain a bare-directory `read_verilog -sv -defer <dir>` line for the `+incdir+` case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)