### PR TITLE
test: add minimal_project fixture and CLI tests against RootConfig

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,25 @@
+"""Shared pytest fixtures for the rtl_buddy test suite."""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+
+_FIXTURES_ROOT = Path(__file__).parent / "fixtures"
+
+
+@pytest.fixture
+def minimal_project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Copy the minimal_project fixture to a tmp dir, chdir into it, and return its path.
+
+    The fixture provides a valid root_config.yaml + regression.yaml + tests.yaml
+    + models.yaml so commands that walk through RootConfig load can be exercised
+    end-to-end without touching real EDA tooling.
+    """
+    target = tmp_path / "project"
+    shutil.copytree(_FIXTURES_ROOT / "minimal_project", target)
+    monkeypatch.chdir(target)
+    return target

--- a/tests/fixtures/minimal_project/models.yaml
+++ b/tests/fixtures/minimal_project/models.yaml
@@ -1,0 +1,6 @@
+rtl-buddy-filetype: model_config
+models:
+  - name: example
+    desc: example model used by CLI smoke tests
+    filelist:
+      - src/example.sv

--- a/tests/fixtures/minimal_project/regression.yaml
+++ b/tests/fixtures/minimal_project/regression.yaml
@@ -1,0 +1,3 @@
+rtl-buddy-filetype: reg_config
+test-configs:
+  - tests.yaml

--- a/tests/fixtures/minimal_project/root_config.yaml
+++ b/tests/fixtures/minimal_project/root_config.yaml
@@ -1,0 +1,28 @@
+# Minimal root_config used by CLI smoke tests. Matches both macOS and Linux
+# hosts so the same fixture works in dev and in CI.
+rtl-buddy-filetype: project_root_config
+
+cfg-platforms:
+  - os: "test-host"
+    unames: ["Darwin", "Linux"]
+    builder: "stub"
+    verible: "stub-verible"
+
+cfg-rtl-builder:
+  - name: "stub"
+    builder: "echo"
+    builder-simv: "obj_dir/simv"
+    sim-rand-seed: 1
+    sim-rand-seed-prefix: "+seed="
+    builder-opts:
+      debug:
+        compile-time: "--no-op"
+        run-time: "--no-op"
+
+cfg-verible:
+  - name: "stub-verible"
+    path: "/usr/bin"
+    extra_args: {}
+
+cfg-rtl-reg:
+  reg-cfg-path: "regression.yaml"

--- a/tests/fixtures/minimal_project/src/example.sv
+++ b/tests/fixtures/minimal_project/src/example.sv
@@ -1,0 +1,3 @@
+// stub source file referenced by models.yaml; contents are irrelevant.
+module example;
+endmodule

--- a/tests/fixtures/minimal_project/tests.yaml
+++ b/tests/fixtures/minimal_project/tests.yaml
@@ -1,0 +1,32 @@
+rtl-buddy-filetype: test_config
+testbenches:
+  - name: tb_basic
+    filelist:
+      - src/example.sv
+tests:
+  - name: basic
+    desc: trivial smoke-test entry
+    model: example
+    model_path: models.yaml
+    reglvl: 0
+    plusargs:
+    plusdefines:
+    uvm:
+    preproc:
+    postproc:
+    sweep:
+    testbench: tb_basic
+    sim_timeout:
+  - name: extra
+    desc: second test entry used for --list output
+    model: example
+    model_path: models.yaml
+    reglvl: 5
+    plusargs:
+    plusdefines:
+    uvm:
+    preproc:
+    postproc:
+    sweep:
+    testbench: tb_basic
+    sim_timeout:

--- a/tests/test_cli_with_fixture.py
+++ b/tests/test_cli_with_fixture.py
@@ -1,0 +1,124 @@
+"""CLI smoke tests that exercise the RootConfig load path.
+
+These tests use the ``minimal_project`` fixture (see ``tests/conftest.py``)
+which sets up a valid root_config.yaml + regression.yaml + tests.yaml +
+models.yaml in a temp dir and chdirs into it. They cover the slice of
+``rtl_buddy.py`` and ``config/root.py`` that runs whenever any non-skill,
+non-docs command is invoked.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from rtl_buddy.rtl_buddy import RtlBuddy
+
+
+def _runner() -> tuple[CliRunner, RtlBuddy]:
+    return CliRunner(), RtlBuddy(name="test_cli_fixture")
+
+
+def test_test_list_emits_configured_test_names(minimal_project: Path):
+    runner, rb = _runner()
+    result = runner.invoke(rb.app, ["test", "--list"])
+    assert result.exit_code == 0, result.output
+    # tests.yaml declares "basic" and "extra".
+    assert "basic" in result.output
+    assert "extra" in result.output
+
+
+def test_test_list_explicit_config_path(minimal_project: Path):
+    runner, rb = _runner()
+    result = runner.invoke(rb.app, ["test", "-c", "tests.yaml", "--list"])
+    assert result.exit_code == 0, result.output
+    assert "basic" in result.output
+
+
+def test_test_list_missing_config_errors_with_exit_2(minimal_project: Path):
+    runner, rb = _runner()
+    result = runner.invoke(rb.app, ["test", "-c", "does-not-exist.yaml", "--list"])
+    # FatalRtlBuddyError is caught by run(), but CliRunner only sees the
+    # raised exception. Either way, exit code must be non-zero.
+    assert result.exit_code != 0
+
+
+def test_filelist_writes_generated_filelist(minimal_project: Path):
+    runner, rb = _runner()
+    out = minimal_project / "run.f"
+    result = runner.invoke(
+        rb.app, ["filelist", "example", str(out), "-c", "models.yaml"]
+    )
+    assert result.exit_code == 0, result.output
+    assert out.is_file()
+    text = out.read_text()
+    assert "rtl-buddy generated model filelist" in text
+    assert "example.sv" in text
+
+
+def test_filelist_unknown_model_exits_nonzero(minimal_project: Path):
+    runner, rb = _runner()
+    result = runner.invoke(
+        rb.app, ["filelist", "missing_model", "run.f", "-c", "models.yaml"]
+    )
+    assert result.exit_code != 0
+
+
+def test_builder_override_validation_against_root_config(minimal_project: Path):
+    """``-B <name>`` is validated against builders declared in root_config.yaml."""
+    runner, rb = _runner()
+
+    # Valid builder name from root_config.yaml: "stub".
+    result_ok = runner.invoke(rb.app, ["-B", "stub", "test", "--list"])
+    assert result_ok.exit_code == 0, result_ok.output
+
+    # Unknown builder name should fail validation in cb_builder.
+    result_bad = runner.invoke(rb.app, ["-B", "not-a-builder", "test", "--list"])
+    assert result_bad.exit_code != 0
+    assert (
+        "configured builders" in result_bad.output.lower()
+        or "stub" in result_bad.output
+    )
+
+
+def test_discover_rtl_builder_names_from_real_root_config(minimal_project: Path):
+    """The static discovery helper should find the builder declared in the fixture."""
+    from rtl_buddy.config.root import RootConfig
+
+    names = RootConfig.discover_rtl_builder_names()
+    assert names == ["stub"]
+
+
+def test_filelist_with_strip_and_deduplicate(minimal_project: Path):
+    """Exercise the strip/deduplicate post-processing in VlogFilelist."""
+    runner, rb = _runner()
+    out = minimal_project / "stripped.f"
+    result = runner.invoke(
+        rb.app,
+        [
+            "filelist",
+            "example",
+            str(out),
+            "-c",
+            "models.yaml",
+            "--strip",
+            "--deduplicate",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    text = out.read_text()
+    # With --strip, leading "-y "/"+incdir+" options are removed; the bare path remains.
+    assert "example.sv" in text
+
+
+def test_root_config_resolves_from_nested_cwd(minimal_project: Path, monkeypatch):
+    """RootConfig discovery should walk up from a nested working directory."""
+    nested = minimal_project / "src"
+    monkeypatch.chdir(nested)
+    runner, rb = _runner()
+    result = runner.invoke(
+        rb.app, ["test", "-c", str(minimal_project / "tests.yaml"), "--list"]
+    )
+    assert result.exit_code == 0, result.output
+    assert "basic" in result.output


### PR DESCRIPTION
Adds a reusable project-root test fixture so CLI commands that need a valid `RootConfig` can be exercised in-process via `typer.testing.CliRunner`. Builds on #108 and #109; complements #110 (fail-under threshold).

## Summary
- `tests/fixtures/minimal_project/` — minimal valid `root_config.yaml` + `regression.yaml` + `tests.yaml` + `models.yaml` + a stub source file. Declares one builder (`stub`) and one platform whose `unames` matches both Darwin and Linux, so the fixture works on dev macs and Ubuntu CI without modification.
- `tests/conftest.py` — pytest fixture `minimal_project` that `copytree`s the fixture into `tmp_path` and `monkeypatch.chdir`s into it.
- `tests/test_cli_with_fixture.py` — 9 tests covering `rb test --list`, `rb filelist <model>` (+ `--strip --deduplicate`), `-B` builder-override validation against `root_config.yaml`, `RootConfig.discover_rtl_builder_names`, missing-config / unknown-model error paths, and nested-cwd root discovery.

## Coverage delta

| File | Before | After |
|---|---:|---:|
| `config/root.py` | 43% | **65%** |
| `config/platform.py` | 35% | **75%** |
| `config/model.py` | ~70% | **89%** |
| `config/verible.py` | 83% | **90%** |
| **TOTAL (branch, src/rtl_buddy)** | **49.69%** | **51%** |

The fixture is the load-bearing piece: future PRs can drop `synth.yaml` / `cdc.yaml` / `pnr.yaml` / `power.yaml` / `fpv.yaml` alongside it and write `--list` smoke tests for each subcommand to chip away at the remaining 70+% gap in `rtl_buddy.py`.

## Test plan
- [ ] `uv run pytest -q` → 394 passed
- [ ] `uv run pytest tests/test_cli_with_fixture.py -q` → 9 passed
- [ ] `uv run ruff check` + `uv run ruff format --check` clean
- [ ] Tests workflow runs green on this PR

## Notes
- 1.3pp total bump is modest compared to #109 because most of `rtl_buddy.py`'s 600+ uncovered lines are in command bodies for synth/pnr/power/cdc/fpv — each needs its own minimal config. This PR's value is the fixture infrastructure that makes those follow-ups cheap.
- Bump the `fail_under` from #110 once both that PR and this land — 49 would be appropriate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)