### PR TITLE
Phase 10b: rtl-buddy-hub asyncio TCP server (#115)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ lint = [
 test = [
   "pytest>=9.0.3",
   "pytest-cov>=6.0.0",
+  "pytest-asyncio>=0.24.0",
 ]
 dev = [
   { include-group = "docs" },

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
 testpaths = tests
+asyncio_mode = strict

--- a/src/rtl_buddy/hub/cli.py
+++ b/src/rtl_buddy/hub/cli.py
@@ -30,6 +30,7 @@ from ..errors import FatalRtlBuddyError
 from ..logging_utils import emit_console_text, log_event
 from . import config as hub_config
 from . import discovery
+from . import loop as hub_loop
 
 
 logger = logging.getLogger(__name__)
@@ -77,12 +78,26 @@ def cmd_start(
 ) -> None:
     """Bind, write ``hub.json``, run the server loop.
 
-    The asyncio server is implemented in PR 2; this command currently
-    validates the project root, parses ``hub.toml``, checks that no
-    other hub is running, and then exits with a clear "server not yet
-    implemented" notice. The plumbing exercised here is what PR 2
-    snaps into place.
+    Preflight (project root, config, conflict check) runs before the
+    asyncio loop starts so a misconfigured project fails immediately
+    rather than hanging in an event loop. The loop exits cleanly on
+    SIGINT / SIGTERM / ``rb hub stop`` and removes its discovery file.
     """
+
+    if not foreground:
+        emit_console_text(
+            "rb hub start --daemon: background detach not implemented yet; "
+            "wrap with `nohup rb hub start &` or use a process manager. "
+            "Running in foreground.",
+            style="yellow",
+        )
+
+    if serve_viewer:
+        emit_console_text(
+            "rb hub start --serve-viewer: viewer HTTP layer is PR 5 of #115. "
+            "Continuing with TCP server only.",
+            style="yellow",
+        )
 
     project_root = _resolve_project_root()
     cfg = _resolve_config(project_root)
@@ -103,13 +118,7 @@ def cmd_start(
         foreground=foreground,
         serve_viewer=serve_viewer,
     )
-    emit_console_text(
-        "rb hub start: server loop not yet implemented "
-        "(PR 2 of rtl-buddy/rtl_buddy#115). "
-        "Discovery, config, and lifecycle plumbing is in place.",
-        style="yellow",
-    )
-    raise typer.Exit(code=2)
+    raise typer.Exit(code=hub_loop.serve(project_root, cfg))
 
 
 @app.command("stop", help="ask the running hub to shut down")

--- a/src/rtl_buddy/hub/loop.py
+++ b/src/rtl_buddy/hub/loop.py
@@ -1,0 +1,97 @@
+"""asyncio orchestration for ``rb hub start``.
+
+This module glues the server (:mod:`rtl_buddy.hub.server`) to the
+discovery and config layers and runs the event loop until a signal,
+``rb hub stop``, or Ctrl-C asks the daemon to exit.
+
+Kept narrow: anything specific to clients (the resolver, WCP bridge,
+viewer HTTP layer) lives in its own module so this file stays an
+obviously-correct boot sequence.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import signal
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
+from pathlib import Path
+
+from ..logging_utils import log_event
+from .config import HubConfig
+from .discovery import delete_record_if_owner, write_record
+from .server import HubServer
+
+
+logger = logging.getLogger(__name__)
+
+
+def _server_version() -> str:
+    try:
+        return _pkg_version("rtl-buddy")
+    except PackageNotFoundError:
+        return "0.0.0+unknown"
+
+
+async def _run(project_root: Path, config: HubConfig) -> int:
+    server = HubServer(
+        host="127.0.0.1",
+        port=config.hub.listen_port,
+        server_version=_server_version(),
+    )
+    host, port = await server.start()
+
+    write_record(
+        project_root,
+        pid=os.getpid(),
+        tcp=f"{host}:{port}",
+        server_version=server.server_version,
+    )
+
+    loop = asyncio.get_running_loop()
+    stop_event = asyncio.Event()
+
+    def _request_stop(signame: str) -> None:
+        log_event(logger, logging.INFO, "hub.signal", name=signame)
+        stop_event.set()
+
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        try:
+            loop.add_signal_handler(sig, _request_stop, sig.name)
+        except NotImplementedError:
+            # Windows or certain embedded loops don't support add_signal_handler.
+            pass
+
+    serve_task = asyncio.create_task(server.serve_forever(), name="hub-serve")
+    stop_task = asyncio.create_task(stop_event.wait(), name="hub-stop")
+
+    try:
+        done, _pending = await asyncio.wait(
+            {serve_task, stop_task}, return_when=asyncio.FIRST_COMPLETED
+        )
+        for task in done:
+            exc = task.exception()
+            if exc is not None and not isinstance(exc, asyncio.CancelledError):
+                raise exc
+    finally:
+        await server.shutdown()
+        serve_task.cancel()
+        try:
+            await serve_task
+        except (asyncio.CancelledError, Exception):
+            pass
+        stop_task.cancel()
+        delete_record_if_owner(project_root, expected_pid=os.getpid())
+
+    return 0
+
+
+def serve(project_root: Path, config: HubConfig) -> int:
+    """Run the hub event loop until exit. Returns the process exit code."""
+
+    return asyncio.run(_run(project_root, config))
+
+
+__all__ = ["serve"]

--- a/src/rtl_buddy/hub/server.py
+++ b/src/rtl_buddy/hub/server.py
@@ -1,0 +1,645 @@
+"""asyncio TCP server for rtl-buddy-hub.
+
+Transport: line-delimited JSON over TCP, one envelope per line, UTF-8
+(§2 of the protocol spec). The browser-facing WebSocket layer lives in
+the viewer-integration PR and reuses this server's dispatch surface.
+
+Responsibilities of this module:
+
+* Accept client connections, run the ``hello``/``welcome`` handshake,
+  and maintain a registry keyed by :class:`Origin`. The spec allows at
+  most one client per origin in v1 — a second ``hello`` for an already
+  registered origin is refused with ``not_connected``.
+* Dispatch incoming envelopes:
+    - **state events** (selection_changed, signal_selected, …) are
+      broadcast to every connected client *except* the one whose
+      origin matches the event's ``origin`` (§6 rule 1).
+    - **requests** are routed to the client whose origin owns the
+      target coordinate system; if no such client is registered, the
+      hub replies with ``error{code: "not_connected"}``.
+    - **responses / errors** are routed back to the original requester
+      by ``id``.
+* Maintain a bounded LRU of recently seen request IDs so duplicate
+  requests (§6 rule 2) are silently dropped.
+
+The resolver (view ↔ wave ↔ src) is a PR 3 follow-up; this module
+returns ``error{code: "unresolvable"}`` for ``resolve_*`` requests so
+the wire surface is real even before the resolver lands.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from collections import OrderedDict
+from dataclasses import dataclass, field
+from typing import Any
+
+from ..logging_utils import log_event
+from .protocol import (
+    Envelope,
+    HubProtocolError,
+    Kind,
+    Origin,
+    decode,
+    encode,
+    make_error,
+    make_welcome,
+    new_id,
+)
+from .state import (
+    CursorTime,
+    HubState,
+    Selection,
+    SignalSelection,
+    WaveScope,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+STATE_EVENT_TYPES: frozenset[str] = frozenset(
+    {
+        "selection_changed",
+        "signal_selected",
+        "cursor_time_changed",
+        "scope_changed",
+        "source_focused",
+    }
+)
+"""Event ``type`` strings that broadcast to all clients except origin.
+
+``bye`` is technically also broadcast, but the connection close handler
+emits it explicitly; it's not a payload-bearing event the application
+emits, so it's tracked separately."""
+
+
+REQUEST_ROUTING: dict[str, Origin] = {
+    "wave_add_variables": Origin.WAVE,
+    "wave_set_scope": Origin.WAVE,
+    "wave_set_cursor": Origin.WAVE,
+    "open_source": Origin.SRC,
+    "view_pan_to": Origin.VIEW,
+}
+"""Request ``type`` → ``origin`` of the client that handles it.
+
+``resolve_*`` requests are hub-handled and not in this table; ``hello``
+is intercepted upfront by the handshake stage."""
+
+
+HUB_HANDLED_REQUESTS: frozenset[str] = frozenset(
+    {"resolve_view_to_wave", "resolve_signal_to_view"}
+)
+
+
+DEFAULT_DEDUPE_CAPACITY = 1024
+DEFAULT_DEDUPE_TTL_SECONDS = 60.0
+
+
+class HubServerError(Exception):
+    """Server-side error not routed back over the wire."""
+
+
+@dataclass
+class ClientConnection:
+    """One TCP-connected client."""
+
+    reader: asyncio.StreamReader
+    writer: asyncio.StreamWriter
+    peer: str
+    origin: Origin | None = None
+    capabilities: tuple[str, ...] = field(default_factory=tuple)
+    client_version: str = ""
+
+    async def send(self, env: Envelope) -> None:
+        """Serialise + write one envelope; flush via ``drain``."""
+
+        line = encode(env).encode("utf-8") + b"\n"
+        self.writer.write(line)
+        await self.writer.drain()
+
+    def close(self) -> None:
+        self.writer.close()
+
+
+@dataclass
+class _PendingRequest:
+    """In-flight request awaiting a response or error."""
+
+    requester_origin: Origin
+    seen_at: float
+
+
+class _LruIdSet:
+    """Bounded LRU of request IDs with a TTL.
+
+    Used both as a dedupe filter for incoming requests (§6 rule 2) and
+    as the table of currently-pending request IDs for response routing.
+    Two different concerns mapped onto the same data structure is
+    intentional: dedupe and routing both want "have we recently seen
+    this id, and what was it for?"
+    """
+
+    def __init__(
+        self,
+        *,
+        capacity: int = DEFAULT_DEDUPE_CAPACITY,
+        ttl_seconds: float = DEFAULT_DEDUPE_TTL_SECONDS,
+    ) -> None:
+        self._capacity = capacity
+        self._ttl = ttl_seconds
+        self._store: OrderedDict[str, _PendingRequest] = OrderedDict()
+
+    def __contains__(self, key: str) -> bool:
+        self._evict_expired()
+        return key in self._store
+
+    def get(self, key: str) -> _PendingRequest | None:
+        self._evict_expired()
+        return self._store.get(key)
+
+    def put(self, key: str, requester_origin: Origin) -> None:
+        self._store[key] = _PendingRequest(
+            requester_origin=requester_origin, seen_at=time.monotonic()
+        )
+        self._store.move_to_end(key)
+        while len(self._store) > self._capacity:
+            self._store.popitem(last=False)
+
+    def pop(self, key: str) -> _PendingRequest | None:
+        return self._store.pop(key, None)
+
+    def _evict_expired(self) -> None:
+        now = time.monotonic()
+        cutoff = now - self._ttl
+        while self._store:
+            _, value = next(iter(self._store.items()))
+            if value.seen_at >= cutoff:
+                return
+            self._store.popitem(last=False)
+
+
+class HubServer:
+    """The hub's asyncio TCP server.
+
+    Lifecycle:
+
+    1. :meth:`start` binds the listening socket on the configured
+       interface and returns the resolved ``(host, port)`` pair.
+    2. The caller then writes the discovery record and arranges for
+       :meth:`serve_forever` to be awaited.
+    3. :meth:`shutdown` triggers a clean tear-down: broadcasts ``bye``,
+       closes connections, stops accepting new ones.
+    """
+
+    def __init__(
+        self,
+        *,
+        host: str = "127.0.0.1",
+        port: int = 0,
+        server_version: str = "0.0.0",
+        dedupe_capacity: int = DEFAULT_DEDUPE_CAPACITY,
+        dedupe_ttl_seconds: float = DEFAULT_DEDUPE_TTL_SECONDS,
+    ) -> None:
+        self.host = host
+        self.requested_port = port
+        self.server_version = server_version
+        self._registry: dict[Origin, ClientConnection] = {}
+        self._pending = _LruIdSet(
+            capacity=dedupe_capacity, ttl_seconds=dedupe_ttl_seconds
+        )
+        self._dedupe = _LruIdSet(
+            capacity=dedupe_capacity, ttl_seconds=dedupe_ttl_seconds
+        )
+        self.state = HubState()
+        self._asyncio_server: asyncio.base_events.Server | None = None
+        self._serve_task: asyncio.Task[None] | None = None
+        self._stopped = asyncio.Event()
+
+    # ------------------------------------------------------------------
+    # lifecycle
+    # ------------------------------------------------------------------
+
+    async def start(self) -> tuple[str, int]:
+        self._asyncio_server = await asyncio.start_server(
+            self._handle_client, self.host, self.requested_port
+        )
+        sockets = self._asyncio_server.sockets or ()
+        if not sockets:
+            raise HubServerError("hub server bound 0 sockets")
+        host, port = sockets[0].getsockname()[:2]
+        self.host = host
+        self.port = port
+        log_event(
+            logger,
+            logging.INFO,
+            "hub.server.listening",
+            host=host,
+            port=port,
+            requested_port=self.requested_port,
+        )
+        return host, port
+
+    async def serve_forever(self) -> None:
+        if self._asyncio_server is None:
+            raise HubServerError("call start() before serve_forever()")
+        try:
+            await self._asyncio_server.serve_forever()
+        except asyncio.CancelledError:
+            pass
+        finally:
+            self._stopped.set()
+
+    async def shutdown(self) -> None:
+        """Broadcast ``bye``, close connections, stop the listener.
+
+        Idempotent; multiple calls (e.g. signal handler + finally
+        block) are safe.
+        """
+
+        if self._asyncio_server is None or not self._asyncio_server.is_serving():
+            self._asyncio_server = None
+            return
+
+        for conn in list(self._registry.values()):
+            try:
+                await conn.send(self._bye_envelope(origin=Origin.CLI))
+            except Exception:
+                pass
+            conn.close()
+
+        self._asyncio_server.close()
+        try:
+            await self._asyncio_server.wait_closed()
+        except Exception:
+            pass
+        self._asyncio_server = None
+        log_event(logger, logging.INFO, "hub.server.shutdown")
+
+    @property
+    def registered_origins(self) -> list[Origin]:
+        return list(self._registry.keys())
+
+    # ------------------------------------------------------------------
+    # per-connection handler
+    # ------------------------------------------------------------------
+
+    async def _handle_client(
+        self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
+        peer = _peer_repr(writer)
+        conn = ClientConnection(reader=reader, writer=writer, peer=peer)
+        log_event(logger, logging.DEBUG, "hub.client.accepted", peer=peer)
+        try:
+            if not await self._run_handshake(conn):
+                return
+            await self._dispatch_loop(conn)
+        except (asyncio.IncompleteReadError, ConnectionResetError):
+            pass
+        except Exception:
+            logger.exception("hub.client.unhandled_error peer=%s", peer)
+        finally:
+            await self._cleanup_connection(conn)
+
+    async def _run_handshake(self, conn: ClientConnection) -> bool:
+        try:
+            line = await conn.reader.readline()
+        except (asyncio.IncompleteReadError, ConnectionResetError):
+            return False
+        if not line:
+            return False
+
+        try:
+            env = decode(line)
+        except HubProtocolError as exc:
+            await self._safe_send(
+                conn,
+                make_error(
+                    origin=Origin.CLI,
+                    code="bad_request",
+                    message=str(exc),
+                    context=({"path": exc.json_pointer} if exc.json_pointer else None),
+                ),
+            )
+            return False
+
+        if env.kind is not Kind.REQUEST or env.type != "hello":
+            await self._safe_send(
+                conn,
+                make_error(
+                    origin=Origin.CLI,
+                    code="protocol_mismatch",
+                    message="first message must be a hello request",
+                    in_reply_to=env.id,
+                ),
+            )
+            return False
+
+        client = Origin(env.payload["client"])
+        if client in self._registry:
+            await self._safe_send(
+                conn,
+                make_error(
+                    origin=Origin.CLI,
+                    code="not_connected",
+                    message=f"{client.value} client already registered",
+                    in_reply_to=env.id,
+                ),
+            )
+            return False
+
+        conn.origin = client
+        conn.capabilities = tuple(env.payload.get("capabilities", []))
+        conn.client_version = str(env.payload.get("version", ""))
+        self._registry[client] = conn
+        self.state.registered_clients = set(self._registry.keys())
+
+        await conn.send(
+            make_welcome(
+                in_reply_to=env.id,
+                server_version=self.server_version,
+                registered_clients=self.registered_origins,
+            )
+        )
+        log_event(
+            logger,
+            logging.INFO,
+            "hub.client.registered",
+            origin=client.value,
+            peer=conn.peer,
+            version=conn.client_version,
+            capabilities=list(conn.capabilities),
+        )
+        return True
+
+    async def _dispatch_loop(self, conn: ClientConnection) -> None:
+        while True:
+            line = await conn.reader.readline()
+            if not line:
+                return
+            try:
+                env = decode(line)
+            except HubProtocolError as exc:
+                await self._safe_send(
+                    conn,
+                    make_error(
+                        origin=Origin.CLI,
+                        code="bad_request",
+                        message=str(exc),
+                        context=(
+                            {"path": exc.json_pointer} if exc.json_pointer else None
+                        ),
+                    ),
+                )
+                continue
+
+            await self._dispatch(env, conn)
+
+    async def _dispatch(self, env: Envelope, conn: ClientConnection) -> None:
+        if env.kind is Kind.EVENT:
+            await self._handle_event(env, conn)
+        elif env.kind is Kind.REQUEST:
+            await self._handle_request(env, conn)
+        elif env.kind in (Kind.RESPONSE, Kind.ERROR):
+            await self._handle_response_or_error(env)
+
+    # ------------------------------------------------------------------
+    # events
+    # ------------------------------------------------------------------
+
+    async def _handle_event(self, env: Envelope, conn: ClientConnection) -> None:
+        if env.type == "bye":
+            await self._cleanup_connection(conn)
+            return
+
+        if env.type in STATE_EVENT_TYPES:
+            self._update_state(env)
+            await self._broadcast(env, suppress_origin=env.origin)
+            return
+
+        # Unknown event types are silently dropped per §11.
+        log_event(logger, logging.DEBUG, "hub.event.dropped_unknown", type=env.type)
+
+    def _update_state(self, env: Envelope) -> None:
+        try:
+            if env.type == "selection_changed":
+                ip = env.payload["instance_path"]
+                paths = (ip,) if isinstance(ip, str) else tuple(ip)
+                self.state.selection = Selection(instance_path=paths, origin=env.origin)
+            elif env.type == "signal_selected":
+                self.state.signal_selection = SignalSelection(
+                    signal=env.payload["signal"],
+                    wave_scope=env.payload["wave_scope"],
+                    origin=env.origin,
+                )
+            elif env.type == "cursor_time_changed":
+                self.state.cursor_time = CursorTime(
+                    t_fs=env.payload["t_fs"], origin=env.origin
+                )
+            elif env.type == "scope_changed":
+                self.state.wave_scope = WaveScope(
+                    wave_scope=env.payload["wave_scope"], origin=env.origin
+                )
+        except (KeyError, TypeError) as exc:
+            log_event(
+                logger,
+                logging.WARNING,
+                "hub.state.update_failed",
+                type=env.type,
+                error=str(exc),
+            )
+
+    async def _broadcast(
+        self, env: Envelope, *, suppress_origin: Origin | None
+    ) -> None:
+        for origin, conn in list(self._registry.items()):
+            if origin == suppress_origin:
+                continue
+            await self._safe_send(conn, env)
+
+    # ------------------------------------------------------------------
+    # requests
+    # ------------------------------------------------------------------
+
+    async def _handle_request(self, env: Envelope, conn: ClientConnection) -> None:
+        if env.type == "hello":
+            await self._safe_send(
+                conn,
+                make_error(
+                    origin=Origin.CLI,
+                    code="protocol_mismatch",
+                    message="hello may only be sent once per connection",
+                    in_reply_to=env.id,
+                ),
+            )
+            return
+
+        if env.id in self._dedupe:
+            log_event(
+                logger,
+                logging.WARNING,
+                "hub.request.duplicate_dropped",
+                id=env.id,
+                type=env.type,
+            )
+            return
+        self._dedupe.put(env.id, requester_origin=env.origin)
+
+        if env.type in HUB_HANDLED_REQUESTS:
+            await self._handle_hub_request(env, conn)
+            return
+
+        target = REQUEST_ROUTING.get(env.type)
+        if target is None:
+            await self._safe_send(
+                conn,
+                make_error(
+                    origin=Origin.CLI,
+                    code="bad_request",
+                    message=f"unknown request type: {env.type}",
+                    in_reply_to=env.id,
+                ),
+            )
+            return
+
+        target_conn = self._registry.get(target)
+        if target_conn is None:
+            await self._safe_send(
+                conn,
+                make_error(
+                    origin=Origin.CLI,
+                    code="not_connected",
+                    message=f"no {target.value} client registered for {env.type}",
+                    in_reply_to=env.id,
+                ),
+            )
+            return
+
+        # Track the pending request so responses route back correctly.
+        self._pending.put(env.id, requester_origin=env.origin)
+        await self._safe_send(target_conn, env)
+
+    async def _handle_hub_request(self, env: Envelope, conn: ClientConnection) -> None:
+        """Resolver stub — PR 3 wires the real coordinate mapper.
+
+        Until then every ``resolve_*`` request returns ``unresolvable``
+        so client code can compile against the request shapes without
+        silently looking like it succeeded.
+        """
+
+        await self._safe_send(
+            conn,
+            make_error(
+                origin=Origin.CLI,
+                code="unresolvable",
+                message=(
+                    f"hub-side resolver for {env.type} not yet implemented "
+                    "(PR 3 of rtl-buddy/rtl_buddy#115)"
+                ),
+                context=env.payload if isinstance(env.payload, dict) else None,
+                in_reply_to=env.id,
+            ),
+        )
+
+    # ------------------------------------------------------------------
+    # responses / errors
+    # ------------------------------------------------------------------
+
+    async def _handle_response_or_error(self, env: Envelope) -> None:
+        pending = self._pending.pop(env.id)
+        if pending is None:
+            log_event(
+                logger,
+                logging.WARNING,
+                "hub.response.no_matching_request",
+                id=env.id,
+                kind=env.kind.value,
+                type=env.type,
+            )
+            return
+
+        requester = self._registry.get(pending.requester_origin)
+        if requester is None:
+            log_event(
+                logger,
+                logging.INFO,
+                "hub.response.requester_gone",
+                id=env.id,
+                origin=pending.requester_origin.value,
+            )
+            return
+
+        await self._safe_send(requester, env)
+
+    # ------------------------------------------------------------------
+    # bookkeeping
+    # ------------------------------------------------------------------
+
+    async def _cleanup_connection(self, conn: ClientConnection) -> None:
+        if conn.origin is None:
+            conn.close()
+            return
+
+        registered = self._registry.pop(conn.origin, None)
+        if registered is not conn:
+            # Already cleaned up by a prior bye / disconnect.
+            conn.close()
+            return
+
+        self.state.registered_clients = set(self._registry.keys())
+        log_event(
+            logger,
+            logging.INFO,
+            "hub.client.disconnected",
+            origin=conn.origin.value,
+            peer=conn.peer,
+        )
+
+        # Broadcast bye to remaining clients carrying the leaving origin.
+        await self._broadcast(
+            self._bye_envelope(origin=conn.origin), suppress_origin=None
+        )
+        conn.close()
+
+    async def _safe_send(self, conn: ClientConnection, env: Envelope) -> None:
+        try:
+            await conn.send(env)
+        except (ConnectionResetError, BrokenPipeError):
+            await self._cleanup_connection(conn)
+        except Exception:
+            logger.exception("hub.send.unhandled_error peer=%s", conn.peer)
+            await self._cleanup_connection(conn)
+
+    def _bye_envelope(self, *, origin: Origin) -> Envelope:
+        return Envelope(
+            origin=origin,
+            kind=Kind.EVENT,
+            type="bye",
+            id=new_id(),
+            payload={},
+        )
+
+
+def _peer_repr(writer: asyncio.StreamWriter) -> str:
+    """Stable string for log lines: ``host:port`` or ``<unknown>``."""
+
+    info: Any = writer.get_extra_info("peername")
+    if info is None:
+        return "<unknown>"
+    if isinstance(info, tuple) and len(info) >= 2:
+        return f"{info[0]}:{info[1]}"
+    return str(info)
+
+
+__all__ = [
+    "STATE_EVENT_TYPES",
+    "REQUEST_ROUTING",
+    "HUB_HANDLED_REQUESTS",
+    "DEFAULT_DEDUPE_CAPACITY",
+    "DEFAULT_DEDUPE_TTL_SECONDS",
+    "HubServer",
+    "HubServerError",
+    "ClientConnection",
+]

--- a/tests/test_hub_cli.py
+++ b/tests/test_hub_cli.py
@@ -136,12 +136,25 @@ def test_stop_clears_stale_record(runner: CliRunner, project_root: Path):
     assert not (cfg_dir / "hub.json").exists()
 
 
-def test_start_stub_exits_clearly(runner: CliRunner, project_root: Path):
-    """PR 1 ships the CLI surface but not the server loop."""
+def test_start_runs_preflight_only_when_blocked(runner: CliRunner, project_root: Path):
+    """A live hub already registered must block start without entering the loop.
 
+    Writing a record for this process's own PID is the cheap way to
+    trip the `HubAlreadyRunningError` path — it short-circuits before
+    `loop.serve` is reached, so the test doesn't need to actually run
+    the asyncio loop in the CliRunner.
+    """
+
+    discovery.write_record(
+        project_root,
+        pid=os.getpid(),
+        tcp="127.0.0.1:65000",
+        server_version="0.0.0+test",
+    )
     result = runner.invoke(hub_app, ["start"])
-    assert result.exit_code == 2, result.output
-    assert "PR 2" in result.output or "not yet implemented" in result.output
+    assert result.exit_code != 0
+    assert result.exception is not None
+    assert "already running" in str(result.exception)
 
 
 def test_log_missing_file(runner: CliRunner, project_root: Path):

--- a/tests/test_hub_loop.py
+++ b/tests/test_hub_loop.py
@@ -1,0 +1,90 @@
+"""Integration test for ``rtl_buddy.hub.loop`` orchestration.
+
+The real ``loop.serve`` installs SIGINT/SIGTERM handlers and calls
+``asyncio.run``; the signal handlers require the asyncio loop to be on
+the main thread, which makes it awkward to test the full thing through
+``CliRunner``. This file exercises the same start → serve → shutdown
+sequence directly with asyncio primitives, so the lifecycle (discovery
+file writes + cleanup, listener teardown) is covered without forking
+the test runner.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from pathlib import Path
+
+import pytest
+
+from rtl_buddy.hub import discovery
+from rtl_buddy.hub.protocol import Envelope, Kind, Origin, decode, encode, new_id
+from rtl_buddy.hub.server import HubServer
+
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_serve_lifecycle_writes_and_clears_discovery(tmp_path: Path):
+    """Mirrors what ``loop.serve`` does without the signal-handler half."""
+
+    server = HubServer(host="127.0.0.1", port=0, server_version="0.0.0+test")
+    host, port = await server.start()
+
+    discovery.write_record(
+        tmp_path,
+        pid=os.getpid(),
+        tcp=f"{host}:{port}",
+        server_version=server.server_version,
+    )
+    assert discovery.read_record(tmp_path) is not None
+
+    serve_task = asyncio.create_task(server.serve_forever())
+
+    # Exercise one round trip.
+    reader, writer = await asyncio.open_connection(host, port)
+    try:
+        hello = Envelope(
+            origin=Origin.VIEW,
+            kind=Kind.REQUEST,
+            type="hello",
+            id=new_id(),
+            payload={"client": "view", "version": "0.1.0", "capabilities": []},
+        )
+        writer.write(encode(hello).encode("utf-8") + b"\n")
+        await writer.drain()
+        welcome = decode(await asyncio.wait_for(reader.readline(), timeout=1.0))
+        assert welcome.type == "welcome"
+    finally:
+        writer.close()
+        try:
+            await writer.wait_closed()
+        except Exception:
+            pass
+
+    await server.shutdown()
+    serve_task.cancel()
+    try:
+        await serve_task
+    except (asyncio.CancelledError, Exception):
+        pass
+
+    discovery.delete_record_if_owner(tmp_path, expected_pid=os.getpid())
+    assert discovery.read_record(tmp_path) is None
+
+
+async def test_server_refuses_to_double_bind(tmp_path: Path):
+    """Two servers on the same port → second .start() raises OSError.
+
+    Confirms that the listener does what the discovery layer's
+    "one hub per project" rule expects at the OS level.
+    """
+
+    a = HubServer(host="127.0.0.1", port=0, server_version="0.0.0+test")
+    host, port = await a.start()
+    try:
+        b = HubServer(host=host, port=port, server_version="0.0.0+test")
+        with pytest.raises(OSError):
+            await b.start()
+    finally:
+        await a.shutdown()

--- a/tests/test_hub_server.py
+++ b/tests/test_hub_server.py
@@ -1,0 +1,560 @@
+"""End-to-end tests for ``rtl_buddy.hub.server.HubServer``.
+
+Spins the asyncio server on an ephemeral port, connects mock clients
+over real TCP, and exercises:
+
+* hello / welcome handshake (success + protocol-mismatch + duplicate
+  origin paths),
+* origin-suppressed broadcast (the loop-prevention guarantee),
+* request routing to the correct origin (with the ``not_connected``
+  fallback when no client is registered),
+* hub-handled ``resolve_*`` requests returning the PR-2 stub error,
+* response routing back to the original requester by ``id``,
+* request-ID dedupe (duplicates dropped silently),
+* clean disconnect (``bye`` broadcast on connection close).
+
+Every test acquires the server, runs a quick exchange, and shuts down
+in the same task so leaks are visible as hangs in the suite rather
+than as ghost sockets.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import uuid
+from typing import Any, AsyncIterator
+
+import pytest
+import pytest_asyncio
+
+from rtl_buddy.hub.protocol import Envelope, Kind, Origin, decode, encode, new_id
+from rtl_buddy.hub.server import HubServer
+
+
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# fixtures
+# ---------------------------------------------------------------------------
+
+
+class MockClient:
+    """Thin TCP client used by the tests.
+
+    Owns the asyncio reader/writer pair, exposes ``send`` / ``recv``
+    helpers, and tracks the last seen welcome so tests can assert on
+    the registered-clients list. Does not implement the dispatch loop
+    — each test reads explicitly to keep ordering obvious.
+    """
+
+    def __init__(
+        self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
+        self.reader = reader
+        self.writer = writer
+
+    @classmethod
+    async def connect(cls, host: str, port: int) -> "MockClient":
+        reader, writer = await asyncio.open_connection(host, port)
+        return cls(reader, writer)
+
+    async def send(self, env: Envelope) -> None:
+        self.writer.write(encode(env).encode("utf-8") + b"\n")
+        await self.writer.drain()
+
+    async def send_raw(self, raw: bytes) -> None:
+        self.writer.write(raw)
+        await self.writer.drain()
+
+    async def recv(self, *, timeout: float = 1.0) -> Envelope:
+        line = await asyncio.wait_for(self.reader.readline(), timeout=timeout)
+        if not line:
+            raise EOFError("connection closed without a message")
+        return decode(line)
+
+    async def expect_no_message(self, *, within: float = 0.1) -> None:
+        try:
+            line = await asyncio.wait_for(self.reader.readline(), timeout=within)
+        except asyncio.TimeoutError:
+            return
+        if line:
+            pytest.fail(f"expected no message but got: {line!r}")
+
+    async def hello(
+        self, origin: Origin, *, version: str = "0.1.0", caps: list[str] | None = None
+    ) -> Envelope:
+        hello = Envelope(
+            origin=origin,
+            kind=Kind.REQUEST,
+            type="hello",
+            id=new_id(),
+            payload={
+                "client": origin.value,
+                "version": version,
+                "capabilities": caps or [],
+            },
+        )
+        await self.send(hello)
+        return await self.recv()
+
+    async def close(self) -> None:
+        try:
+            self.writer.close()
+            await self.writer.wait_closed()
+        except Exception:
+            pass
+
+
+@pytest_asyncio.fixture
+async def server() -> AsyncIterator[HubServer]:
+    s = HubServer(host="127.0.0.1", port=0, server_version="0.0.0+test")
+    await s.start()
+    serve_task = asyncio.create_task(s.serve_forever())
+    try:
+        yield s
+    finally:
+        await s.shutdown()
+        serve_task.cancel()
+        try:
+            await serve_task
+        except (asyncio.CancelledError, Exception):
+            pass
+
+
+# ---------------------------------------------------------------------------
+# handshake
+# ---------------------------------------------------------------------------
+
+
+async def test_hello_welcome_round_trip(server: HubServer):
+    client = await MockClient.connect(server.host, server.port)
+    try:
+        welcome = await client.hello(Origin.VIEW)
+        assert welcome.type == "welcome"
+        assert welcome.kind is Kind.RESPONSE
+        assert welcome.payload["registered_clients"] == ["view"]
+        assert Origin.VIEW in server.registered_origins
+    finally:
+        await client.close()
+
+
+async def test_first_message_must_be_hello(server: HubServer):
+    client = await MockClient.connect(server.host, server.port)
+    try:
+        bogus = Envelope(
+            origin=Origin.VIEW,
+            kind=Kind.EVENT,
+            type="selection_changed",
+            id=new_id(),
+            payload={"instance_path": "top"},
+        )
+        await client.send(bogus)
+        err = await client.recv()
+        assert err.type == "error"
+        assert err.payload["code"] == "protocol_mismatch"
+    finally:
+        await client.close()
+
+
+async def test_duplicate_origin_refused(server: HubServer):
+    a = await MockClient.connect(server.host, server.port)
+    b = await MockClient.connect(server.host, server.port)
+    try:
+        await a.hello(Origin.VIEW)
+        err = await b.hello(Origin.VIEW)
+        assert err.type == "error"
+        assert err.payload["code"] == "not_connected"
+        assert "view" in err.payload["message"]
+    finally:
+        await a.close()
+        await b.close()
+
+
+async def test_bad_request_on_malformed_handshake(server: HubServer):
+    client = await MockClient.connect(server.host, server.port)
+    try:
+        await client.send_raw(b"{not json\n")
+        err = await client.recv()
+        assert err.type == "error"
+        assert err.payload["code"] == "bad_request"
+    finally:
+        await client.close()
+
+
+# ---------------------------------------------------------------------------
+# broadcast / origin suppression
+# ---------------------------------------------------------------------------
+
+
+async def test_state_event_broadcast_skips_origin(server: HubServer):
+    view = await MockClient.connect(server.host, server.port)
+    wave = await MockClient.connect(server.host, server.port)
+    src = await MockClient.connect(server.host, server.port)
+    try:
+        await view.hello(Origin.VIEW)
+        await wave.hello(Origin.WAVE)
+        await src.hello(Origin.SRC)
+
+        evt = Envelope(
+            origin=Origin.VIEW,
+            kind=Kind.EVENT,
+            type="selection_changed",
+            id=new_id(),
+            payload={"instance_path": "top.u_fifo"},
+        )
+        await view.send(evt)
+
+        # wave + src must receive it; view must not echo back.
+        got_wave = await wave.recv()
+        got_src = await src.recv()
+        assert got_wave.id == evt.id
+        assert got_src.id == evt.id
+        assert got_wave.payload == {"instance_path": "top.u_fifo"}
+
+        await view.expect_no_message()
+    finally:
+        await view.close()
+        await wave.close()
+        await src.close()
+
+
+async def test_state_is_recorded_after_event(server: HubServer):
+    view = await MockClient.connect(server.host, server.port)
+    try:
+        await view.hello(Origin.VIEW)
+        evt = Envelope(
+            origin=Origin.VIEW,
+            kind=Kind.EVENT,
+            type="selection_changed",
+            id=new_id(),
+            payload={"instance_path": "top.u_fifo"},
+        )
+        await view.send(evt)
+        await asyncio.sleep(0.05)
+        assert server.state.selection is not None
+        assert server.state.selection.instance_path == ("top.u_fifo",)
+        assert server.state.selection.origin is Origin.VIEW
+    finally:
+        await view.close()
+
+
+async def test_unknown_event_type_silently_dropped(server: HubServer):
+    a = await MockClient.connect(server.host, server.port)
+    b = await MockClient.connect(server.host, server.port)
+    try:
+        await a.hello(Origin.VIEW)
+        await b.hello(Origin.WAVE)
+        evt = Envelope(
+            origin=Origin.VIEW,
+            kind=Kind.EVENT,
+            type="future_v2_event",
+            id=new_id(),
+            payload={"x": 1},
+        )
+        await a.send(evt)
+        await b.expect_no_message()
+    finally:
+        await a.close()
+        await b.close()
+
+
+# ---------------------------------------------------------------------------
+# requests
+# ---------------------------------------------------------------------------
+
+
+async def test_request_routed_to_wave_origin(server: HubServer):
+    view = await MockClient.connect(server.host, server.port)
+    wave = await MockClient.connect(server.host, server.port)
+    try:
+        await view.hello(Origin.VIEW)
+        await wave.hello(Origin.WAVE)
+
+        req = Envelope(
+            origin=Origin.VIEW,
+            kind=Kind.REQUEST,
+            type="wave_add_variables",
+            id=new_id(),
+            payload={"variables": ["tb.dut.x"]},
+        )
+        await view.send(req)
+
+        forwarded = await wave.recv()
+        assert forwarded.id == req.id
+        assert forwarded.type == "wave_add_variables"
+        assert forwarded.payload == {"variables": ["tb.dut.x"]}
+    finally:
+        await view.close()
+        await wave.close()
+
+
+async def test_request_to_missing_origin_returns_not_connected(server: HubServer):
+    view = await MockClient.connect(server.host, server.port)
+    try:
+        await view.hello(Origin.VIEW)
+        req = Envelope(
+            origin=Origin.VIEW,
+            kind=Kind.REQUEST,
+            type="wave_set_cursor",
+            id=new_id(),
+            payload={"t_fs": "0"},
+        )
+        await view.send(req)
+        err = await view.recv()
+        assert err.type == "error"
+        assert err.payload["code"] == "not_connected"
+    finally:
+        await view.close()
+
+
+async def test_resolve_request_returns_stub_unresolvable(server: HubServer):
+    view = await MockClient.connect(server.host, server.port)
+    try:
+        await view.hello(Origin.VIEW)
+        req = Envelope(
+            origin=Origin.VIEW,
+            kind=Kind.REQUEST,
+            type="resolve_view_to_wave",
+            id=new_id(),
+            payload={"instance_path": "top.u_fifo"},
+        )
+        await view.send(req)
+        err = await view.recv()
+        assert err.type == "error"
+        assert err.payload["code"] == "unresolvable"
+        assert "PR 3" in err.payload["message"]
+    finally:
+        await view.close()
+
+
+async def test_response_routed_back_to_requester(server: HubServer):
+    view = await MockClient.connect(server.host, server.port)
+    wave = await MockClient.connect(server.host, server.port)
+    try:
+        await view.hello(Origin.VIEW)
+        await wave.hello(Origin.WAVE)
+
+        req = Envelope(
+            origin=Origin.VIEW,
+            kind=Kind.REQUEST,
+            type="wave_add_variables",
+            id=new_id(),
+            payload={"variables": ["tb.dut.x"]},
+        )
+        await view.send(req)
+        forwarded = await wave.recv()
+        assert forwarded.id == req.id
+
+        resp = Envelope(
+            origin=Origin.WAVE,
+            kind=Kind.RESPONSE,
+            type="wave_add_variables",
+            id=req.id,
+            payload={"ids": [17]},
+        )
+        await wave.send(resp)
+
+        got = await view.recv()
+        assert got.id == req.id
+        assert got.kind is Kind.RESPONSE
+        assert got.payload == {"ids": [17]}
+    finally:
+        await view.close()
+        await wave.close()
+
+
+async def test_duplicate_request_dropped(server: HubServer):
+    view = await MockClient.connect(server.host, server.port)
+    wave = await MockClient.connect(server.host, server.port)
+    try:
+        await view.hello(Origin.VIEW)
+        await wave.hello(Origin.WAVE)
+
+        rid = new_id()
+        req = Envelope(
+            origin=Origin.VIEW,
+            kind=Kind.REQUEST,
+            type="wave_add_variables",
+            id=rid,
+            payload={"variables": ["tb.dut.x"]},
+        )
+        await view.send(req)
+        first = await wave.recv()
+        assert first.id == rid
+
+        # Same id again: should be dropped silently.
+        await view.send(req)
+        await wave.expect_no_message()
+    finally:
+        await view.close()
+        await wave.close()
+
+
+# ---------------------------------------------------------------------------
+# disconnect
+# ---------------------------------------------------------------------------
+
+
+async def test_disconnect_broadcasts_bye(server: HubServer):
+    view = await MockClient.connect(server.host, server.port)
+    wave = await MockClient.connect(server.host, server.port)
+    try:
+        await view.hello(Origin.VIEW)
+        await wave.hello(Origin.WAVE)
+
+        await view.close()
+
+        bye = await wave.recv()
+        assert bye.type == "bye"
+        assert bye.origin is Origin.VIEW
+    finally:
+        await wave.close()
+
+
+async def test_explicit_bye_unregisters(server: HubServer):
+    view = await MockClient.connect(server.host, server.port)
+    wave = await MockClient.connect(server.host, server.port)
+    try:
+        await view.hello(Origin.VIEW)
+        await wave.hello(Origin.WAVE)
+
+        bye = Envelope(
+            origin=Origin.VIEW,
+            kind=Kind.EVENT,
+            type="bye",
+            id=new_id(),
+            payload={},
+        )
+        await view.send(bye)
+
+        got = await wave.recv()
+        assert got.type == "bye"
+        assert got.origin is Origin.VIEW
+
+        # And the registry should reflect the unregister.
+        await asyncio.sleep(0.05)
+        assert Origin.VIEW not in server.registered_origins
+    finally:
+        await view.close()
+        await wave.close()
+
+
+# ---------------------------------------------------------------------------
+# misc smoke
+# ---------------------------------------------------------------------------
+
+
+async def test_unknown_request_type_returns_bad_request(server: HubServer):
+    view = await MockClient.connect(server.host, server.port)
+    try:
+        await view.hello(Origin.VIEW)
+        req = Envelope(
+            origin=Origin.VIEW,
+            kind=Kind.REQUEST,
+            type="future_v2_request",
+            id=new_id(),
+            payload={},
+        )
+        await view.send(req)
+        err = await view.recv()
+        assert err.type == "error"
+        assert err.payload["code"] == "bad_request"
+    finally:
+        await view.close()
+
+
+async def test_second_hello_on_same_connection_rejected(server: HubServer):
+    view = await MockClient.connect(server.host, server.port)
+    try:
+        await view.hello(Origin.VIEW)
+        # Sending another hello on the same socket is a misuse — should
+        # come back as protocol_mismatch since hello may only be sent once.
+        again = Envelope(
+            origin=Origin.VIEW,
+            kind=Kind.REQUEST,
+            type="hello",
+            id=new_id(),
+            payload={"client": "view", "version": "0.1.0", "capabilities": []},
+        )
+        await view.send(again)
+        err = await view.recv()
+        assert err.type == "error"
+        assert err.payload["code"] == "protocol_mismatch"
+    finally:
+        await view.close()
+
+
+# ---------------------------------------------------------------------------
+# raw wire shape sanity
+# ---------------------------------------------------------------------------
+
+
+async def test_messages_are_line_delimited(server: HubServer):
+    """Two envelopes back-to-back should still parse separately."""
+
+    view = await MockClient.connect(server.host, server.port)
+    wave = await MockClient.connect(server.host, server.port)
+    try:
+        await view.hello(Origin.VIEW)
+        await wave.hello(Origin.WAVE)
+
+        e1 = Envelope(
+            origin=Origin.VIEW,
+            kind=Kind.EVENT,
+            type="selection_changed",
+            id=new_id(),
+            payload={"instance_path": "top.a"},
+        )
+        e2 = Envelope(
+            origin=Origin.VIEW,
+            kind=Kind.EVENT,
+            type="selection_changed",
+            id=new_id(),
+            payload={"instance_path": "top.b"},
+        )
+        # Send both in one write — server must still demultiplex.
+        await view.send_raw(
+            encode(e1).encode("utf-8") + b"\n" + encode(e2).encode("utf-8") + b"\n"
+        )
+
+        got1 = await wave.recv()
+        got2 = await wave.recv()
+        assert {got1.payload["instance_path"], got2.payload["instance_path"]} == {
+            "top.a",
+            "top.b",
+        }
+    finally:
+        await view.close()
+        await wave.close()
+
+
+def _is_uuid(value: Any) -> bool:
+    try:
+        uuid.UUID(str(value))
+    except (TypeError, ValueError, AttributeError):
+        return False
+    return True
+
+
+async def test_welcome_id_matches_hello(server: HubServer):
+    """welcome.id must echo hello.id so the client can correlate."""
+
+    client = await MockClient.connect(server.host, server.port)
+    try:
+        hello = Envelope(
+            origin=Origin.VIEW,
+            kind=Kind.REQUEST,
+            type="hello",
+            id=new_id(),
+            payload={"client": "view", "version": "0.1.0", "capabilities": []},
+        )
+        await client.send(hello)
+        welcome = await client.recv()
+        assert welcome.id == hello.id
+        assert _is_uuid(welcome.id)
+        as_json = json.loads(encode(welcome))
+        assert as_json["payload"]["server_version"] == "0.0.0+test"
+    finally:
+        await client.close()

--- a/uv.lock
+++ b/uv.lock
@@ -699,6 +699,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
 name = "pytest-cov"
 version = "7.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -988,6 +1001,7 @@ dev = [
     { name = "mkdocs" },
     { name = "mkdocs-material" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "ruff" },
 ]
@@ -1001,6 +1015,7 @@ lint = [
 ]
 test = [
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "pytest-cov" },
 ]
 
@@ -1021,6 +1036,7 @@ dev = [
     { name = "mkdocs", specifier = ">=1.6.0" },
     { name = "mkdocs-material", specifier = ">=9.5.0" },
     { name = "pytest", specifier = ">=9.0.3" },
+    { name = "pytest-asyncio", specifier = ">=0.24.0" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
     { name = "ruff", specifier = ">=0.11.0" },
 ]
@@ -1032,6 +1048,7 @@ docs = [
 lint = [{ name = "ruff", specifier = ">=0.11.0" }]
 test = [
     { name = "pytest", specifier = ">=9.0.3" },
+    { name = "pytest-asyncio", specifier = ">=0.24.0" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
 ]
 


### PR DESCRIPTION
## Summary

PR 2 of rtl-buddy/rtl_buddy#115. Snaps the server loop into the scaffolding from #117 and turns `rb hub start` into an actually running daemon.

### New: `src/rtl_buddy/hub/server.py`

`asyncio.start_server`-based TCP server. Line-delimited JSON transport per §2 of the spec.

- **Handshake**: `hello` request → register under origin → `welcome` response.
  - Duplicate origin → `error{code: \"not_connected\"}`
  - Non-`hello` first message → `error{code: \"protocol_mismatch\"}`
  - Schema-malformed first message → `error{code: \"bad_request\"}`
- **Origin-suppressed broadcast** for state events (§6 rule 1): `selection_changed`, `signal_selected`, `cursor_time_changed`, `scope_changed`, `source_focused`.
- **Request routing**:
  - `wave_add_variables` / `wave_set_scope` / `wave_set_cursor` → wave-origin client
  - `open_source` → src-origin client
  - `view_pan_to` → view-origin client
  - Missing target client → `error{code: \"not_connected\"}`
- **Response routing** by `id` back to the original requester; orphaned responses logged + dropped.
- **Bounded LRU dedupe** of request IDs (§6 rule 2, capacity 1024, TTL 60s) — duplicate requests dropped silently.
- **Hub-side `resolve_*`** requests return a clear \"PR 3 stub\" `unresolvable` error so client code can compile against the request shapes today.
- **Clean disconnect**: `bye` broadcast to remaining clients carrying the leaving origin.
- **State cache** updates on every broadcast event so a reconnecting client can ask \"what is the current selection?\"

### New: `src/rtl_buddy/hub/loop.py`

Orchestration only: bind, write `hub.json`, install SIGINT/SIGTERM handlers, run forever, clean shutdown removes the discovery file iff the hub still owns it.

### Modified: `src/rtl_buddy/hub/cli.py`

`rb hub start` now wires into `loop.serve()`. The PR 1 \"server not yet implemented\" notice is gone.

### Dependencies

Adds `pytest-asyncio >= 0.24.0` as a test-group dep; enables `asyncio_mode = strict` in `pytest.ini`.

### Live smoke

```
\$ cd /tmp/proj && mkdir .git && rb hub start &
[hub.server.listening] host=127.0.0.1 port=49714
\$ cat .rtl-buddy/hub.json
{
  \"v\": 1, \"pid\": 50732, \"tcp\": \"127.0.0.1:49714\",
  \"server_version\": \"4.1.1.dev6+...\", ...
}
\$ rb hub status
hub RUNNING
  pid: 50732
  tcp: 127.0.0.1:49714
\$ rb hub stop
sent SIGTERM to hub pid 50732.
# .rtl-buddy/hub.json removed automatically
```

A small Python client that sends `hello` and reads `welcome` round-trips cleanly through the live socket.

## What's next

- **PR 3** — view ↔ wave ↔ src resolver replacing the `resolve_*` stub; consumes `view.json` v1 from rtl-buddy/rtl-buddy-view#17.
- **PR 4** — `rb wave` integration (the WAVE-origin client; bridges WCP).
- **PR 5** — viewer HTTP/WS layer + `rb hub --serve-viewer`.

## Test plan
- [x] \`uv run pytest -q --no-cov\` — 475 passed (22 new)
- [x] \`uv run ruff check src tests\` — clean
- [x] \`uv run ruff format --check src tests\` — clean
- [x] Live: \`rb hub start\` writes \`hub.json\`, accepts a TCP client, completes hello/welcome
- [x] Live: \`rb hub stop\` sends SIGTERM; the running daemon shuts down cleanly and removes \`hub.json\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)