### PR TITLE
ci(coverage): set fail_under threshold to lock in current state

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,7 @@ omit = [
 [tool.coverage.report]
 show_missing = true
 skip_covered = false
+fail_under = 48
 exclude_lines = [
   "pragma: no cover",
   "raise NotImplementedError",


### PR DESCRIPTION
## Summary
- Sets `[tool.coverage.report].fail_under = 48` so CI blocks regressions below the current 49.69% branch coverage.
- Threshold is 2pp below today's measurement to absorb normal noise from refactors that briefly perturb coverage; bump it after future coverage PRs land.

## Note
The 54% number from #109's description was statement-only coverage; with `branch = true` enabled the actual total is 49.69%. Setting the bar at 50 would fail CI today, so it's 48.

## Test plan
- [ ] `uv run pytest --cov -q` → "Required test coverage of 48.0% reached. Total coverage: 49.69%"
- [ ] Tests workflow runs green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)