### PR TITLE
Phase 10b: scaffold rtl-buddy-hub package + rb hub CLI (#115)

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -60,6 +60,7 @@ Usage: rtl-buddy [OPTIONS] COMMAND [ARGS]...
 │ cdc-regression     run CDC lint regression                                           │
 │ fpv                run formal property verification                                  │
 │ fpv-regression     run FPV regression                                                │
+│ hub                manage the rtl-buddy-hub daemon                                   │
 │ skill              manage the rtl_buddy agent skill                                  │
 │ docs               browse bundled documentation                                      │
 │ spec               spec traceability commands                                        │

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,8 @@ dependencies = [
   "click >= 8.3.0",
   "pyserde[yaml] >= 0.27.0",
   "rich >= 14.0.0",
-  "pywellen >= 0.20.0"
+  "pywellen >= 0.20.0",
+  "jsonschema >= 4.21.0",
 ]
 
 authors = [

--- a/src/rtl_buddy/hub/__init__.py
+++ b/src/rtl_buddy/hub/__init__.py
@@ -1,0 +1,39 @@
+"""rtl-buddy-hub daemon package.
+
+Phase 10b implementation (`rtl-buddy/rtl_buddy#115`) of the wire
+contract frozen by `rtl-buddy/rtl-buddy-view#19` —
+``docs/hub-protocol.md`` v1 in the rtl-buddy-view repo.
+
+The daemon mediates messages between three views of a SystemVerilog
+design (schematic / waveform / source) so a click in one is reflected
+in the others. See the spec for the full picture; this package contains
+the Python implementation:
+
+* :mod:`rtl_buddy.hub.protocol` — wire envelope codec.
+* :mod:`rtl_buddy.hub.config`   — ``.rtl-buddy/hub.toml`` loader.
+* :mod:`rtl_buddy.hub.discovery`— ``.rtl-buddy/hub.json`` lifecycle.
+* :mod:`rtl_buddy.hub.state`    — in-memory selection / cursor cache.
+* :mod:`rtl_buddy.hub.cli`      — ``rb hub`` Typer subcommand surface.
+"""
+
+from .protocol import (
+    HubProtocolError,
+    Origin,
+    Kind,
+    Envelope,
+    decode,
+    encode,
+    new_id,
+    PROTOCOL_VERSION,
+)
+
+__all__ = [
+    "HubProtocolError",
+    "Origin",
+    "Kind",
+    "Envelope",
+    "decode",
+    "encode",
+    "new_id",
+    "PROTOCOL_VERSION",
+]

--- a/src/rtl_buddy/hub/cli.py
+++ b/src/rtl_buddy/hub/cli.py
@@ -1,0 +1,250 @@
+"""``rb hub`` Typer subcommand surface.
+
+Phase 10b ships in slices; this module covers the CLI plumbing for all
+of the user-facing entry points so the muscle memory locks in early.
+The server-side commands (``start``, ``stop``) currently exercise only
+the discovery + config layers — the asyncio server lands in PR 2.
+
+Command summary (per §4.1 of the protocol spec):
+
+* ``rb hub start``    — bind, write ``.rtl-buddy/hub.json``, run loop.
+* ``rb hub stop``     — SIGTERM the PID in ``hub.json``.
+* ``rb hub status``   — print the current discovery record + liveness.
+* ``rb hub log``      — tail ``.rtl-buddy/hub.log``.
+* ``rb hub config validate`` — schema-check ``.rtl-buddy/hub.toml``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from importlib.metadata import version as _pkg_version
+from pathlib import Path
+
+import typer
+from typing_extensions import Annotated
+
+from ..config.root import discover_project_root
+from ..errors import FatalRtlBuddyError
+from ..logging_utils import emit_console_text, log_event
+from . import config as hub_config
+from . import discovery
+
+
+logger = logging.getLogger(__name__)
+
+
+app = typer.Typer(help="manage the rtl-buddy-hub daemon", no_args_is_help=True)
+config_app = typer.Typer(help="hub.toml utilities", no_args_is_help=True)
+app.add_typer(config_app, name="config")
+
+
+def _resolve_project_root() -> Path:
+    """Find the rtl-buddy project root for the current invocation.
+
+    The hub is strictly per-project (§4.1 / §4.7). Failing here with a
+    pointer at ``rb`` discovery rules is more useful than a downstream
+    "no such file" error from the discovery layer.
+    """
+
+    try:
+        return discover_project_root()
+    except FatalRtlBuddyError as exc:
+        raise FatalRtlBuddyError(
+            f"{exc} The hub is per-project: run `rb hub ...` from inside a project tree."
+        ) from exc
+
+
+def _resolve_config(project_root: Path) -> hub_config.HubConfig:
+    path = hub_config.default_config_path(project_root)
+    return hub_config.load_hub_config(path if path.exists() else None)
+
+
+@app.command("start", help="start the rtl-buddy-hub daemon for this project")
+def cmd_start(
+    foreground: Annotated[
+        bool,
+        typer.Option("--foreground/--daemon", help="Run in the foreground (default)."),
+    ] = True,
+    serve_viewer: Annotated[
+        bool,
+        typer.Option(
+            "--serve-viewer/--no-serve-viewer",
+            help="Also serve the rtl-buddy-view SPA. Requires PR 5 of #115.",
+        ),
+    ] = False,
+) -> None:
+    """Bind, write ``hub.json``, run the server loop.
+
+    The asyncio server is implemented in PR 2; this command currently
+    validates the project root, parses ``hub.toml``, checks that no
+    other hub is running, and then exits with a clear "server not yet
+    implemented" notice. The plumbing exercised here is what PR 2
+    snaps into place.
+    """
+
+    project_root = _resolve_project_root()
+    cfg = _resolve_config(project_root)
+
+    existing = discovery.read_record(project_root)
+    if existing is not None and discovery._pid_is_live(existing.pid):  # noqa: SLF001
+        raise discovery.HubAlreadyRunningError(
+            existing.pid, discovery.discovery_path(project_root)
+        )
+
+    log_event(
+        logger,
+        logging.INFO,
+        "hub.start.preflight_ok",
+        project_root=str(project_root),
+        listen_port=cfg.hub.listen_port,
+        http_port=cfg.hub.http_port,
+        foreground=foreground,
+        serve_viewer=serve_viewer,
+    )
+    emit_console_text(
+        "rb hub start: server loop not yet implemented "
+        "(PR 2 of rtl-buddy/rtl_buddy#115). "
+        "Discovery, config, and lifecycle plumbing is in place.",
+        style="yellow",
+    )
+    raise typer.Exit(code=2)
+
+
+@app.command("stop", help="ask the running hub to shut down")
+def cmd_stop() -> None:
+    project_root = _resolve_project_root()
+    record = discovery.read_record(project_root)
+    if record is None:
+        emit_console_text(
+            f"no hub running for {project_root} (no .rtl-buddy/hub.json).",
+            style="yellow",
+        )
+        raise typer.Exit(code=1)
+    if not discovery._pid_is_live(record.pid):  # noqa: SLF001
+        emit_console_text(
+            f"hub.json points at pid {record.pid} but that process is not running; "
+            "removing the stale file.",
+            style="yellow",
+        )
+        discovery.delete_record_if_owner(project_root, expected_pid=record.pid)
+        raise typer.Exit(code=1)
+
+    discovery.signal_process(record.pid)
+    log_event(
+        logger,
+        logging.INFO,
+        "hub.stop.signal_sent",
+        pid=record.pid,
+        project_root=str(project_root),
+    )
+    emit_console_text(f"sent SIGTERM to hub pid {record.pid}.")
+
+
+@app.command("status", help="print the running hub's discovery record")
+def cmd_status() -> None:
+    project_root = _resolve_project_root()
+    record = discovery.read_record(project_root)
+    if record is None:
+        emit_console_text(f"no hub running for {project_root}.", style="yellow")
+        raise typer.Exit(code=1)
+
+    live = discovery._pid_is_live(record.pid)  # noqa: SLF001
+    state = "RUNNING" if live else "STALE (pid not alive)"
+    style = "green" if live else "red"
+
+    emit_console_text(f"hub {state}", style=style)
+    emit_console_text(f"  project_root   : {record.project_root}")
+    emit_console_text(f"  pid            : {record.pid}")
+    emit_console_text(f"  tcp            : {record.tcp}")
+    emit_console_text(f"  server_version : {record.server_version}")
+    emit_console_text(f"  started_at     : {record.started_at}")
+    if not live:
+        raise typer.Exit(code=1)
+
+
+@app.command("log", help="tail the hub log")
+def cmd_log(
+    lines: Annotated[
+        int,
+        typer.Option("-n", "--lines", help="Trailing lines to print before following."),
+    ] = 50,
+    follow: Annotated[
+        bool,
+        typer.Option("-f/--no-follow", help="Follow the log (tail -f)."),
+    ] = False,
+) -> None:
+    project_root = _resolve_project_root()
+    cfg = _resolve_config(project_root)
+    log_path = (project_root / cfg.hub.log_path).resolve()
+    if not log_path.exists():
+        emit_console_text(f"log not found: {log_path}", style="yellow")
+        raise typer.Exit(code=1)
+
+    _tail(log_path, lines=lines)
+    if follow:
+        _follow(log_path)
+
+
+def _tail(path: Path, *, lines: int) -> None:
+    with path.open("r", encoding="utf-8", errors="replace") as fh:
+        tail = fh.readlines()[-lines:]
+    for line in tail:
+        emit_console_text(line.rstrip("\n"))
+
+
+def _follow(path: Path) -> None:
+    with path.open("r", encoding="utf-8", errors="replace") as fh:
+        fh.seek(0, os.SEEK_END)
+        try:
+            while True:
+                line = fh.readline()
+                if not line:
+                    time.sleep(0.2)
+                    continue
+                emit_console_text(line.rstrip("\n"))
+        except KeyboardInterrupt:
+            return
+
+
+@config_app.command("validate", help="schema-check .rtl-buddy/hub.toml")
+def cmd_config_validate(
+    path: Annotated[
+        Path | None,
+        typer.Option("--path", help="Override the default project hub.toml path."),
+    ] = None,
+) -> None:
+    if path is None:
+        project_root = _resolve_project_root()
+        path = hub_config.default_config_path(project_root)
+
+    if not path.exists():
+        emit_console_text(
+            f"{path} does not exist — defaults will be used at startup.",
+            style="yellow",
+        )
+        return
+
+    try:
+        cfg = hub_config.load_hub_config(path)
+    except hub_config.HubConfigError as exc:
+        emit_console_text(str(exc), style="red")
+        raise typer.Exit(code=1)
+
+    emit_console_text(f"ok: {path}")
+    emit_console_text(f"  listen_port    : {cfg.hub.listen_port}")
+    emit_console_text(f"  http_port      : {cfg.hub.http_port}")
+    emit_console_text(f"  log_path       : {cfg.hub.log_path}")
+    emit_console_text(f"  tb_prefix      : {cfg.mapping.tb_prefix!r}")
+    emit_console_text(f"  signal_aliases : {len(cfg.mapping.signal_aliases)}")
+
+
+def _package_version() -> str:
+    try:
+        return _pkg_version("rtl-buddy")
+    except Exception:
+        return "0.0.0+unknown"
+
+
+__all__ = ["app"]

--- a/src/rtl_buddy/hub/config.py
+++ b/src/rtl_buddy/hub/config.py
@@ -1,0 +1,193 @@
+"""Loader for ``<project_root>/.rtl-buddy/hub.toml``.
+
+The hub config is intentionally tiny (§5 of the protocol spec): a
+``[hub]`` block for transport-layer tunables and a ``[mapping]`` block
+for the testbench-prefix strip + per-instance aliases that drive
+``view ↔ wave`` resolution. Anything else (surfer flags, nvim
+keymaps, …) lives in the adapters, not here.
+
+The loader is forgiving by design — the file is optional and defaults
+are baked into :class:`HubConfig`. Unknown top-level sections raise
+:class:`HubConfigError` so typos are caught at startup, but unknown
+keys *inside* known sections are tolerated to keep forward-compat
+cheap.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from dataclasses import dataclass, field, replace
+from pathlib import Path
+from typing import Any
+
+
+HUB_CONFIG_FILENAME = "hub.toml"
+DEFAULT_TB_PREFIX = "tb.dut."
+DEFAULT_LOG_PATH = ".rtl-buddy/hub.log"
+
+
+class HubConfigError(Exception):
+    """Raised when the on-disk ``hub.toml`` is malformed or unreadable."""
+
+
+@dataclass(frozen=True, slots=True)
+class SignalAlias:
+    """Pre-strip rewrite from a legacy testbench scope to a view path.
+
+    Applied *before* :attr:`HubMappingConfig.tb_prefix` is stripped, so
+    the ``wave`` side of the alias is the literal wave path, not a
+    post-prefix-strip remnant. See §5 of the protocol spec.
+    """
+
+    wave: str
+    view: str
+
+
+@dataclass(frozen=True, slots=True)
+class HubServerConfig:
+    """``[hub]`` block — transport configuration."""
+
+    listen_port: int = 0
+    http_port: int = 0
+    log_path: str = DEFAULT_LOG_PATH
+
+
+@dataclass(frozen=True, slots=True)
+class HubMappingConfig:
+    """``[mapping]`` block — coordinate translation configuration."""
+
+    tb_prefix: str = DEFAULT_TB_PREFIX
+    signal_aliases: tuple[SignalAlias, ...] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True, slots=True)
+class HubConfig:
+    """Parsed ``hub.toml`` — handed to the server loop and resolver."""
+
+    hub: HubServerConfig = field(default_factory=HubServerConfig)
+    mapping: HubMappingConfig = field(default_factory=HubMappingConfig)
+    source_path: Path | None = None
+
+    @property
+    def listen_port(self) -> int:
+        return self.hub.listen_port
+
+    @property
+    def tb_prefix(self) -> str:
+        return self.mapping.tb_prefix
+
+
+_KNOWN_SECTIONS = frozenset({"hub", "mapping"})
+
+
+def load_hub_config(path: Path | None) -> HubConfig:
+    """Read ``path`` (a ``hub.toml``) and return a :class:`HubConfig`.
+
+    When ``path`` is ``None`` or points at a non-existent file, returns
+    a default :class:`HubConfig`. The protocol's design choice is that
+    the hub runs with sensible defaults even on a freshly initialised
+    project; the file is for overrides, not gating.
+    """
+
+    if path is None or not path.exists():
+        return HubConfig()
+
+    try:
+        with path.open("rb") as fh:
+            raw = tomllib.load(fh)
+    except OSError as exc:
+        raise HubConfigError(f"cannot read {path}: {exc}") from exc
+    except tomllib.TOMLDecodeError as exc:
+        raise HubConfigError(f"{path}: invalid TOML — {exc}") from exc
+
+    unknown = sorted(set(raw) - _KNOWN_SECTIONS)
+    if unknown:
+        raise HubConfigError(
+            f"{path}: unknown section(s) {unknown}; expected any of {sorted(_KNOWN_SECTIONS)}"
+        )
+
+    hub_block = _parse_hub_block(raw.get("hub", {}), path)
+    mapping_block = _parse_mapping_block(raw.get("mapping", {}), path)
+    return HubConfig(hub=hub_block, mapping=mapping_block, source_path=path)
+
+
+def _parse_hub_block(raw: dict[str, Any], path: Path) -> HubServerConfig:
+    defaults = HubServerConfig()
+
+    listen_port = raw.get("listen_port", defaults.listen_port)
+    if not isinstance(listen_port, int) or listen_port < 0 or listen_port > 65535:
+        raise HubConfigError(
+            f"{path}: [hub].listen_port must be an integer in [0, 65535], got {listen_port!r}"
+        )
+
+    http_port = raw.get("http_port", defaults.http_port)
+    if not isinstance(http_port, int) or http_port < 0 or http_port > 65535:
+        raise HubConfigError(
+            f"{path}: [hub].http_port must be an integer in [0, 65535], got {http_port!r}"
+        )
+
+    log_path = raw.get("log_path", defaults.log_path)
+    if not isinstance(log_path, str) or not log_path:
+        raise HubConfigError(
+            f"{path}: [hub].log_path must be a non-empty string, got {log_path!r}"
+        )
+
+    return replace(
+        defaults, listen_port=listen_port, http_port=http_port, log_path=log_path
+    )
+
+
+def _parse_mapping_block(raw: dict[str, Any], path: Path) -> HubMappingConfig:
+    defaults = HubMappingConfig()
+
+    tb_prefix = raw.get("tb_prefix", defaults.tb_prefix)
+    if not isinstance(tb_prefix, str):
+        raise HubConfigError(
+            f"{path}: [mapping].tb_prefix must be a string, got {tb_prefix!r}"
+        )
+
+    aliases_raw = raw.get("signal_aliases", [])
+    if not isinstance(aliases_raw, list):
+        raise HubConfigError(
+            f"{path}: [mapping].signal_aliases must be a list of tables, got {type(aliases_raw).__name__}"
+        )
+
+    aliases: list[SignalAlias] = []
+    for idx, item in enumerate(aliases_raw):
+        if not isinstance(item, dict):
+            raise HubConfigError(
+                f"{path}: [mapping].signal_aliases[{idx}] must be a table, got {type(item).__name__}"
+            )
+        wave = item.get("wave")
+        view = item.get("view")
+        if not isinstance(wave, str) or not wave:
+            raise HubConfigError(
+                f"{path}: [mapping].signal_aliases[{idx}].wave must be a non-empty string"
+            )
+        if not isinstance(view, str) or not view:
+            raise HubConfigError(
+                f"{path}: [mapping].signal_aliases[{idx}].view must be a non-empty string"
+            )
+        aliases.append(SignalAlias(wave=wave, view=view))
+
+    return HubMappingConfig(tb_prefix=tb_prefix, signal_aliases=tuple(aliases))
+
+
+def default_config_path(project_root: Path) -> Path:
+    """Where the hub looks for its config inside ``project_root``."""
+
+    return project_root / ".rtl-buddy" / HUB_CONFIG_FILENAME
+
+
+__all__ = [
+    "HUB_CONFIG_FILENAME",
+    "DEFAULT_TB_PREFIX",
+    "DEFAULT_LOG_PATH",
+    "HubConfig",
+    "HubConfigError",
+    "HubServerConfig",
+    "HubMappingConfig",
+    "SignalAlias",
+    "load_hub_config",
+    "default_config_path",
+]

--- a/src/rtl_buddy/hub/discovery.py
+++ b/src/rtl_buddy/hub/discovery.py
@@ -1,0 +1,259 @@
+"""``<project_root>/.rtl-buddy/hub.json`` — per-project hub discovery.
+
+Lifecycle in plain English (matches §4.1, §4.2 of the protocol spec):
+
+1. **Startup**: the hub writes a ``HubRecord`` to disk containing its
+   PID, TCP listen address, ``rtl_buddy`` version, and an ISO-8601
+   start timestamp. The file is per-project (in
+   ``<project_root>/.rtl-buddy/``); there is no user-global fallback.
+2. **Discovery**: clients walk up from their CWD until they find the
+   ``.rtl-buddy/hub.json`` and connect. The
+   ``$RTL_BUDDY_HUB`` env var overrides the file lookup (useful for
+   tests, scripted launches, and child processes the hub spawns).
+3. **Shutdown**: on clean exit the hub deletes the file *only if its
+   PID still matches* — that way a crashed-and-replaced hub doesn't
+   clobber the live one's file.
+4. **Conflict detection**: starting a second hub for the same project
+   fails fast (the in-memory record points at a still-live PID).
+
+The module is small on purpose — discovery is the one piece of
+hub-state every adapter touches, so it has to be obvious to read and
+hard to corrupt.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import signal as signal_module
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+HUB_DIR_NAME = ".rtl-buddy"
+HUB_DISCOVERY_FILENAME = "hub.json"
+HUB_DISCOVERY_SCHEMA_VERSION = 1
+
+ENV_OVERRIDE = "RTL_BUDDY_HUB"
+
+
+class HubDiscoveryError(Exception):
+    """Raised when the on-disk discovery file is unreadable or malformed."""
+
+
+class HubAlreadyRunningError(HubDiscoveryError):
+    """Raised when a hub start is attempted while another is live for the project."""
+
+    def __init__(self, pid: int, path: Path) -> None:
+        super().__init__(
+            f"hub already running for this project (pid {pid}); "
+            f"see {path}. Use `rb hub stop` or kill the process first."
+        )
+        self.pid = pid
+        self.path = path
+
+
+@dataclass(frozen=True, slots=True)
+class HubRecord:
+    """The contents of ``hub.json``.
+
+    Kept intentionally narrow; anything that's not needed by a client
+    to *connect* belongs in the runtime log, not in the discovery file.
+    """
+
+    v: int
+    pid: int
+    tcp: str
+    server_version: str
+    project_root: str
+    started_at: str
+
+    def to_dict(self) -> dict[str, object]:
+        return asdict(self)
+
+
+def hub_dir(project_root: Path) -> Path:
+    """Return ``<project_root>/.rtl-buddy/`` (does not create it)."""
+
+    return project_root / HUB_DIR_NAME
+
+
+def discovery_path(project_root: Path) -> Path:
+    """Return the per-project ``hub.json`` path."""
+
+    return hub_dir(project_root) / HUB_DISCOVERY_FILENAME
+
+
+def ensure_hub_dir(project_root: Path) -> Path:
+    """Create the ``.rtl-buddy/`` directory if missing; return its path."""
+
+    target = hub_dir(project_root)
+    target.mkdir(parents=True, exist_ok=True)
+    return target
+
+
+def write_record(
+    project_root: Path,
+    *,
+    pid: int,
+    tcp: str,
+    server_version: str,
+) -> HubRecord:
+    """Write ``hub.json`` after enforcing the one-hub-per-project rule.
+
+    Uses an atomic ``rename`` so a reader will never see a half-written
+    file. Raises :class:`HubAlreadyRunningError` if a live record already
+    exists for this project.
+    """
+
+    ensure_hub_dir(project_root)
+    target = discovery_path(project_root)
+
+    existing = _read_record_if_present(target)
+    if existing is not None and _pid_is_live(existing.pid):
+        raise HubAlreadyRunningError(existing.pid, target)
+
+    record = HubRecord(
+        v=HUB_DISCOVERY_SCHEMA_VERSION,
+        pid=pid,
+        tcp=tcp,
+        server_version=server_version,
+        project_root=str(project_root.resolve()),
+        started_at=datetime.now(timezone.utc).isoformat(timespec="seconds"),
+    )
+
+    tmp = target.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(record.to_dict(), indent=2) + "\n", encoding="utf-8")
+    tmp.replace(target)
+    return record
+
+
+def read_record(project_root: Path) -> HubRecord | None:
+    """Return the on-disk ``HubRecord`` for ``project_root`` or ``None``."""
+
+    return _read_record_if_present(discovery_path(project_root))
+
+
+def delete_record_if_owner(project_root: Path, *, expected_pid: int) -> bool:
+    """Remove ``hub.json`` iff its ``pid`` matches ``expected_pid``.
+
+    Returns ``True`` when the file was deleted. The PID check prevents
+    a stale shutdown handler from clobbering a fresh hub that grabbed
+    the file in between (the "crashed and replaced" race).
+    """
+
+    target = discovery_path(project_root)
+    current = _read_record_if_present(target)
+    if current is None or current.pid != expected_pid:
+        return False
+    try:
+        target.unlink()
+    except FileNotFoundError:
+        return False
+    return True
+
+
+def env_override() -> str | None:
+    """Return ``$RTL_BUDDY_HUB`` if set, else ``None``.
+
+    The override is a literal ``host:port`` string; callers parse it.
+    """
+
+    return os.environ.get(ENV_OVERRIDE) or None
+
+
+def find_project_root_with_hub(start: Path) -> Path | None:
+    """Walk up from ``start`` looking for ``.rtl-buddy/hub.json``.
+
+    Used by clients (the nvim plugin, ``rb wave``, the CLI's
+    ``rb hub status`` outside the start directory) to locate the hub
+    without a hard-coded project path. Returns the directory containing
+    ``.rtl-buddy/`` or ``None``.
+    """
+
+    candidate = start.resolve()
+    while True:
+        if (candidate / HUB_DIR_NAME / HUB_DISCOVERY_FILENAME).is_file():
+            return candidate
+        parent = candidate.parent
+        if parent == candidate:
+            return None
+        candidate = parent
+
+
+def _read_record_if_present(path: Path) -> HubRecord | None:
+    if not path.is_file():
+        return None
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise HubDiscoveryError(f"{path}: invalid hub.json — {exc}") from exc
+
+    if not isinstance(raw, dict):
+        raise HubDiscoveryError(f"{path}: hub.json must be a JSON object")
+    try:
+        return HubRecord(
+            v=int(raw["v"]),
+            pid=int(raw["pid"]),
+            tcp=str(raw["tcp"]),
+            server_version=str(raw["server_version"]),
+            project_root=str(raw["project_root"]),
+            started_at=str(raw["started_at"]),
+        )
+    except (KeyError, TypeError, ValueError) as exc:
+        raise HubDiscoveryError(
+            f"{path}: hub.json missing or malformed field — {exc}"
+        ) from exc
+
+
+def _pid_is_live(pid: int) -> bool:
+    """Return ``True`` if ``pid`` names a live process owned by anyone.
+
+    Uses ``os.kill(pid, 0)``: signal 0 doesn't actually deliver, but
+    POSIX requires the caller to have permission to signal the target
+    (or get EPERM, which still confirms liveness). Windows would need a
+    different path, but the hub is POSIX-only in v1.
+    """
+
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # Another user's process — still live.
+        return True
+    return True
+
+
+def signal_process(pid: int, *, sig: int = signal_module.SIGTERM) -> None:
+    """Send ``sig`` to ``pid``.
+
+    Thin wrapper kept here so ``rb hub stop`` doesn't have to import
+    ``signal`` directly; the discovery module owns the
+    "talk to the running hub by PID" concern.
+    """
+
+    os.kill(pid, sig)
+
+
+__all__ = [
+    "HUB_DIR_NAME",
+    "HUB_DISCOVERY_FILENAME",
+    "HUB_DISCOVERY_SCHEMA_VERSION",
+    "ENV_OVERRIDE",
+    "HubDiscoveryError",
+    "HubAlreadyRunningError",
+    "HubRecord",
+    "hub_dir",
+    "discovery_path",
+    "ensure_hub_dir",
+    "write_record",
+    "read_record",
+    "delete_record_if_owner",
+    "env_override",
+    "find_project_root_with_hub",
+    "signal_process",
+]

--- a/src/rtl_buddy/hub/protocol.py
+++ b/src/rtl_buddy/hub/protocol.py
@@ -1,0 +1,291 @@
+"""Wire envelope codec for the rtl-buddy-hub protocol v1.
+
+The spec lives in ``docs/hub-protocol.md`` of the
+``rtl-buddy/rtl-buddy-view`` repo and is enforced by the JSON Schema at
+``schemas/hub-protocol-v1.json`` (vendored alongside this module as
+:mod:`rtl_buddy.hub.schema`).
+
+This module exposes:
+
+* :data:`PROTOCOL_VERSION` — the integer ``v`` field shared by every
+  envelope; mismatch is a fatal protocol error.
+* :class:`Origin` / :class:`Kind` — the closed enums from the spec.
+* :class:`Envelope` — frozen dataclass mirroring §2 of the spec.
+* :func:`encode` / :func:`decode` — round-trip ``Envelope`` ↔ JSON
+  with schema validation on both sides.
+* :func:`new_id` — UUID4 generator used by message creators.
+
+The schema is loaded once at import time; both encode and decode call
+into the same validator so a malformed payload fails fast with a
+:class:`HubProtocolError`. The validator is intentionally strict
+(``additionalProperties: false`` on every payload object); unknown
+fields are caller bugs, not forward-compatibility points.
+
+Unknown ``type`` strings are NOT a schema error — §11 of the spec
+requires clients to silently drop unknown types so a v1 client and a
+future v1.1 hub can co-exist. The validator only enforces the envelope
+shape (``v``, ``id``, ``origin``, ``kind``, ``type``); ``type``-specific
+payload subschemas are matched conditionally via ``if/then`` and skip
+unknown types.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import dataclass
+from enum import Enum
+from importlib import resources
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+
+PROTOCOL_VERSION: int = 1
+
+
+class Origin(str, Enum):
+    """``origin`` field — the conceptual originator of a message."""
+
+    VIEW = "view"
+    WAVE = "wave"
+    SRC = "src"
+    CLI = "cli"
+
+
+class Kind(str, Enum):
+    """``kind`` field — envelope category."""
+
+    EVENT = "event"
+    REQUEST = "request"
+    RESPONSE = "response"
+    ERROR = "error"
+
+
+class HubProtocolError(Exception):
+    """Raised when a wire payload violates the v1 envelope or schema.
+
+    Carries the offending JSON pointer in :attr:`json_pointer` when the
+    failure was reported by the JSON Schema validator (else ``""``).
+    Mirrors the ``bad_request`` error code from the protocol's error
+    catalog.
+    """
+
+    def __init__(self, message: str, *, json_pointer: str = "") -> None:
+        super().__init__(message)
+        self.json_pointer = json_pointer
+
+
+@dataclass(frozen=True, slots=True)
+class Envelope:
+    """A protocol message after parsing — mirrors §2 of the spec.
+
+    ``id`` is the request/response correlation key and the dedupe key
+    for the loop-prevention LRU (§6). Callers SHOULD generate new IDs
+    with :func:`new_id`; the codec validates the canonical UUID shape
+    but does not generate IDs on its own.
+    """
+
+    origin: Origin
+    kind: Kind
+    type: str
+    id: str
+    payload: Any = None
+    v: int = PROTOCOL_VERSION
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the JSON-compatible dict shape used by :func:`encode`."""
+
+        out: dict[str, Any] = {
+            "v": self.v,
+            "id": self.id,
+            "origin": self.origin.value,
+            "kind": self.kind.value,
+            "type": self.type,
+        }
+        if self.payload is not None:
+            out["payload"] = self.payload
+        return out
+
+
+def new_id() -> str:
+    """Return a fresh canonical UUID4 string for use as ``id``."""
+
+    return str(uuid.uuid4())
+
+
+_SCHEMA_RESOURCE = "hub-protocol-v1.json"
+
+
+def _load_schema() -> dict[str, Any]:
+    text = (
+        resources.files("rtl_buddy.hub.schema")
+        .joinpath(_SCHEMA_RESOURCE)
+        .read_text(encoding="utf-8")
+    )
+    return json.loads(text)
+
+
+_SCHEMA: dict[str, Any] = _load_schema()
+_VALIDATOR: Draft202012Validator = Draft202012Validator(_SCHEMA)
+
+
+def schema() -> dict[str, Any]:
+    """Return a deep copy of the vendored JSON Schema.
+
+    Useful for tests that want to drift-check against the source-of-
+    truth copy in ``rtl-buddy-view/schemas/hub-protocol-v1.json``.
+    """
+
+    return json.loads(json.dumps(_SCHEMA))
+
+
+def _validate(obj: dict[str, Any]) -> None:
+    errors = sorted(_VALIDATOR.iter_errors(obj), key=lambda e: e.path)
+    if not errors:
+        return
+    first = errors[0]
+    pointer = "/" + "/".join(str(p) for p in first.absolute_path)
+    raise HubProtocolError(
+        f"envelope failed schema validation at {pointer}: {first.message}",
+        json_pointer=pointer,
+    )
+
+
+def decode(raw: str | bytes | dict[str, Any]) -> Envelope:
+    """Parse a wire payload into an :class:`Envelope`.
+
+    Accepts either a JSON string/bytes (the line-delimited TCP
+    transport) or a pre-parsed dict (the WebSocket layer, which has
+    already framed). Raises :class:`HubProtocolError` if the payload is
+    not valid JSON, fails the schema, or carries the wrong protocol
+    version.
+    """
+
+    if isinstance(raw, (str, bytes)):
+        try:
+            obj = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise HubProtocolError(f"not valid JSON: {exc.msg}") from exc
+    else:
+        obj = raw
+
+    if not isinstance(obj, dict):
+        raise HubProtocolError("envelope must be a JSON object")
+
+    _validate(obj)
+
+    v = obj["v"]
+    if v != PROTOCOL_VERSION:
+        raise HubProtocolError(
+            f"protocol mismatch: expected v={PROTOCOL_VERSION}, got v={v}"
+        )
+
+    return Envelope(
+        origin=Origin(obj["origin"]),
+        kind=Kind(obj["kind"]),
+        type=obj["type"],
+        id=obj["id"],
+        payload=obj.get("payload"),
+        v=v,
+    )
+
+
+def encode(envelope: Envelope) -> str:
+    """Serialize an :class:`Envelope` to a wire-ready JSON string.
+
+    The line-delimited TCP transport expects exactly one envelope per
+    line; this function returns the JSON without a trailing newline so
+    the transport layer can frame consistently across NDJSON and
+    WebSocket. Validates against the schema before returning so a
+    bug in caller code surfaces here, not at the remote peer.
+    """
+
+    obj = envelope.to_dict()
+    _validate(obj)
+    return json.dumps(obj, ensure_ascii=False, separators=(",", ":"))
+
+
+def make_error(
+    *,
+    origin: Origin,
+    code: str,
+    message: str,
+    context: dict[str, Any] | None = None,
+    in_reply_to: str | None = None,
+) -> Envelope:
+    """Construct an ``error`` envelope per §3 of the spec.
+
+    ``in_reply_to`` is the request ``id`` to echo back; when ``None``
+    (e.g. a spontaneous error not tied to a request) a fresh UUID is
+    generated. ``code`` MUST be one of the strings enumerated in the
+    spec's error table; otherwise the schema validator rejects it.
+    """
+
+    payload: dict[str, Any] = {"code": code, "message": message}
+    if context is not None:
+        payload["context"] = context
+    return Envelope(
+        origin=origin,
+        kind=Kind.ERROR,
+        type="error",
+        id=in_reply_to or new_id(),
+        payload=payload,
+    )
+
+
+def make_hello(
+    *,
+    client: Origin,
+    version: str,
+    capabilities: list[str],
+) -> Envelope:
+    """Construct a ``hello`` request envelope (§4.3, §11)."""
+
+    return Envelope(
+        origin=client,
+        kind=Kind.REQUEST,
+        type="hello",
+        id=new_id(),
+        payload={
+            "client": client.value,
+            "version": version,
+            "capabilities": capabilities,
+        },
+    )
+
+
+def make_welcome(
+    *,
+    in_reply_to: str,
+    server_version: str,
+    registered_clients: list[Origin],
+) -> Envelope:
+    """Construct the hub's ``welcome`` response envelope (§4.3)."""
+
+    return Envelope(
+        origin=Origin.CLI,
+        kind=Kind.RESPONSE,
+        type="welcome",
+        id=in_reply_to,
+        payload={
+            "server_version": server_version,
+            "registered_clients": [c.value for c in registered_clients],
+        },
+    )
+
+
+__all__ = [
+    "PROTOCOL_VERSION",
+    "Origin",
+    "Kind",
+    "Envelope",
+    "HubProtocolError",
+    "decode",
+    "encode",
+    "new_id",
+    "schema",
+    "make_error",
+    "make_hello",
+    "make_welcome",
+]

--- a/src/rtl_buddy/hub/schema/__init__.py
+++ b/src/rtl_buddy/hub/schema/__init__.py
@@ -1,0 +1,10 @@
+"""Vendored copy of the hub-protocol-v1 JSON Schema.
+
+Source of truth: ``schemas/hub-protocol-v1.json`` in
+``rtl-buddy/rtl-buddy-view`` (frozen by Phase 10a,
+``rtl-buddy/rtl-buddy-view#19``). The file in this package MUST stay
+byte-identical to that source; the
+``tests/test_hub_protocol.py::test_vendored_schema_matches_source``
+case enforces this when the rtl-buddy-view repo is present alongside
+this checkout.
+"""

--- a/src/rtl_buddy/hub/schema/hub-protocol-v1.json
+++ b/src/rtl_buddy/hub/schema/hub-protocol-v1.json
@@ -1,0 +1,424 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://rtl-buddy.dev/schemas/hub-protocol-v1.json",
+  "title": "rtl-buddy-hub protocol v1 envelope",
+  "description": "Wire contract for messages exchanged between rtl-buddy-hub and its clients (viewer, surfer/WCP adapter, nvim plugin, CLI). See docs/hub-protocol.md.",
+  "type": "object",
+  "required": ["v", "id", "origin", "kind", "type"],
+  "additionalProperties": false,
+  "properties": {
+    "v": {
+      "const": 1,
+      "description": "Protocol major version."
+    },
+    "id": {
+      "type": "string",
+      "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+      "description": "RFC 4122 UUID for request/response correlation and loop-prevention dedupe."
+    },
+    "origin": {
+      "enum": ["view", "wave", "src", "cli"],
+      "description": "Conceptual originator of the message; the loop-prevention discriminator."
+    },
+    "kind": {
+      "enum": ["event", "request", "response", "error"]
+    },
+    "type": {
+      "type": "string",
+      "description": "Message type. See docs/hub-protocol.md §3 for the v1 catalog. Unknown types MUST be silently dropped at DEBUG."
+    },
+    "payload": {
+      "description": "Type-specific. May be null for messages without payload (e.g. bye)."
+    }
+  },
+  "allOf": [
+    {
+      "if": { "properties": { "type": { "const": "selection_changed" } }, "required": ["type"] },
+      "then": {
+        "properties": {
+          "kind": { "const": "event" },
+          "payload": {
+            "type": "object",
+            "required": ["instance_path"],
+            "additionalProperties": false,
+            "properties": {
+              "instance_path": {
+                "oneOf": [
+                  { "type": "string", "minLength": 1 },
+                  { "type": "array", "items": { "type": "string", "minLength": 1 }, "minItems": 1 }
+                ],
+                "description": "Single instance path, or a list when collapsed from a multi-driver signal (§6)."
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "type": { "const": "signal_selected" } }, "required": ["type"] },
+      "then": {
+        "properties": {
+          "kind": { "const": "event" },
+          "payload": {
+            "type": "object",
+            "required": ["signal", "wave_scope"],
+            "additionalProperties": false,
+            "properties": {
+              "signal": { "type": "string", "minLength": 1 },
+              "wave_scope": { "type": "string", "minLength": 1 }
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "type": { "const": "cursor_time_changed" } }, "required": ["type"] },
+      "then": {
+        "properties": {
+          "kind": { "const": "event" },
+          "payload": {
+            "type": "object",
+            "required": ["t_fs"],
+            "additionalProperties": false,
+            "properties": {
+              "t_fs": {
+                "type": "string",
+                "pattern": "^-?[0-9]+$",
+                "description": "Time in femtoseconds, encoded as a decimal string to avoid JSON number precision loss for large timestamps."
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "type": { "const": "scope_changed" } }, "required": ["type"] },
+      "then": {
+        "properties": {
+          "kind": { "const": "event" },
+          "payload": {
+            "type": "object",
+            "required": ["wave_scope"],
+            "additionalProperties": false,
+            "properties": {
+              "wave_scope": { "type": "string", "minLength": 1 }
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "type": { "const": "source_focused" } }, "required": ["type"] },
+      "then": {
+        "properties": {
+          "kind": { "const": "event" },
+          "payload": {
+            "type": "object",
+            "required": ["file", "line", "col"],
+            "additionalProperties": false,
+            "properties": {
+              "file": { "type": "string", "minLength": 1, "description": "Absolute path." },
+              "line": { "type": "integer", "minimum": 1 },
+              "col":  { "type": "integer", "minimum": 1 }
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "type": { "const": "open_source" } }, "required": ["type"] },
+      "then": {
+        "oneOf": [
+          {
+            "properties": {
+              "kind": { "const": "request" },
+              "payload": {
+                "type": "object",
+                "required": ["file", "line", "col"],
+                "additionalProperties": false,
+                "properties": {
+                  "file": { "type": "string", "minLength": 1 },
+                  "line": { "type": "integer", "minimum": 1 },
+                  "col":  { "type": "integer", "minimum": 1 }
+                }
+              }
+            }
+          },
+          {
+            "properties": {
+              "kind": { "const": "response" },
+              "payload": {
+                "type": "object",
+                "required": ["ok"],
+                "additionalProperties": false,
+                "properties": { "ok": { "type": "boolean" } }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "if": { "properties": { "type": { "const": "wave_add_variables" } }, "required": ["type"] },
+      "then": {
+        "oneOf": [
+          {
+            "properties": {
+              "kind": { "const": "request" },
+              "payload": {
+                "type": "object",
+                "required": ["variables"],
+                "additionalProperties": false,
+                "properties": {
+                  "variables": { "type": "array", "items": { "type": "string", "minLength": 1 }, "minItems": 1 }
+                }
+              }
+            }
+          },
+          {
+            "properties": {
+              "kind": { "const": "response" },
+              "payload": {
+                "type": "object",
+                "required": ["ids"],
+                "additionalProperties": false,
+                "properties": {
+                  "ids": { "type": "array", "items": { "type": "integer", "minimum": 0 } }
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "if": { "properties": { "type": { "const": "wave_set_scope" } }, "required": ["type"] },
+      "then": {
+        "oneOf": [
+          {
+            "properties": {
+              "kind": { "const": "request" },
+              "payload": {
+                "type": "object",
+                "required": ["wave_scope"],
+                "additionalProperties": false,
+                "properties": { "wave_scope": { "type": "string", "minLength": 1 } }
+              }
+            }
+          },
+          {
+            "properties": {
+              "kind": { "const": "response" },
+              "payload": {
+                "type": "object",
+                "required": ["ok"],
+                "additionalProperties": false,
+                "properties": { "ok": { "type": "boolean" } }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "if": { "properties": { "type": { "const": "wave_set_cursor" } }, "required": ["type"] },
+      "then": {
+        "oneOf": [
+          {
+            "properties": {
+              "kind": { "const": "request" },
+              "payload": {
+                "type": "object",
+                "required": ["t_fs"],
+                "additionalProperties": false,
+                "properties": {
+                  "t_fs": { "type": "string", "pattern": "^-?[0-9]+$" }
+                }
+              }
+            }
+          },
+          {
+            "properties": {
+              "kind": { "const": "response" },
+              "payload": {
+                "type": "object",
+                "required": ["ok"],
+                "additionalProperties": false,
+                "properties": { "ok": { "type": "boolean" } }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "if": { "properties": { "type": { "const": "view_pan_to" } }, "required": ["type"] },
+      "then": {
+        "oneOf": [
+          {
+            "properties": {
+              "kind": { "const": "request" },
+              "payload": {
+                "type": "object",
+                "required": ["instance_path"],
+                "additionalProperties": false,
+                "properties": { "instance_path": { "type": "string", "minLength": 1 } }
+              }
+            }
+          },
+          {
+            "properties": {
+              "kind": { "const": "response" },
+              "payload": {
+                "type": "object",
+                "required": ["ok"],
+                "additionalProperties": false,
+                "properties": { "ok": { "type": "boolean" } }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "if": { "properties": { "type": { "const": "resolve_view_to_wave" } }, "required": ["type"] },
+      "then": {
+        "oneOf": [
+          {
+            "properties": {
+              "kind": { "const": "request" },
+              "payload": {
+                "type": "object",
+                "required": ["instance_path"],
+                "additionalProperties": false,
+                "properties": { "instance_path": { "type": "string", "minLength": 1 } }
+              }
+            }
+          },
+          {
+            "properties": {
+              "kind": { "const": "response" },
+              "payload": {
+                "type": "object",
+                "required": ["wave_scope"],
+                "additionalProperties": false,
+                "properties": { "wave_scope": { "type": "string", "minLength": 1 } }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "if": { "properties": { "type": { "const": "resolve_signal_to_view" } }, "required": ["type"] },
+      "then": {
+        "oneOf": [
+          {
+            "properties": {
+              "kind": { "const": "request" },
+              "payload": {
+                "type": "object",
+                "required": ["signal", "wave_scope"],
+                "additionalProperties": false,
+                "properties": {
+                  "signal": { "type": "string", "minLength": 1 },
+                  "wave_scope": { "type": "string", "minLength": 1 }
+                }
+              }
+            }
+          },
+          {
+            "properties": {
+              "kind": { "const": "response" },
+              "payload": {
+                "type": "object",
+                "required": ["instance_path", "port"],
+                "additionalProperties": false,
+                "properties": {
+                  "instance_path": { "type": "array", "items": { "type": "string", "minLength": 1 }, "minItems": 1 },
+                  "port": { "type": "string", "minLength": 1 }
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "if": { "properties": { "type": { "const": "hello" } }, "required": ["type"] },
+      "then": {
+        "properties": {
+          "kind": { "const": "request" },
+          "origin": { "enum": ["view", "wave", "src", "cli"] },
+          "payload": {
+            "type": "object",
+            "required": ["client", "version", "capabilities"],
+            "additionalProperties": false,
+            "properties": {
+              "client": { "enum": ["view", "wave", "src", "cli"] },
+              "version": { "type": "string", "minLength": 1, "description": "Semver of the client implementation." },
+              "capabilities": { "type": "array", "items": { "type": "string", "minLength": 1 }, "uniqueItems": true }
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "type": { "const": "welcome" } }, "required": ["type"] },
+      "then": {
+        "properties": {
+          "kind": { "const": "response" },
+          "payload": {
+            "type": "object",
+            "required": ["server_version", "registered_clients"],
+            "additionalProperties": false,
+            "properties": {
+              "server_version": { "type": "string", "minLength": 1 },
+              "registered_clients": {
+                "type": "array",
+                "items": { "enum": ["view", "wave", "src", "cli"] },
+                "uniqueItems": true
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "type": { "const": "bye" } }, "required": ["type"] },
+      "then": {
+        "properties": {
+          "kind": { "const": "event" },
+          "payload": {
+            "oneOf": [
+              { "type": "null" },
+              { "type": "object", "additionalProperties": false }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "type": { "const": "error" } }, "required": ["type"] },
+      "then": {
+        "properties": {
+          "kind": { "const": "error" },
+          "payload": {
+            "type": "object",
+            "required": ["code", "message"],
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "enum": ["unresolvable", "not_connected", "bad_request", "protocol_mismatch"],
+                "description": "`timeout` is a client-side-only code and is never sent on the wire."
+              },
+              "message": { "type": "string", "minLength": 1 },
+              "context": { "type": "object", "description": "Arbitrary structured context for the error; e.g. the offending input." }
+            }
+          }
+        }
+      }
+    }
+  ],
+  "$comment": "Loop prevention and origin-suppression rules (docs §6) are runtime invariants the hub enforces; they are not expressible in JSON Schema."
+}

--- a/src/rtl_buddy/hub/state.py
+++ b/src/rtl_buddy/hub/state.py
@@ -1,0 +1,98 @@
+"""In-memory selection / cursor / scope cache.
+
+The hub keeps a one-slot cache per coordinate type so a client that
+reconnects mid-session can ask "what is the current selection?"
+without forcing the other clients to re-broadcast. This is the
+minimum amount of server-side state required to keep cross-view sync
+useful across reconnects; everything else (the design tree, the
+waveform, the source files) is owned by the producers.
+
+This module ships the cache structures only — no observers, no
+broadcast plumbing. PR 2 (the WS/TCP server) layers an asyncio pub/sub
+on top.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+from .protocol import Origin
+
+
+@dataclass(frozen=True, slots=True)
+class Selection:
+    """Last broadcast ``selection_changed`` payload + its origin."""
+
+    instance_path: tuple[str, ...]
+    """Always a tuple — a single-path selection is length 1 and the
+    multi-driver collapse case (§7) is length > 1. Stored as a tuple
+    so the dataclass stays hashable / frozen."""
+
+    origin: Origin
+
+
+@dataclass(frozen=True, slots=True)
+class SignalSelection:
+    """Last broadcast ``signal_selected`` payload + its origin."""
+
+    signal: str
+    wave_scope: str
+    origin: Origin
+
+
+@dataclass(frozen=True, slots=True)
+class CursorTime:
+    """Last broadcast ``cursor_time_changed`` payload + its origin.
+
+    Time is preserved as the on-wire decimal string to avoid JSON
+    number precision loss; the only consumers of the numeric value are
+    surfer (which deserialises it itself) and resolvers that don't
+    care about the time at all.
+    """
+
+    t_fs: str
+    origin: Origin
+
+
+@dataclass(frozen=True, slots=True)
+class WaveScope:
+    """Last broadcast ``scope_changed`` payload + its origin."""
+
+    wave_scope: str
+    origin: Origin
+
+
+@dataclass
+class HubState:
+    """One-slot cache per coordinate type.
+
+    Mutable on purpose; the server replaces fields wholesale when a new
+    state event is observed. Lock-free in this module — the asyncio
+    server in PR 2 holds the only writer task so no synchronisation is
+    needed there either.
+    """
+
+    selection: Optional[Selection] = None
+    signal_selection: Optional[SignalSelection] = None
+    cursor_time: Optional[CursorTime] = None
+    wave_scope: Optional[WaveScope] = None
+
+    registered_clients: set[Origin] = field(default_factory=set)
+
+    def reset(self) -> None:
+        """Clear all cached slots (used on ``waveforms_loaded`` and tests)."""
+
+        self.selection = None
+        self.signal_selection = None
+        self.cursor_time = None
+        self.wave_scope = None
+
+
+__all__ = [
+    "Selection",
+    "SignalSelection",
+    "CursorTime",
+    "WaveScope",
+    "HubState",
+]

--- a/src/rtl_buddy/rtl_buddy.py
+++ b/src/rtl_buddy/rtl_buddy.py
@@ -43,6 +43,7 @@ from .runner.power_results import PowerSkipResults
 from .runner.synth_runner import SynthRunner
 from .runner.synth_results import SynthSkipResults
 from .seed_mode import SeedMode
+from .hub.cli import app as hub_app
 from .skill_install import app as skill_app
 from .tools.coverage import CoverageReporter
 from .tools.artifact_paths import test_artifact_dir
@@ -156,6 +157,7 @@ class RtlBuddy:
         self.app.command("fpv-regression", help="run FPV regression")(
             self.do_fpv_regression
         )
+        self.app.add_typer(hub_app, name="hub", help="manage the rtl-buddy-hub daemon")
         self.app.add_typer(
             skill_app, name="skill", help="manage the rtl_buddy agent skill"
         )
@@ -196,7 +198,7 @@ class RtlBuddy:
 
     def run(self):
         try:
-            self.app(standalone_mode=False)
+            rv = self.app(standalone_mode=False)
         except click.exceptions.Exit as exc:
             return exc.exit_code
         except click.exceptions.Abort:
@@ -207,7 +209,11 @@ class RtlBuddy:
         except (FatalRtlBuddyError, FilelistError) as exc:
             emit_console_text(str(exc), style="red")
             return 2
-        return 0
+        # standalone_mode=False makes click *return* the exit code from
+        # `typer.Exit(code=N)` rather than re-raise it, so we have to
+        # surface it here. Existing commands that return None continue
+        # to exit cleanly with code 0.
+        return rv if isinstance(rv, int) else 0
 
     def _is_test_list_invocation(self, ctx: typer.Context) -> bool:
         return ctx.invoked_subcommand == "test" and "--list" in sys.argv[1:]
@@ -275,7 +281,7 @@ class RtlBuddy:
 
         self.machine = machine
 
-        if ctx.invoked_subcommand in {"skill", "docs", "spec"}:
+        if ctx.invoked_subcommand in {"skill", "docs", "spec", "hub"}:
             return
 
         setup_logging(debug=debug, verbose=verbose, color=color, machine=machine)

--- a/tests/test_hub_cli.py
+++ b/tests/test_hub_cli.py
@@ -1,0 +1,161 @@
+"""CLI smoke tests for ``rb hub`` subcommands.
+
+These exercise option parsing, exit codes, and the read-side of the
+discovery + config layers. The server loop itself lands in PR 2 of
+rtl-buddy/rtl_buddy#115 and is exercised separately.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from rtl_buddy.hub import discovery
+from rtl_buddy.hub.cli import app as hub_app
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture
+def project_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A tmp dir with the minimum project markers: a ``.git`` directory.
+
+    The hub CLI uses ``discover_project_root()`` which accepts either
+    ``root_config.yaml`` or ``.git``; we use ``.git`` to keep the
+    fixture self-contained.
+    """
+
+    (tmp_path / ".git").mkdir()
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+def test_help_lists_subcommands(runner: CliRunner):
+    result = runner.invoke(hub_app, ["--help"])
+    assert result.exit_code == 0, result.output
+    assert "start" in result.output
+    assert "stop" in result.output
+    assert "status" in result.output
+    assert "log" in result.output
+    assert "config" in result.output
+
+
+def test_config_help_lists_validate(runner: CliRunner):
+    result = runner.invoke(hub_app, ["config", "--help"])
+    assert result.exit_code == 0, result.output
+    assert "validate" in result.output
+
+
+def test_config_validate_missing_file_is_ok(runner: CliRunner, project_root: Path):
+    result = runner.invoke(hub_app, ["config", "validate"])
+    assert result.exit_code == 0, result.output
+    assert "defaults" in result.output
+
+
+def test_config_validate_good_file(runner: CliRunner, project_root: Path):
+    cfg_dir = project_root / ".rtl-buddy"
+    cfg_dir.mkdir()
+    (cfg_dir / "hub.toml").write_text(
+        '[hub]\nlisten_port = 0\n[mapping]\ntb_prefix = "tb.dut."\n',
+        encoding="utf-8",
+    )
+    result = runner.invoke(hub_app, ["config", "validate"])
+    assert result.exit_code == 0, result.output
+    assert "ok:" in result.output
+    assert "tb.dut." in result.output
+
+
+def test_config_validate_bad_file(runner: CliRunner, project_root: Path):
+    cfg_dir = project_root / ".rtl-buddy"
+    cfg_dir.mkdir()
+    (cfg_dir / "hub.toml").write_text("[unknown_section]\nx = 1\n", encoding="utf-8")
+    result = runner.invoke(hub_app, ["config", "validate"])
+    assert result.exit_code == 1, result.output
+    assert "unknown" in result.output.lower()
+
+
+def test_status_no_hub(runner: CliRunner, project_root: Path):
+    result = runner.invoke(hub_app, ["status"])
+    assert result.exit_code == 1, result.output
+    assert "no hub running" in result.output
+
+
+def test_status_running_hub(runner: CliRunner, project_root: Path):
+    discovery.write_record(
+        project_root,
+        pid=os.getpid(),
+        tcp="127.0.0.1:54321",
+        server_version="0.1.0",
+    )
+    result = runner.invoke(hub_app, ["status"])
+    assert result.exit_code == 0, result.output
+    assert "RUNNING" in result.output
+    assert "127.0.0.1:54321" in result.output
+
+
+def test_status_stale_record(runner: CliRunner, project_root: Path):
+    # Use a pid that is virtually guaranteed to be dead.
+    cfg_dir = project_root / ".rtl-buddy"
+    cfg_dir.mkdir()
+    (cfg_dir / "hub.json").write_text(
+        '{"v": 1, "pid": 999999, "tcp": "127.0.0.1:1",'
+        ' "server_version": "0.1.0",'
+        f' "project_root": "{project_root}",'
+        ' "started_at": "2026-01-01T00:00:00+00:00"}',
+        encoding="utf-8",
+    )
+    result = runner.invoke(hub_app, ["status"])
+    assert result.exit_code == 1, result.output
+    assert "STALE" in result.output
+
+
+def test_stop_with_no_hub(runner: CliRunner, project_root: Path):
+    result = runner.invoke(hub_app, ["stop"])
+    assert result.exit_code == 1, result.output
+    assert "no hub running" in result.output
+
+
+def test_stop_clears_stale_record(runner: CliRunner, project_root: Path):
+    cfg_dir = project_root / ".rtl-buddy"
+    cfg_dir.mkdir()
+    (cfg_dir / "hub.json").write_text(
+        '{"v": 1, "pid": 999999, "tcp": "127.0.0.1:1",'
+        ' "server_version": "0.1.0",'
+        f' "project_root": "{project_root}",'
+        ' "started_at": "2026-01-01T00:00:00+00:00"}',
+        encoding="utf-8",
+    )
+    result = runner.invoke(hub_app, ["stop"])
+    assert result.exit_code == 1, result.output
+    assert not (cfg_dir / "hub.json").exists()
+
+
+def test_start_stub_exits_clearly(runner: CliRunner, project_root: Path):
+    """PR 1 ships the CLI surface but not the server loop."""
+
+    result = runner.invoke(hub_app, ["start"])
+    assert result.exit_code == 2, result.output
+    assert "PR 2" in result.output or "not yet implemented" in result.output
+
+
+def test_log_missing_file(runner: CliRunner, project_root: Path):
+    result = runner.invoke(hub_app, ["log"])
+    assert result.exit_code == 1, result.output
+    assert "log not found" in result.output
+
+
+def test_log_prints_tail(runner: CliRunner, project_root: Path):
+    cfg_dir = project_root / ".rtl-buddy"
+    cfg_dir.mkdir()
+    (cfg_dir / "hub.log").write_text("line-a\nline-b\nline-c\n", encoding="utf-8")
+    result = runner.invoke(hub_app, ["log", "-n", "2"])
+    assert result.exit_code == 0, result.output
+    assert "line-b" in result.output
+    assert "line-c" in result.output
+    assert "line-a" not in result.output

--- a/tests/test_hub_config.py
+++ b/tests/test_hub_config.py
@@ -1,0 +1,118 @@
+"""Tests for ``rtl_buddy.hub.config`` — TOML loader."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from rtl_buddy.hub.config import (
+    DEFAULT_TB_PREFIX,
+    HubConfig,
+    HubConfigError,
+    SignalAlias,
+    default_config_path,
+    load_hub_config,
+)
+
+
+def _write(path: Path, body: str) -> Path:
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def test_missing_file_yields_defaults(tmp_path: Path):
+    cfg = load_hub_config(None)
+    assert cfg == HubConfig()
+    assert cfg.hub.listen_port == 0
+    assert cfg.mapping.tb_prefix == DEFAULT_TB_PREFIX
+
+    cfg2 = load_hub_config(tmp_path / "absent.toml")
+    assert cfg2 == HubConfig()
+
+
+def test_round_trip_minimal(tmp_path: Path):
+    path = _write(
+        tmp_path / "hub.toml",
+        """
+[hub]
+listen_port = 54321
+http_port = 54322
+log_path = ".rtl-buddy/hub.log"
+
+[mapping]
+tb_prefix = "tb.dut."
+""",
+    )
+    cfg = load_hub_config(path)
+    assert cfg.hub.listen_port == 54321
+    assert cfg.hub.http_port == 54322
+    assert cfg.mapping.tb_prefix == "tb.dut."
+    assert cfg.source_path == path
+
+
+def test_signal_aliases_parsed(tmp_path: Path):
+    path = _write(
+        tmp_path / "hub.toml",
+        """
+[mapping]
+tb_prefix = "tb.dut."
+signal_aliases = [
+  { wave = "tb.dut.foo_pre_renamed", view = "top.foo" },
+  { wave = "tb.dut.bar_pre_renamed", view = "top.bar" },
+]
+""",
+    )
+    cfg = load_hub_config(path)
+    assert cfg.mapping.signal_aliases == (
+        SignalAlias(wave="tb.dut.foo_pre_renamed", view="top.foo"),
+        SignalAlias(wave="tb.dut.bar_pre_renamed", view="top.bar"),
+    )
+
+
+def test_unknown_section_rejected(tmp_path: Path):
+    path = _write(
+        tmp_path / "hub.toml",
+        """
+[adapters.surfer]
+port = 1234
+""",
+    )
+    with pytest.raises(HubConfigError):
+        load_hub_config(path)
+
+
+def test_bad_port_rejected(tmp_path: Path):
+    path = _write(
+        tmp_path / "hub.toml",
+        """
+[hub]
+listen_port = -1
+""",
+    )
+    with pytest.raises(HubConfigError):
+        load_hub_config(path)
+
+
+def test_alias_without_wave_field_rejected(tmp_path: Path):
+    path = _write(
+        tmp_path / "hub.toml",
+        """
+[mapping]
+signal_aliases = [
+  { view = "top.foo" }
+]
+""",
+    )
+    with pytest.raises(HubConfigError):
+        load_hub_config(path)
+
+
+def test_invalid_toml_yields_clear_error(tmp_path: Path):
+    path = _write(tmp_path / "hub.toml", "[unclosed-table")
+    with pytest.raises(HubConfigError, match="invalid TOML"):
+        load_hub_config(path)
+
+
+def test_default_config_path_layout(tmp_path: Path):
+    assert default_config_path(tmp_path) == tmp_path / ".rtl-buddy" / "hub.toml"

--- a/tests/test_hub_discovery.py
+++ b/tests/test_hub_discovery.py
@@ -1,0 +1,124 @@
+"""Tests for ``rtl_buddy.hub.discovery`` — hub.json lifecycle."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from rtl_buddy.hub.discovery import (
+    HubAlreadyRunningError,
+    HubDiscoveryError,
+    delete_record_if_owner,
+    discovery_path,
+    env_override,
+    find_project_root_with_hub,
+    read_record,
+    write_record,
+)
+
+
+def test_write_and_read_record_round_trip(tmp_path: Path):
+    rec = write_record(
+        tmp_path,
+        pid=os.getpid(),
+        tcp="127.0.0.1:54321",
+        server_version="0.1.0",
+    )
+    assert rec.pid == os.getpid()
+    assert discovery_path(tmp_path).exists()
+
+    loaded = read_record(tmp_path)
+    assert loaded is not None
+    assert loaded.tcp == "127.0.0.1:54321"
+    assert loaded.server_version == "0.1.0"
+    assert Path(loaded.project_root).resolve() == tmp_path.resolve()
+    # started_at is ISO-8601 with 'T' separator and a timezone designator.
+    assert "T" in loaded.started_at
+
+
+def test_read_record_missing_returns_none(tmp_path: Path):
+    assert read_record(tmp_path) is None
+
+
+def test_read_record_corrupt_raises(tmp_path: Path):
+    target = discovery_path(tmp_path)
+    target.parent.mkdir(parents=True)
+    target.write_text("not json", encoding="utf-8")
+    with pytest.raises(HubDiscoveryError):
+        read_record(tmp_path)
+
+
+def test_read_record_missing_field_raises(tmp_path: Path):
+    target = discovery_path(tmp_path)
+    target.parent.mkdir(parents=True)
+    target.write_text(json.dumps({"v": 1, "pid": 123}), encoding="utf-8")
+    with pytest.raises(HubDiscoveryError, match="missing or malformed field"):
+        read_record(tmp_path)
+
+
+def test_second_write_with_live_pid_refused(tmp_path: Path):
+    write_record(tmp_path, pid=os.getpid(), tcp="127.0.0.1:1", server_version="0.1.0")
+    with pytest.raises(HubAlreadyRunningError):
+        write_record(
+            tmp_path, pid=os.getpid(), tcp="127.0.0.1:2", server_version="0.1.0"
+        )
+
+
+def test_second_write_with_dead_pid_overwrites(tmp_path: Path):
+    # First write a record with a guaranteed-dead pid (the helper does the
+    # liveness check we want to bypass — patch it for clarity).
+    target = discovery_path(tmp_path)
+    target.parent.mkdir(parents=True)
+    target.write_text(
+        json.dumps(
+            {
+                "v": 1,
+                "pid": 999999,
+                "tcp": "127.0.0.1:9",
+                "server_version": "0.0.1",
+                "project_root": str(tmp_path),
+                "started_at": "2026-01-01T00:00:00+00:00",
+            }
+        ),
+        encoding="utf-8",
+    )
+    rec = write_record(
+        tmp_path, pid=os.getpid(), tcp="127.0.0.1:1", server_version="0.1.0"
+    )
+    assert rec.pid == os.getpid()
+
+
+def test_delete_record_if_owner(tmp_path: Path):
+    write_record(tmp_path, pid=os.getpid(), tcp="127.0.0.1:1", server_version="0.1.0")
+    assert delete_record_if_owner(tmp_path, expected_pid=os.getpid()) is True
+    assert read_record(tmp_path) is None
+
+
+def test_delete_record_if_owner_refuses_wrong_pid(tmp_path: Path):
+    write_record(tmp_path, pid=os.getpid(), tcp="127.0.0.1:1", server_version="0.1.0")
+    assert delete_record_if_owner(tmp_path, expected_pid=12345) is False
+    assert read_record(tmp_path) is not None
+
+
+def test_find_project_root_walks_up(tmp_path: Path):
+    write_record(tmp_path, pid=os.getpid(), tcp="127.0.0.1:1", server_version="0.1.0")
+    nested = tmp_path / "a" / "b" / "c"
+    nested.mkdir(parents=True)
+    assert find_project_root_with_hub(nested) == tmp_path.resolve()
+
+
+def test_find_project_root_returns_none_when_absent(tmp_path: Path):
+    assert find_project_root_with_hub(tmp_path) is None
+
+
+def test_env_override_uses_env(monkeypatch):
+    monkeypatch.setenv("RTL_BUDDY_HUB", "127.0.0.1:7000")
+    assert env_override() == "127.0.0.1:7000"
+
+
+def test_env_override_unset(monkeypatch):
+    monkeypatch.delenv("RTL_BUDDY_HUB", raising=False)
+    assert env_override() is None

--- a/tests/test_hub_protocol.py
+++ b/tests/test_hub_protocol.py
@@ -1,0 +1,322 @@
+"""Tests for ``rtl_buddy.hub.protocol`` — envelope codec + schema."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from pathlib import Path
+
+import pytest
+
+from rtl_buddy.hub import protocol
+from rtl_buddy.hub.protocol import (
+    Envelope,
+    HubProtocolError,
+    Kind,
+    Origin,
+    decode,
+    encode,
+    make_error,
+    make_hello,
+    make_welcome,
+    new_id,
+)
+
+
+# ---------------------------------------------------------------------------
+# round trips
+# ---------------------------------------------------------------------------
+
+
+def test_decode_encode_round_trip_event():
+    payload = {
+        "v": 1,
+        "id": str(uuid.uuid4()),
+        "origin": "view",
+        "kind": "event",
+        "type": "selection_changed",
+        "payload": {"instance_path": "top.u_fifo.u_wr_ptr"},
+    }
+    env = decode(json.dumps(payload))
+    assert env.origin is Origin.VIEW
+    assert env.kind is Kind.EVENT
+    assert env.type == "selection_changed"
+    assert env.payload == payload["payload"]
+    assert json.loads(encode(env)) == payload
+
+
+def test_decode_accepts_dict_directly():
+    payload = {
+        "v": 1,
+        "id": str(uuid.uuid4()),
+        "origin": "wave",
+        "kind": "event",
+        "type": "cursor_time_changed",
+        "payload": {"t_fs": "12500000"},
+    }
+    env = decode(payload)
+    assert env.origin is Origin.WAVE
+    assert env.payload == {"t_fs": "12500000"}
+
+
+def test_encode_drops_payload_when_none():
+    env = Envelope(
+        origin=Origin.CLI, kind=Kind.EVENT, type="bye", id=new_id(), payload=None
+    )
+    obj = json.loads(encode(env))
+    assert "payload" not in obj
+
+
+# ---------------------------------------------------------------------------
+# schema enforcement
+# ---------------------------------------------------------------------------
+
+
+def test_decode_rejects_unknown_origin():
+    raw = json.dumps(
+        {
+            "v": 1,
+            "id": str(uuid.uuid4()),
+            "origin": "nope",
+            "kind": "event",
+            "type": "selection_changed",
+            "payload": {"instance_path": "top"},
+        }
+    )
+    with pytest.raises(HubProtocolError):
+        decode(raw)
+
+
+def test_decode_rejects_protocol_version_mismatch():
+    raw = json.dumps(
+        {
+            "v": 2,
+            "id": str(uuid.uuid4()),
+            "origin": "view",
+            "kind": "event",
+            "type": "selection_changed",
+            "payload": {"instance_path": "top"},
+        }
+    )
+    with pytest.raises(HubProtocolError):
+        decode(raw)
+
+
+def test_decode_rejects_bad_uuid():
+    raw = json.dumps(
+        {
+            "v": 1,
+            "id": "not-a-uuid",
+            "origin": "view",
+            "kind": "event",
+            "type": "selection_changed",
+            "payload": {"instance_path": "top"},
+        }
+    )
+    with pytest.raises(HubProtocolError) as ei:
+        decode(raw)
+    assert "/id" in ei.value.json_pointer
+
+
+def test_decode_rejects_missing_payload_field():
+    """selection_changed requires payload.instance_path."""
+
+    raw = json.dumps(
+        {
+            "v": 1,
+            "id": str(uuid.uuid4()),
+            "origin": "view",
+            "kind": "event",
+            "type": "selection_changed",
+            "payload": {},
+        }
+    )
+    with pytest.raises(HubProtocolError):
+        decode(raw)
+
+
+def test_decode_rejects_additional_payload_properties():
+    """additionalProperties: false on every payload subschema."""
+
+    raw = json.dumps(
+        {
+            "v": 1,
+            "id": str(uuid.uuid4()),
+            "origin": "view",
+            "kind": "event",
+            "type": "selection_changed",
+            "payload": {"instance_path": "top", "extra": True},
+        }
+    )
+    with pytest.raises(HubProtocolError):
+        decode(raw)
+
+
+def test_decode_rejects_wrong_kind_for_event_type():
+    raw = json.dumps(
+        {
+            "v": 1,
+            "id": str(uuid.uuid4()),
+            "origin": "view",
+            "kind": "request",  # selection_changed is event-only
+            "type": "selection_changed",
+            "payload": {"instance_path": "top"},
+        }
+    )
+    with pytest.raises(HubProtocolError):
+        decode(raw)
+
+
+def test_decode_silently_accepts_unknown_type():
+    """§11: unknown types MUST be silently dropped at DEBUG.
+
+    The codec accepts them; downstream routing is what discards them.
+    """
+
+    raw = json.dumps(
+        {
+            "v": 1,
+            "id": str(uuid.uuid4()),
+            "origin": "view",
+            "kind": "event",
+            "type": "future_v2_event",
+            "payload": {"anything": "goes"},
+        }
+    )
+    env = decode(raw)
+    assert env.type == "future_v2_event"
+
+
+def test_decode_rejects_malformed_json():
+    with pytest.raises(HubProtocolError):
+        decode("{not-json")
+
+
+# ---------------------------------------------------------------------------
+# encode-side validation
+# ---------------------------------------------------------------------------
+
+
+def test_encode_rejects_invalid_envelope():
+    """A bug in a caller surfaces here, not on the remote peer."""
+
+    env = Envelope(
+        origin=Origin.VIEW,
+        kind=Kind.EVENT,
+        type="selection_changed",
+        id="not-a-uuid",
+        payload={"instance_path": "top"},
+    )
+    with pytest.raises(HubProtocolError):
+        encode(env)
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def test_make_hello_produces_valid_envelope():
+    env = make_hello(client=Origin.VIEW, version="0.1.0", capabilities=["x", "y"])
+    raw = encode(env)
+    assert decode(raw) == env
+
+
+def test_make_welcome_carries_request_id():
+    hello = make_hello(client=Origin.VIEW, version="0.1.0", capabilities=[])
+    welcome = make_welcome(
+        in_reply_to=hello.id,
+        server_version="0.1.0",
+        registered_clients=[Origin.WAVE],
+    )
+    assert welcome.id == hello.id
+    assert welcome.payload == {
+        "server_version": "0.1.0",
+        "registered_clients": ["wave"],
+    }
+
+
+def test_make_error_carries_request_id_when_in_reply_to():
+    err = make_error(
+        origin=Origin.CLI,
+        code="unresolvable",
+        message="no scope",
+        context={"instance_path": "top.x"},
+        in_reply_to="11111111-1111-1111-1111-111111111111",
+    )
+    assert err.id == "11111111-1111-1111-1111-111111111111"
+    assert err.payload["code"] == "unresolvable"
+    encode(err)  # must pass schema
+
+
+def test_make_error_generates_id_when_spontaneous():
+    err = make_error(origin=Origin.CLI, code="bad_request", message="oops")
+    uuid.UUID(err.id)  # must parse
+
+
+def test_new_id_is_uuid4():
+    val = new_id()
+    parsed = uuid.UUID(val)
+    assert parsed.version == 4
+
+
+# ---------------------------------------------------------------------------
+# vendored schema drift
+# ---------------------------------------------------------------------------
+
+
+def test_vendored_schema_has_expected_types():
+    """Catch accidental schema drift: every spec ``type`` is present."""
+
+    schema = protocol.schema()
+    types_seen: set[str] = set()
+    for branch in schema.get("allOf", []):
+        const = branch.get("if", {}).get("properties", {}).get("type", {}).get("const")
+        if const is not None:
+            types_seen.add(const)
+    expected = {
+        "selection_changed",
+        "signal_selected",
+        "cursor_time_changed",
+        "scope_changed",
+        "source_focused",
+        "open_source",
+        "wave_add_variables",
+        "wave_set_scope",
+        "wave_set_cursor",
+        "view_pan_to",
+        "resolve_view_to_wave",
+        "resolve_signal_to_view",
+        "hello",
+        "welcome",
+        "bye",
+        "error",
+    }
+    assert types_seen == expected
+
+
+def test_vendored_schema_matches_source_when_view_repo_present():
+    """Schema is vendored — drift detection when the view repo is a sibling.
+
+    The source of truth lives in ``rtl-buddy/rtl-buddy-view``. CI for
+    rtl_buddy does not clone that repo, so this test no-ops there; it
+    fires locally when both checkouts are side-by-side.
+    """
+
+    sibling = Path(__file__).resolve().parents[2] / "rtl-buddy-view"
+    src_schema = sibling / "schemas" / "hub-protocol-v1.json"
+    if not src_schema.is_file():
+        pytest.skip("rtl-buddy-view sibling checkout not present")
+
+    vendored = (
+        Path(__file__).resolve().parents[1]
+        / "src"
+        / "rtl_buddy"
+        / "hub"
+        / "schema"
+        / "hub-protocol-v1.json"
+    )
+    assert vendored.read_bytes() == src_schema.read_bytes(), (
+        "vendored schema has drifted from the rtl-buddy-view source. "
+        "Re-copy and commit; the wire contract is owned by Phase 10a."
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -12,6 +12,15 @@ wheels = [
 ]
 
 [[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
 name = "babel"
 version = "2.18.0"
 source = { registry = "https://pypi.org/simple" }
@@ -315,6 +324,33 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
 ]
 
 [[package]]
@@ -784,6 +820,20 @@ wheels = [
 ]
 
 [[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.33.1"
 source = { registry = "https://pypi.org/simple" }
@@ -812,10 +862,119 @@ wheels = [
 ]
 
 [[package]]
+name = "rpds-py"
+version = "0.30.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/af/3f2f423103f1113b36230496629986e0ef7e199d2aa8392452b484b38ced/rpds_py-0.30.0.tar.gz", hash = "sha256:dd8ff7cf90014af0c0f787eea34794ebf6415242ee1d6fa91eaba725cc441e84", size = 69469, upload-time = "2025-11-30T20:24:38.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/6e/f964e88b3d2abee2a82c1ac8366da848fce1c6d834dc2132c3fda3970290/rpds_py-0.30.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:a2bffea6a4ca9f01b3f8e548302470306689684e61602aa3d141e34da06cf425", size = 370157, upload-time = "2025-11-30T20:21:53.789Z" },
+    { url = "https://files.pythonhosted.org/packages/94/ba/24e5ebb7c1c82e74c4e4f33b2112a5573ddc703915b13a073737b59b86e0/rpds_py-0.30.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:dc4f992dfe1e2bc3ebc7444f6c7051b4bc13cd8e33e43511e8ffd13bf407010d", size = 359676, upload-time = "2025-11-30T20:21:55.475Z" },
+    { url = "https://files.pythonhosted.org/packages/84/86/04dbba1b087227747d64d80c3b74df946b986c57af0a9f0c98726d4d7a3b/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:422c3cb9856d80b09d30d2eb255d0754b23e090034e1deb4083f8004bd0761e4", size = 389938, upload-time = "2025-11-30T20:21:57.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/bb/1463f0b1722b7f45431bdd468301991d1328b16cffe0b1c2918eba2c4eee/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:07ae8a593e1c3c6b82ca3292efbe73c30b61332fd612e05abee07c79359f292f", size = 402932, upload-time = "2025-11-30T20:21:58.47Z" },
+    { url = "https://files.pythonhosted.org/packages/99/ee/2520700a5c1f2d76631f948b0736cdf9b0acb25abd0ca8e889b5c62ac2e3/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:12f90dd7557b6bd57f40abe7747e81e0c0b119bef015ea7726e69fe550e394a4", size = 525830, upload-time = "2025-11-30T20:21:59.699Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/ad/bd0331f740f5705cc555a5e17fdf334671262160270962e69a2bdef3bf76/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:99b47d6ad9a6da00bec6aabe5a6279ecd3c06a329d4aa4771034a21e335c3a97", size = 412033, upload-time = "2025-11-30T20:22:00.991Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/1e/372195d326549bb51f0ba0f2ecb9874579906b97e08880e7a65c3bef1a99/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:33f559f3104504506a44bb666b93a33f5d33133765b0c216a5bf2f1e1503af89", size = 390828, upload-time = "2025-11-30T20:22:02.723Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/2b/d88bb33294e3e0c76bc8f351a3721212713629ffca1700fa94979cb3eae8/rpds_py-0.30.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:946fe926af6e44f3697abbc305ea168c2c31d3e3ef1058cf68f379bf0335a78d", size = 404683, upload-time = "2025-11-30T20:22:04.367Z" },
+    { url = "https://files.pythonhosted.org/packages/50/32/c759a8d42bcb5289c1fac697cd92f6fe01a018dd937e62ae77e0e7f15702/rpds_py-0.30.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:495aeca4b93d465efde585977365187149e75383ad2684f81519f504f5c13038", size = 421583, upload-time = "2025-11-30T20:22:05.814Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/81/e729761dbd55ddf5d84ec4ff1f47857f4374b0f19bdabfcf929164da3e24/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d9a0ca5da0386dee0655b4ccdf46119df60e0f10da268d04fe7cc87886872ba7", size = 572496, upload-time = "2025-11-30T20:22:07.713Z" },
+    { url = "https://files.pythonhosted.org/packages/14/f6/69066a924c3557c9c30baa6ec3a0aa07526305684c6f86c696b08860726c/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:8d6d1cc13664ec13c1b84241204ff3b12f9bb82464b8ad6e7a5d3486975c2eed", size = 598669, upload-time = "2025-11-30T20:22:09.312Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/48/905896b1eb8a05630d20333d1d8ffd162394127b74ce0b0784ae04498d32/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3896fa1be39912cf0757753826bc8bdc8ca331a28a7c4ae46b7a21280b06bb85", size = 561011, upload-time = "2025-11-30T20:22:11.309Z" },
+    { url = "https://files.pythonhosted.org/packages/22/16/cd3027c7e279d22e5eb431dd3c0fbc677bed58797fe7581e148f3f68818b/rpds_py-0.30.0-cp311-cp311-win32.whl", hash = "sha256:55f66022632205940f1827effeff17c4fa7ae1953d2b74a8581baaefb7d16f8c", size = 221406, upload-time = "2025-11-30T20:22:13.101Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/5b/e7b7aa136f28462b344e652ee010d4de26ee9fd16f1bfd5811f5153ccf89/rpds_py-0.30.0-cp311-cp311-win_amd64.whl", hash = "sha256:a51033ff701fca756439d641c0ad09a41d9242fa69121c7d8769604a0a629825", size = 236024, upload-time = "2025-11-30T20:22:14.853Z" },
+    { url = "https://files.pythonhosted.org/packages/14/a6/364bba985e4c13658edb156640608f2c9e1d3ea3c81b27aa9d889fff0e31/rpds_py-0.30.0-cp311-cp311-win_arm64.whl", hash = "sha256:47b0ef6231c58f506ef0b74d44e330405caa8428e770fec25329ed2cb971a229", size = 229069, upload-time = "2025-11-30T20:22:16.577Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e7/98a2f4ac921d82f33e03f3835f5bf3a4a40aa1bfdc57975e74a97b2b4bdd/rpds_py-0.30.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a161f20d9a43006833cd7068375a94d035714d73a172b681d8881820600abfad", size = 375086, upload-time = "2025-11-30T20:22:17.93Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/a1/bca7fd3d452b272e13335db8d6b0b3ecde0f90ad6f16f3328c6fb150c889/rpds_py-0.30.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6abc8880d9d036ecaafe709079969f56e876fcf107f7a8e9920ba6d5a3878d05", size = 359053, upload-time = "2025-11-30T20:22:19.297Z" },
+    { url = "https://files.pythonhosted.org/packages/65/1c/ae157e83a6357eceff62ba7e52113e3ec4834a84cfe07fa4b0757a7d105f/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca28829ae5f5d569bb62a79512c842a03a12576375d5ece7d2cadf8abe96ec28", size = 390763, upload-time = "2025-11-30T20:22:21.661Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/36/eb2eb8515e2ad24c0bd43c3ee9cd74c33f7ca6430755ccdb240fd3144c44/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a1010ed9524c73b94d15919ca4d41d8780980e1765babf85f9a2f90d247153dd", size = 408951, upload-time = "2025-11-30T20:22:23.408Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/65/ad8dc1784a331fabbd740ef6f71ce2198c7ed0890dab595adb9ea2d775a1/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f8d1736cfb49381ba528cd5baa46f82fdc65c06e843dab24dd70b63d09121b3f", size = 514622, upload-time = "2025-11-30T20:22:25.16Z" },
+    { url = "https://files.pythonhosted.org/packages/63/8e/0cfa7ae158e15e143fe03993b5bcd743a59f541f5952e1546b1ac1b5fd45/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d948b135c4693daff7bc2dcfc4ec57237a29bd37e60c2fabf5aff2bbacf3e2f1", size = 414492, upload-time = "2025-11-30T20:22:26.505Z" },
+    { url = "https://files.pythonhosted.org/packages/60/1b/6f8f29f3f995c7ffdde46a626ddccd7c63aefc0efae881dc13b6e5d5bb16/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47f236970bccb2233267d89173d3ad2703cd36a0e2a6e92d0560d333871a3d23", size = 394080, upload-time = "2025-11-30T20:22:27.934Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/d5/a266341051a7a3ca2f4b750a3aa4abc986378431fc2da508c5034d081b70/rpds_py-0.30.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:2e6ecb5a5bcacf59c3f912155044479af1d0b6681280048b338b28e364aca1f6", size = 408680, upload-time = "2025-11-30T20:22:29.341Z" },
+    { url = "https://files.pythonhosted.org/packages/10/3b/71b725851df9ab7a7a4e33cf36d241933da66040d195a84781f49c50490c/rpds_py-0.30.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a8fa71a2e078c527c3e9dc9fc5a98c9db40bcc8a92b4e8858e36d329f8684b51", size = 423589, upload-time = "2025-11-30T20:22:31.469Z" },
+    { url = "https://files.pythonhosted.org/packages/00/2b/e59e58c544dc9bd8bd8384ecdb8ea91f6727f0e37a7131baeff8d6f51661/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:73c67f2db7bc334e518d097c6d1e6fed021bbc9b7d678d6cc433478365d1d5f5", size = 573289, upload-time = "2025-11-30T20:22:32.997Z" },
+    { url = "https://files.pythonhosted.org/packages/da/3e/a18e6f5b460893172a7d6a680e86d3b6bc87a54c1f0b03446a3c8c7b588f/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5ba103fb455be00f3b1c2076c9d4264bfcb037c976167a6047ed82f23153f02e", size = 599737, upload-time = "2025-11-30T20:22:34.419Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e2/714694e4b87b85a18e2c243614974413c60aa107fd815b8cbc42b873d1d7/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7cee9c752c0364588353e627da8a7e808a66873672bcb5f52890c33fd965b394", size = 563120, upload-time = "2025-11-30T20:22:35.903Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/ab/d5d5e3bcedb0a77f4f613706b750e50a5a3ba1c15ccd3665ecc636c968fd/rpds_py-0.30.0-cp312-cp312-win32.whl", hash = "sha256:1ab5b83dbcf55acc8b08fc62b796ef672c457b17dbd7820a11d6c52c06839bdf", size = 223782, upload-time = "2025-11-30T20:22:37.271Z" },
+    { url = "https://files.pythonhosted.org/packages/39/3b/f786af9957306fdc38a74cef405b7b93180f481fb48453a114bb6465744a/rpds_py-0.30.0-cp312-cp312-win_amd64.whl", hash = "sha256:a090322ca841abd453d43456ac34db46e8b05fd9b3b4ac0c78bcde8b089f959b", size = 240463, upload-time = "2025-11-30T20:22:39.021Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d2/b91dc748126c1559042cfe41990deb92c4ee3e2b415f6b5234969ffaf0cc/rpds_py-0.30.0-cp312-cp312-win_arm64.whl", hash = "sha256:669b1805bd639dd2989b281be2cfd951c6121b65e729d9b843e9639ef1fd555e", size = 230868, upload-time = "2025-11-30T20:22:40.493Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/dc/d61221eb88ff410de3c49143407f6f3147acf2538c86f2ab7ce65ae7d5f9/rpds_py-0.30.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:f83424d738204d9770830d35290ff3273fbb02b41f919870479fab14b9d303b2", size = 374887, upload-time = "2025-11-30T20:22:41.812Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/32/55fb50ae104061dbc564ef15cc43c013dc4a9f4527a1f4d99baddf56fe5f/rpds_py-0.30.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e7536cd91353c5273434b4e003cbda89034d67e7710eab8761fd918ec6c69cf8", size = 358904, upload-time = "2025-11-30T20:22:43.479Z" },
+    { url = "https://files.pythonhosted.org/packages/58/70/faed8186300e3b9bdd138d0273109784eea2396c68458ed580f885dfe7ad/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2771c6c15973347f50fece41fc447c054b7ac2ae0502388ce3b6738cd366e3d4", size = 389945, upload-time = "2025-11-30T20:22:44.819Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/a8/073cac3ed2c6387df38f71296d002ab43496a96b92c823e76f46b8af0543/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0a59119fc6e3f460315fe9d08149f8102aa322299deaa5cab5b40092345c2136", size = 407783, upload-time = "2025-11-30T20:22:46.103Z" },
+    { url = "https://files.pythonhosted.org/packages/77/57/5999eb8c58671f1c11eba084115e77a8899d6e694d2a18f69f0ba471ec8b/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:76fec018282b4ead0364022e3c54b60bf368b9d926877957a8624b58419169b7", size = 515021, upload-time = "2025-11-30T20:22:47.458Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/af/5ab4833eadc36c0a8ed2bc5c0de0493c04f6c06de223170bd0798ff98ced/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:692bef75a5525db97318e8cd061542b5a79812d711ea03dbc1f6f8dbb0c5f0d2", size = 414589, upload-time = "2025-11-30T20:22:48.872Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/de/f7192e12b21b9e9a68a6d0f249b4af3fdcdff8418be0767a627564afa1f1/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9027da1ce107104c50c81383cae773ef5c24d296dd11c99e2629dbd7967a20c6", size = 394025, upload-time = "2025-11-30T20:22:50.196Z" },
+    { url = "https://files.pythonhosted.org/packages/91/c4/fc70cd0249496493500e7cc2de87504f5aa6509de1e88623431fec76d4b6/rpds_py-0.30.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:9cf69cdda1f5968a30a359aba2f7f9aa648a9ce4b580d6826437f2b291cfc86e", size = 408895, upload-time = "2025-11-30T20:22:51.87Z" },
+    { url = "https://files.pythonhosted.org/packages/58/95/d9275b05ab96556fefff73a385813eb66032e4c99f411d0795372d9abcea/rpds_py-0.30.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a4796a717bf12b9da9d3ad002519a86063dcac8988b030e405704ef7d74d2d9d", size = 422799, upload-time = "2025-11-30T20:22:53.341Z" },
+    { url = "https://files.pythonhosted.org/packages/06/c1/3088fc04b6624eb12a57eb814f0d4997a44b0d208d6cace713033ff1a6ba/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5d4c2aa7c50ad4728a094ebd5eb46c452e9cb7edbfdb18f9e1221f597a73e1e7", size = 572731, upload-time = "2025-11-30T20:22:54.778Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/42/c612a833183b39774e8ac8fecae81263a68b9583ee343db33ab571a7ce55/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ba81a9203d07805435eb06f536d95a266c21e5b2dfbf6517748ca40c98d19e31", size = 599027, upload-time = "2025-11-30T20:22:56.212Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/60/525a50f45b01d70005403ae0e25f43c0384369ad24ffe46e8d9068b50086/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:945dccface01af02675628334f7cf49c2af4c1c904748efc5cf7bbdf0b579f95", size = 563020, upload-time = "2025-11-30T20:22:58.2Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/5d/47c4655e9bcd5ca907148535c10e7d489044243cc9941c16ed7cd53be91d/rpds_py-0.30.0-cp313-cp313-win32.whl", hash = "sha256:b40fb160a2db369a194cb27943582b38f79fc4887291417685f3ad693c5a1d5d", size = 223139, upload-time = "2025-11-30T20:23:00.209Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/e1/485132437d20aa4d3e1d8b3fb5a5e65aa8139f1e097080c2a8443201742c/rpds_py-0.30.0-cp313-cp313-win_amd64.whl", hash = "sha256:806f36b1b605e2d6a72716f321f20036b9489d29c51c91f4dd29a3e3afb73b15", size = 240224, upload-time = "2025-11-30T20:23:02.008Z" },
+    { url = "https://files.pythonhosted.org/packages/24/95/ffd128ed1146a153d928617b0ef673960130be0009c77d8fbf0abe306713/rpds_py-0.30.0-cp313-cp313-win_arm64.whl", hash = "sha256:d96c2086587c7c30d44f31f42eae4eac89b60dabbac18c7669be3700f13c3ce1", size = 230645, upload-time = "2025-11-30T20:23:03.43Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/1b/b10de890a0def2a319a2626334a7f0ae388215eb60914dbac8a3bae54435/rpds_py-0.30.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:eb0b93f2e5c2189ee831ee43f156ed34e2a89a78a66b98cadad955972548be5a", size = 364443, upload-time = "2025-11-30T20:23:04.878Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/bf/27e39f5971dc4f305a4fb9c672ca06f290f7c4e261c568f3dea16a410d47/rpds_py-0.30.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:922e10f31f303c7c920da8981051ff6d8c1a56207dbdf330d9047f6d30b70e5e", size = 353375, upload-time = "2025-11-30T20:23:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/40/58/442ada3bba6e8e6615fc00483135c14a7538d2ffac30e2d933ccf6852232/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cdc62c8286ba9bf7f47befdcea13ea0e26bf294bda99758fd90535cbaf408000", size = 383850, upload-time = "2025-11-30T20:23:07.825Z" },
+    { url = "https://files.pythonhosted.org/packages/14/14/f59b0127409a33c6ef6f5c1ebd5ad8e32d7861c9c7adfa9a624fc3889f6c/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:47f9a91efc418b54fb8190a6b4aa7813a23fb79c51f4bb84e418f5476c38b8db", size = 392812, upload-time = "2025-11-30T20:23:09.228Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/66/e0be3e162ac299b3a22527e8913767d869e6cc75c46bd844aa43fb81ab62/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1f3587eb9b17f3789ad50824084fa6f81921bbf9a795826570bda82cb3ed91f2", size = 517841, upload-time = "2025-11-30T20:23:11.186Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/55/fa3b9cf31d0c963ecf1ba777f7cf4b2a2c976795ac430d24a1f43d25a6ba/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:39c02563fc592411c2c61d26b6c5fe1e51eaa44a75aa2c8735ca88b0d9599daa", size = 408149, upload-time = "2025-11-30T20:23:12.864Z" },
+    { url = "https://files.pythonhosted.org/packages/60/ca/780cf3b1a32b18c0f05c441958d3758f02544f1d613abf9488cd78876378/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51a1234d8febafdfd33a42d97da7a43f5dcb120c1060e352a3fbc0c6d36e2083", size = 383843, upload-time = "2025-11-30T20:23:14.638Z" },
+    { url = "https://files.pythonhosted.org/packages/82/86/d5f2e04f2aa6247c613da0c1dd87fcd08fa17107e858193566048a1e2f0a/rpds_py-0.30.0-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:eb2c4071ab598733724c08221091e8d80e89064cd472819285a9ab0f24bcedb9", size = 396507, upload-time = "2025-11-30T20:23:16.105Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/9a/453255d2f769fe44e07ea9785c8347edaf867f7026872e76c1ad9f7bed92/rpds_py-0.30.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6bdfdb946967d816e6adf9a3d8201bfad269c67efe6cefd7093ef959683c8de0", size = 414949, upload-time = "2025-11-30T20:23:17.539Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/31/622a86cdc0c45d6df0e9ccb6becdba5074735e7033c20e401a6d9d0e2ca0/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c77afbd5f5250bf27bf516c7c4a016813eb2d3e116139aed0096940c5982da94", size = 565790, upload-time = "2025-11-30T20:23:19.029Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/5d/15bbf0fb4a3f58a3b1c67855ec1efcc4ceaef4e86644665fff03e1b66d8d/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:61046904275472a76c8c90c9ccee9013d70a6d0f73eecefd38c1ae7c39045a08", size = 590217, upload-time = "2025-11-30T20:23:20.885Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/61/21b8c41f68e60c8cc3b2e25644f0e3681926020f11d06ab0b78e3c6bbff1/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4c5f36a861bc4b7da6516dbdf302c55313afa09b81931e8280361a4f6c9a2d27", size = 555806, upload-time = "2025-11-30T20:23:22.488Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/39/7e067bb06c31de48de3eb200f9fc7c58982a4d3db44b07e73963e10d3be9/rpds_py-0.30.0-cp313-cp313t-win32.whl", hash = "sha256:3d4a69de7a3e50ffc214ae16d79d8fbb0922972da0356dcf4d0fdca2878559c6", size = 211341, upload-time = "2025-11-30T20:23:24.449Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/4d/222ef0b46443cf4cf46764d9c630f3fe4abaa7245be9417e56e9f52b8f65/rpds_py-0.30.0-cp313-cp313t-win_amd64.whl", hash = "sha256:f14fc5df50a716f7ece6a80b6c78bb35ea2ca47c499e422aa4463455dd96d56d", size = 225768, upload-time = "2025-11-30T20:23:25.908Z" },
+    { url = "https://files.pythonhosted.org/packages/86/81/dad16382ebbd3d0e0328776d8fd7ca94220e4fa0798d1dc5e7da48cb3201/rpds_py-0.30.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:68f19c879420aa08f61203801423f6cd5ac5f0ac4ac82a2368a9fcd6a9a075e0", size = 362099, upload-time = "2025-11-30T20:23:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/60/19f7884db5d5603edf3c6bce35408f45ad3e97e10007df0e17dd57af18f8/rpds_py-0.30.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ec7c4490c672c1a0389d319b3a9cfcd098dcdc4783991553c332a15acf7249be", size = 353192, upload-time = "2025-11-30T20:23:29.151Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/c4/76eb0e1e72d1a9c4703c69607cec123c29028bff28ce41588792417098ac/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f251c812357a3fed308d684a5079ddfb9d933860fc6de89f2b7ab00da481e65f", size = 384080, upload-time = "2025-11-30T20:23:30.785Z" },
+    { url = "https://files.pythonhosted.org/packages/72/87/87ea665e92f3298d1b26d78814721dc39ed8d2c74b86e83348d6b48a6f31/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ac98b175585ecf4c0348fd7b29c3864bda53b805c773cbf7bfdaffc8070c976f", size = 394841, upload-time = "2025-11-30T20:23:32.209Z" },
+    { url = "https://files.pythonhosted.org/packages/77/ad/7783a89ca0587c15dcbf139b4a8364a872a25f861bdb88ed99f9b0dec985/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3e62880792319dbeb7eb866547f2e35973289e7d5696c6e295476448f5b63c87", size = 516670, upload-time = "2025-11-30T20:23:33.742Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/3c/2882bdac942bd2172f3da574eab16f309ae10a3925644e969536553cb4ee/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4e7fc54e0900ab35d041b0601431b0a0eb495f0851a0639b6ef90f7741b39a18", size = 408005, upload-time = "2025-11-30T20:23:35.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/81/9a91c0111ce1758c92516a3e44776920b579d9a7c09b2b06b642d4de3f0f/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47e77dc9822d3ad616c3d5759ea5631a75e5809d5a28707744ef79d7a1bcfcad", size = 382112, upload-time = "2025-11-30T20:23:36.842Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/8e/1da49d4a107027e5fbc64daeab96a0706361a2918da10cb41769244b805d/rpds_py-0.30.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:b4dc1a6ff022ff85ecafef7979a2c6eb423430e05f1165d6688234e62ba99a07", size = 399049, upload-time = "2025-11-30T20:23:38.343Z" },
+    { url = "https://files.pythonhosted.org/packages/df/5a/7ee239b1aa48a127570ec03becbb29c9d5a9eb092febbd1699d567cae859/rpds_py-0.30.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4559c972db3a360808309e06a74628b95eaccbf961c335c8fe0d590cf587456f", size = 415661, upload-time = "2025-11-30T20:23:40.263Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ea/caa143cf6b772f823bc7929a45da1fa83569ee49b11d18d0ada7f5ee6fd6/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0ed177ed9bded28f8deb6ab40c183cd1192aa0de40c12f38be4d59cd33cb5c65", size = 565606, upload-time = "2025-11-30T20:23:42.186Z" },
+    { url = "https://files.pythonhosted.org/packages/64/91/ac20ba2d69303f961ad8cf55bf7dbdb4763f627291ba3d0d7d67333cced9/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ad1fa8db769b76ea911cb4e10f049d80bf518c104f15b3edb2371cc65375c46f", size = 591126, upload-time = "2025-11-30T20:23:44.086Z" },
+    { url = "https://files.pythonhosted.org/packages/21/20/7ff5f3c8b00c8a95f75985128c26ba44503fb35b8e0259d812766ea966c7/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:46e83c697b1f1c72b50e5ee5adb4353eef7406fb3f2043d64c33f20ad1c2fc53", size = 553371, upload-time = "2025-11-30T20:23:46.004Z" },
+    { url = "https://files.pythonhosted.org/packages/72/c7/81dadd7b27c8ee391c132a6b192111ca58d866577ce2d9b0ca157552cce0/rpds_py-0.30.0-cp314-cp314-win32.whl", hash = "sha256:ee454b2a007d57363c2dfd5b6ca4a5d7e2c518938f8ed3b706e37e5d470801ed", size = 215298, upload-time = "2025-11-30T20:23:47.696Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d2/1aaac33287e8cfb07aab2e6b8ac1deca62f6f65411344f1433c55e6f3eb8/rpds_py-0.30.0-cp314-cp314-win_amd64.whl", hash = "sha256:95f0802447ac2d10bcc69f6dc28fe95fdf17940367b21d34e34c737870758950", size = 228604, upload-time = "2025-11-30T20:23:49.501Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/95/ab005315818cc519ad074cb7784dae60d939163108bd2b394e60dc7b5461/rpds_py-0.30.0-cp314-cp314-win_arm64.whl", hash = "sha256:613aa4771c99f03346e54c3f038e4cc574ac09a3ddfb0e8878487335e96dead6", size = 222391, upload-time = "2025-11-30T20:23:50.96Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/68/154fe0194d83b973cdedcdcc88947a2752411165930182ae41d983dcefa6/rpds_py-0.30.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:7e6ecfcb62edfd632e56983964e6884851786443739dbfe3582947e87274f7cb", size = 364868, upload-time = "2025-11-30T20:23:52.494Z" },
+    { url = "https://files.pythonhosted.org/packages/83/69/8bbc8b07ec854d92a8b75668c24d2abcb1719ebf890f5604c61c9369a16f/rpds_py-0.30.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a1d0bc22a7cdc173fedebb73ef81e07faef93692b8c1ad3733b67e31e1b6e1b8", size = 353747, upload-time = "2025-11-30T20:23:54.036Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/00/ba2e50183dbd9abcce9497fa5149c62b4ff3e22d338a30d690f9af970561/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d08f00679177226c4cb8c5265012eea897c8ca3b93f429e546600c971bcbae7", size = 383795, upload-time = "2025-11-30T20:23:55.556Z" },
+    { url = "https://files.pythonhosted.org/packages/05/6f/86f0272b84926bcb0e4c972262f54223e8ecc556b3224d281e6598fc9268/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5965af57d5848192c13534f90f9dd16464f3c37aaf166cc1da1cae1fd5a34898", size = 393330, upload-time = "2025-11-30T20:23:57.033Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/e9/0e02bb2e6dc63d212641da45df2b0bf29699d01715913e0d0f017ee29438/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9a4e86e34e9ab6b667c27f3211ca48f73dba7cd3d90f8d5b11be56e5dbc3fb4e", size = 518194, upload-time = "2025-11-30T20:23:58.637Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/ca/be7bca14cf21513bdf9c0606aba17d1f389ea2b6987035eb4f62bd923f25/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e5d3e6b26f2c785d65cc25ef1e5267ccbe1b069c5c21b8cc724efee290554419", size = 408340, upload-time = "2025-11-30T20:24:00.2Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c7/736e00ebf39ed81d75544c0da6ef7b0998f8201b369acf842f9a90dc8fce/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:626a7433c34566535b6e56a1b39a7b17ba961e97ce3b80ec62e6f1312c025551", size = 383765, upload-time = "2025-11-30T20:24:01.759Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/3f/da50dfde9956aaf365c4adc9533b100008ed31aea635f2b8d7b627e25b49/rpds_py-0.30.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:acd7eb3f4471577b9b5a41baf02a978e8bdeb08b4b355273994f8b87032000a8", size = 396834, upload-time = "2025-11-30T20:24:03.687Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/00/34bcc2565b6020eab2623349efbdec810676ad571995911f1abdae62a3a0/rpds_py-0.30.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fe5fa731a1fa8a0a56b0977413f8cacac1768dad38d16b3a296712709476fbd5", size = 415470, upload-time = "2025-11-30T20:24:05.232Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/28/882e72b5b3e6f718d5453bd4d0d9cf8df36fddeb4ddbbab17869d5868616/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:74a3243a411126362712ee1524dfc90c650a503502f135d54d1b352bd01f2404", size = 565630, upload-time = "2025-11-30T20:24:06.878Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/97/04a65539c17692de5b85c6e293520fd01317fd878ea1995f0367d4532fb1/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:3e8eeb0544f2eb0d2581774be4c3410356eba189529a6b3e36bbbf9696175856", size = 591148, upload-time = "2025-11-30T20:24:08.445Z" },
+    { url = "https://files.pythonhosted.org/packages/85/70/92482ccffb96f5441aab93e26c4d66489eb599efdcf96fad90c14bbfb976/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:dbd936cde57abfee19ab3213cf9c26be06d60750e60a8e4dd85d1ab12c8b1f40", size = 556030, upload-time = "2025-11-30T20:24:10.956Z" },
+    { url = "https://files.pythonhosted.org/packages/20/53/7c7e784abfa500a2b6b583b147ee4bb5a2b3747a9166bab52fec4b5b5e7d/rpds_py-0.30.0-cp314-cp314t-win32.whl", hash = "sha256:dc824125c72246d924f7f796b4f63c1e9dc810c7d9e2355864b3c3a73d59ade0", size = 211570, upload-time = "2025-11-30T20:24:12.735Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/02/fa464cdfbe6b26e0600b62c528b72d8608f5cc49f96b8d6e38c95d60c676/rpds_py-0.30.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27f4b0e92de5bfbc6f86e43959e6edd1425c33b5e69aab0984a72047f2bcf1e3", size = 226532, upload-time = "2025-11-30T20:24:14.634Z" },
+    { url = "https://files.pythonhosted.org/packages/69/71/3f34339ee70521864411f8b6992e7ab13ac30d8e4e3309e07c7361767d91/rpds_py-0.30.0-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:c2262bdba0ad4fc6fb5545660673925c2d2a5d9e2e0fb603aad545427be0fc58", size = 372292, upload-time = "2025-11-30T20:24:16.537Z" },
+    { url = "https://files.pythonhosted.org/packages/57/09/f183df9b8f2d66720d2ef71075c59f7e1b336bec7ee4c48f0a2b06857653/rpds_py-0.30.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:ee6af14263f25eedc3bb918a3c04245106a42dfd4f5c2285ea6f997b1fc3f89a", size = 362128, upload-time = "2025-11-30T20:24:18.086Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/68/5c2594e937253457342e078f0cc1ded3dd7b2ad59afdbf2d354869110a02/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3adbb8179ce342d235c31ab8ec511e66c73faa27a47e076ccc92421add53e2bb", size = 391542, upload-time = "2025-11-30T20:24:20.092Z" },
+    { url = "https://files.pythonhosted.org/packages/49/5c/31ef1afd70b4b4fbdb2800249f34c57c64beb687495b10aec0365f53dfc4/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:250fa00e9543ac9b97ac258bd37367ff5256666122c2d0f2bc97577c60a1818c", size = 404004, upload-time = "2025-11-30T20:24:22.231Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/63/0cfbea38d05756f3440ce6534d51a491d26176ac045e2707adc99bb6e60a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9854cf4f488b3d57b9aaeb105f06d78e5529d3145b1e4a41750167e8c213c6d3", size = 527063, upload-time = "2025-11-30T20:24:24.302Z" },
+    { url = "https://files.pythonhosted.org/packages/42/e6/01e1f72a2456678b0f618fc9a1a13f882061690893c192fcad9f2926553a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:993914b8e560023bc0a8bf742c5f303551992dcb85e247b1e5c7f4a7d145bda5", size = 413099, upload-time = "2025-11-30T20:24:25.916Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/25/8df56677f209003dcbb180765520c544525e3ef21ea72279c98b9aa7c7fb/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58edca431fb9b29950807e301826586e5bbf24163677732429770a697ffe6738", size = 392177, upload-time = "2025-11-30T20:24:27.834Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/b4/0a771378c5f16f8115f796d1f437950158679bcd2a7c68cf251cfb00ed5b/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_31_riscv64.whl", hash = "sha256:dea5b552272a944763b34394d04577cf0f9bd013207bc32323b5a89a53cf9c2f", size = 406015, upload-time = "2025-11-30T20:24:29.457Z" },
+    { url = "https://files.pythonhosted.org/packages/36/d8/456dbba0af75049dc6f63ff295a2f92766b9d521fa00de67a2bd6427d57a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ba3af48635eb83d03f6c9735dfb21785303e73d22ad03d489e88adae6eab8877", size = 423736, upload-time = "2025-11-30T20:24:31.22Z" },
+    { url = "https://files.pythonhosted.org/packages/13/64/b4d76f227d5c45a7e0b796c674fd81b0a6c4fbd48dc29271857d8219571c/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:dff13836529b921e22f15cb099751209a60009731a68519630a24d61f0b1b30a", size = 573981, upload-time = "2025-11-30T20:24:32.934Z" },
+    { url = "https://files.pythonhosted.org/packages/20/91/092bacadeda3edf92bf743cc96a7be133e13a39cdbfd7b5082e7ab638406/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:1b151685b23929ab7beec71080a8889d4d6d9fa9a983d213f07121205d48e2c4", size = 599782, upload-time = "2025-11-30T20:24:35.169Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/b7/b95708304cd49b7b6f82fdd039f1748b66ec2b21d6a45180910802f1abf1/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:ac37f9f516c51e5753f27dfdef11a88330f04de2d564be3991384b2f3535d02e", size = 562191, upload-time = "2025-11-30T20:24:36.853Z" },
+]
+
+[[package]]
 name = "rtl-buddy"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
+    { name = "jsonschema" },
     { name = "pyserde", extra = ["yaml"] },
     { name = "pywellen" },
     { name = "rich" },
@@ -848,6 +1007,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "click", specifier = ">=8.3.0" },
+    { name = "jsonschema", specifier = ">=4.21.0" },
     { name = "pyserde", extras = ["yaml"], specifier = ">=0.27.0" },
     { name = "pywellen", specifier = ">=0.20.0" },
     { name = "rich", specifier = ">=14.0.0" },


### PR DESCRIPTION
## Summary

First slice of the rtl-buddy-hub daemon (rtl-buddy/rtl_buddy#115). Lands the layers the server loop plugs into, so PR 2 can focus entirely on asyncio rather than wiring.

### New package: `src/rtl_buddy/hub/`

- **`protocol.py`** — envelope dataclasses + `encode`/`decode` validated against the v1 JSON Schema frozen by rtl-buddy/rtl-buddy-view#19. Schema is vendored at `src/rtl_buddy/hub/schema/hub-protocol-v1.json` with a drift-check test against the rtl-buddy-view sibling checkout (no-ops in CI).
- **`config.py`** — strict `tomllib`-based loader for `<project_root>/.rtl-buddy/hub.toml`, `[hub]` + `[mapping]` sections only.
- **`discovery.py`** — per-project `hub.json` lifecycle: atomic write, PID liveness check (refuses to start a second hub for the same project), env override via `$RTL_BUDDY_HUB`, walk-up lookup used by clients in §4.2 of the spec.
- **`state.py`** — in-memory selection / cursor / scope cache structures. Pub/sub plumbing lands with the server in PR 2.
- **`cli.py`** — `rb hub start|stop|status|log`, `rb hub config validate` Typer subapp, wired into the main CLI. `start` currently runs preflight (root discovery, config validation, conflict check) and exits with a clear "server loop in PR 2" notice; the rest are functional read-side commands.

### Side fix

`RtlBuddy.run()` previously discarded the return value from `self.app(standalone_mode=False)` — so `typer.Exit(code=N)` was silently exiting 0 for every subcommand that used it. Captures the rv and propagates it. No behaviour change for commands that returned `None`.

### Dependencies

Adds `jsonschema >= 4.21.0` as a runtime dep (used by the protocol codec).

### Coming next (this issue)

- **PR 2**: asyncio TCP server (line-delimited JSON), `hello`/`welcome` handshake, origin-suppressed broadcast (§6), bounded request-ID LRU dedupe.
- **PR 3**: resolver (view ↔ wave ↔ src) + state cache pub/sub.
- **PR 4**: `rb wave` hub integration (the wave adapter, §4.5).
- **PR 5**: viewer HTTP/WS layer + `rb hub --serve-viewer`.

## Test plan
- [x] `uv run pytest -q --no-cov` — 455 passed (52 new)
- [x] `uv run ruff check src tests` — clean
- [x] `uv run ruff format --check src tests` — clean
- [x] `uv run rb hub --help` lists `start | stop | status | log | config`
- [x] `uv run rb hub config validate` ok on a default project (returns 0, prints defaults)
- [x] `uv run rb hub config validate` rejects unknown sections (exit 1)
- [x] `uv run rb hub status` reports no hub running (exit 1)
- [x] `uv run rb hub start` exits 2 with the "PR 2" notice
- [x] CLI reference regenerated (`docs/reference/cli.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)