### PR TITLE
Phase 10b: hub view↔wave↔src resolver (#115)

### DIFF
--- a/src/rtl_buddy/hub/config.py
+++ b/src/rtl_buddy/hub/config.py
@@ -58,6 +58,9 @@ class HubMappingConfig:
 
     tb_prefix: str = DEFAULT_TB_PREFIX
     signal_aliases: tuple[SignalAlias, ...] = field(default_factory=tuple)
+    view_json: str | None = None
+    """Path (relative to the project root) of the ``view.json`` snapshot the
+    resolver consumes. ``None`` falls back to ``.rtl-buddy/view.json``."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -146,6 +149,12 @@ def _parse_mapping_block(raw: dict[str, Any], path: Path) -> HubMappingConfig:
             f"{path}: [mapping].tb_prefix must be a string, got {tb_prefix!r}"
         )
 
+    view_json = raw.get("view_json", defaults.view_json)
+    if view_json is not None and (not isinstance(view_json, str) or not view_json):
+        raise HubConfigError(
+            f"{path}: [mapping].view_json must be a non-empty string, got {view_json!r}"
+        )
+
     aliases_raw = raw.get("signal_aliases", [])
     if not isinstance(aliases_raw, list):
         raise HubConfigError(
@@ -170,7 +179,11 @@ def _parse_mapping_block(raw: dict[str, Any], path: Path) -> HubMappingConfig:
             )
         aliases.append(SignalAlias(wave=wave, view=view))
 
-    return HubMappingConfig(tb_prefix=tb_prefix, signal_aliases=tuple(aliases))
+    return HubMappingConfig(
+        tb_prefix=tb_prefix,
+        signal_aliases=tuple(aliases),
+        view_json=view_json,
+    )
 
 
 def default_config_path(project_root: Path) -> Path:

--- a/src/rtl_buddy/hub/loop.py
+++ b/src/rtl_buddy/hub/loop.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from ..logging_utils import log_event
 from .config import HubConfig
 from .discovery import delete_record_if_owner, write_record
+from .resolver import Resolver, default_view_json_path
 from .server import HubServer
 
 
@@ -36,10 +37,17 @@ def _server_version() -> str:
 
 
 async def _run(project_root: Path, config: HubConfig) -> int:
+    if config.mapping.view_json:
+        view_json_path = (project_root / config.mapping.view_json).resolve()
+    else:
+        view_json_path = default_view_json_path(project_root)
+    resolver = Resolver(view_json_path=view_json_path, mapping=config.mapping)
+
     server = HubServer(
         host="127.0.0.1",
         port=config.hub.listen_port,
         server_version=_server_version(),
+        resolver=resolver,
     )
     host, port = await server.start()
 

--- a/src/rtl_buddy/hub/resolver.py
+++ b/src/rtl_buddy/hub/resolver.py
@@ -1,0 +1,447 @@
+"""Coordinate translator for the rtl-buddy-hub.
+
+Implements §1 of the protocol spec: the hub's only real intelligence is
+mapping between three coordinate systems plus a derived fourth.
+
+* **view**   ``top.u_fifo.u_wr_ptr``      — node in ``view.json``
+* **wave**   ``tb.dut.u_fifo.u_wr_ptr``  — surfer / WCP path
+* **src**    ``(file, line, col)``       — source anchor
+* **signal** ``wr_ptr_q``                — flat signal name in surfer
+
+The four mappings used at the wire layer:
+
+* ``view ↔ wave``   — testbench-prefix strip + per-instance aliases.
+* ``view → src``    — `nodes[].location` lookup.
+* ``signal → view`` — walk the ``port_connections`` of the node at the
+  given ``wave_scope`` and return every child whose port net matches
+  the signal name.
+
+Source of view-side truth is ``view.json`` as emitted by
+``rtl-buddy-view --format json`` (rtl-buddy/rtl-buddy-view). The
+contract is pinned by ``schema_version`` + ``JSON_CONTRACT`` upstream;
+this loader is strict about the fields it consumes and tolerant about
+the rest.
+
+Lookup pieces in this module are pure functions / dataclasses; the
+hub's server layer wraps them into request handlers so the resolver
+itself never touches the network.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable
+
+from ..logging_utils import log_event
+from .config import HubMappingConfig, SignalAlias
+
+
+logger = logging.getLogger(__name__)
+
+
+SUPPORTED_VIEW_SCHEMA_MAJOR = 1
+
+
+class ResolverError(Exception):
+    """Raised for unrecoverable load-time errors.
+
+    Per-request resolution failures use sentinel return values (``None``
+    / empty lists) — the server layer translates those into
+    ``error{code: "unresolvable"}`` envelopes.
+    """
+
+
+@dataclass(frozen=True, slots=True)
+class SourceAnchor:
+    """A ``view.json`` ``location`` value — translated to wire shape.
+
+    The wire protocol's ``open_source`` / ``source_focused`` payloads
+    are ``{file, line, col}``; ``view.json`` uses ``start_line`` /
+    ``start_column`` (with end positions too). This dataclass holds
+    the canonical wire shape so the server doesn't have to translate
+    on every request.
+    """
+
+    file: str
+    line: int
+    col: int
+
+    def as_payload(self) -> dict[str, object]:
+        return {"file": self.file, "line": self.line, "col": self.col}
+
+
+@dataclass(frozen=True, slots=True)
+class SignalDriver:
+    """One driver of a signal as found by :meth:`Resolver.signal_drivers`."""
+
+    instance_path: str
+    port: str
+
+
+@dataclass
+class Node:
+    """A single ``nodes[]`` entry — only the fields the resolver uses."""
+
+    instance_path: str
+    location: SourceAnchor | None = None
+    port_connections: tuple[tuple[str, str], ...] = field(default_factory=tuple)
+    """``(port_name, net_expr_text)`` pairs in the order view.json emits them."""
+
+
+@dataclass
+class ViewModel:
+    """In-memory image of ``view.json`` — keyed for O(1) lookups."""
+
+    top: str
+    nodes_by_path: dict[str, Node]
+    edges_parent_to_children: dict[str, tuple[str, ...]]
+    source_path: Path | None = None
+    source_mtime_ns: int | None = None
+
+    @classmethod
+    def from_dict(cls, raw: dict, *, source_path: Path | None = None) -> "ViewModel":
+        schema = raw.get("schema_version", "")
+        try:
+            major = int(str(schema).split(".", 1)[0])
+        except ValueError as exc:
+            raise ResolverError(
+                f"view.json schema_version unparseable: {schema!r}"
+            ) from exc
+        if major != SUPPORTED_VIEW_SCHEMA_MAJOR:
+            raise ResolverError(
+                f"view.json schema major {major} not supported "
+                f"(expected {SUPPORTED_VIEW_SCHEMA_MAJOR})"
+            )
+
+        top = raw.get("design", {}).get("top")
+        if not isinstance(top, str) or not top:
+            raise ResolverError("view.json missing design.top")
+
+        nodes_by_path: dict[str, Node] = {}
+        for entry in raw.get("nodes", []):
+            ip = entry.get("instance_path")
+            if not isinstance(ip, str) or not ip:
+                continue
+            loc = _location_to_anchor(entry.get("location"))
+            ports: list[tuple[str, str]] = []
+            for pc in entry.get("port_connections", []):
+                if not isinstance(pc, dict):
+                    continue
+                pn = pc.get("port_name")
+                ne = pc.get("net_expr_text")
+                if isinstance(pn, str) and isinstance(ne, str):
+                    ports.append((pn, ne))
+            nodes_by_path[ip] = Node(
+                instance_path=ip, location=loc, port_connections=tuple(ports)
+            )
+
+        edges: dict[str, list[str]] = {}
+        for e in raw.get("edges", []):
+            parent = e.get("parent")
+            child = e.get("child")
+            if not (isinstance(parent, str) and isinstance(child, str)):
+                continue
+            edges.setdefault(parent, []).append(child)
+        edges_frozen = {k: tuple(v) for k, v in edges.items()}
+
+        return cls(
+            top=top,
+            nodes_by_path=nodes_by_path,
+            edges_parent_to_children=edges_frozen,
+            source_path=source_path,
+        )
+
+
+def _location_to_anchor(raw: object) -> SourceAnchor | None:
+    if not isinstance(raw, dict):
+        return None
+    file = raw.get("file")
+    line = raw.get("start_line", raw.get("line"))
+    col = raw.get("start_column", raw.get("col"))
+    if (
+        not isinstance(file, str)
+        or not isinstance(line, int)
+        or not isinstance(col, int)
+    ):
+        return None
+    return SourceAnchor(file=file, line=line, col=col)
+
+
+class Resolver:
+    """Coordinate translator backed by a ``view.json`` snapshot.
+
+    Thread-safe for read paths via a lock around lazy reloads. The
+    resolver lazily reloads view.json when the file's ``mtime`` changes
+    so a re-run of ``rb hier --format json`` mid-session is picked up
+    without restarting the hub.
+
+    Mapping config — ``tb_prefix``, ``signal_aliases`` — is held by
+    reference; rotate it in place from the server layer when config is
+    reloaded.
+    """
+
+    def __init__(
+        self,
+        *,
+        view_json_path: Path | None,
+        mapping: HubMappingConfig,
+    ) -> None:
+        self._view_json_path = view_json_path
+        self._mapping = mapping
+        self._model: ViewModel | None = None
+        self._lock = threading.Lock()
+        self._wave_alias_to_view: dict[str, str] = {}
+        self._view_alias_to_wave: dict[str, str] = {}
+        self._rebuild_alias_index()
+
+    # ------------------------------------------------------------------
+    # configuration
+    # ------------------------------------------------------------------
+
+    @property
+    def view_json_path(self) -> Path | None:
+        return self._view_json_path
+
+    @property
+    def mapping(self) -> HubMappingConfig:
+        return self._mapping
+
+    def update_mapping(self, mapping: HubMappingConfig) -> None:
+        with self._lock:
+            self._mapping = mapping
+            self._rebuild_alias_index()
+
+    def update_view_json_path(self, path: Path | None) -> None:
+        with self._lock:
+            self._view_json_path = path
+            self._model = None
+
+    def _rebuild_alias_index(self) -> None:
+        self._wave_alias_to_view = {
+            a.wave: a.view for a in self._mapping.signal_aliases
+        }
+        self._view_alias_to_wave = {
+            a.view: a.wave for a in self._mapping.signal_aliases
+        }
+
+    # ------------------------------------------------------------------
+    # view ↔ wave (pure transforms; no view.json required)
+    # ------------------------------------------------------------------
+
+    def view_to_wave(self, instance_path: str) -> str | None:
+        """Return the wave path for an instance path, or ``None``.
+
+        Returns ``None`` when ``instance_path`` does not exist in the
+        loaded ``view.json`` — the spec requires that the hub does not
+        guess. If view.json is absent, returns the prefix-transformed
+        path optimistically; this is the "no resolver loaded" fallback
+        the server's error handler exposes as unresolvable when the
+        guess matters.
+        """
+
+        if instance_path in self._view_alias_to_wave:
+            return self._view_alias_to_wave[instance_path]
+
+        # Drop the design.top root if present, then prepend tb_prefix.
+        model = self._load_if_possible()
+        if model is not None:
+            if instance_path not in model.nodes_by_path:
+                return None
+            stripped = _strip_top(instance_path, model.top)
+        else:
+            # Best-effort: no top to anchor against.
+            stripped = instance_path
+
+        prefix = self._mapping.tb_prefix
+        if not prefix:
+            return stripped
+        return prefix + stripped
+
+    def wave_to_view(self, wave_scope: str) -> str | None:
+        """Return the view instance path for a wave path, or ``None``."""
+
+        if wave_scope in self._wave_alias_to_view:
+            return self._wave_alias_to_view[wave_scope]
+
+        prefix = self._mapping.tb_prefix
+        if prefix and wave_scope.startswith(prefix):
+            tail = wave_scope[len(prefix) :]
+        elif not prefix:
+            tail = wave_scope
+        else:
+            return None
+
+        model = self._load_if_possible()
+        if model is None:
+            return tail  # Best-effort.
+
+        candidate = tail
+        if not candidate.startswith(model.top + "."):
+            candidate = f"{model.top}.{candidate}" if candidate else model.top
+
+        if candidate in model.nodes_by_path:
+            return candidate
+        return None
+
+    # ------------------------------------------------------------------
+    # view → src
+    # ------------------------------------------------------------------
+
+    def view_to_src(self, instance_path: str) -> SourceAnchor | None:
+        model = self._load_if_possible()
+        if model is None:
+            return None
+        node = model.nodes_by_path.get(instance_path)
+        if node is None:
+            return None
+        return node.location
+
+    # ------------------------------------------------------------------
+    # signal → drivers (the spec's resolve_signal_to_view)
+    # ------------------------------------------------------------------
+
+    def signal_drivers(
+        self, *, signal: str, wave_scope: str
+    ) -> tuple[SignalDriver, ...]:
+        """Return the list of view instances that drive ``signal`` at ``wave_scope``.
+
+        The spec (§7) requires this be a list — a bus driven by N flops
+        in a generate, or a packed-array assignment, collapses to N
+        instance paths. Empty tuple → "unresolvable".
+
+        Implementation: walk the children of the node at ``wave_scope``
+        and return every child whose ``port_connections`` carry a
+        ``net_expr_text`` equal to ``signal``. Today's view.json is
+        textual (``net_expr_text`` is a raw AST snippet), so this is an
+        exact string match; richer port_pair data lands with Phase 4
+        view.json v1.
+        """
+
+        model = self._load_if_possible()
+        if model is None:
+            return ()
+        parent_view = self.wave_to_view(wave_scope)
+        if parent_view is None:
+            return ()
+        parent = model.nodes_by_path.get(parent_view)
+        if parent is None:
+            return ()
+
+        children = model.edges_parent_to_children.get(parent_view, ())
+        drivers: list[SignalDriver] = []
+        for child_path in children:
+            child = model.nodes_by_path.get(child_path)
+            if child is None:
+                continue
+            for port_name, net_expr in child.port_connections:
+                if net_expr == signal:
+                    drivers.append(
+                        SignalDriver(instance_path=child_path, port=port_name)
+                    )
+                    break
+        return tuple(drivers)
+
+    # ------------------------------------------------------------------
+    # internal: lazy view.json load
+    # ------------------------------------------------------------------
+
+    def _load_if_possible(self) -> ViewModel | None:
+        with self._lock:
+            path = self._view_json_path
+            if path is None or not path.is_file():
+                self._model = None
+                return None
+            try:
+                mtime_ns = path.stat().st_mtime_ns
+            except OSError:
+                self._model = None
+                return None
+
+            cached = self._model
+            if cached is not None and cached.source_mtime_ns == mtime_ns:
+                return cached
+
+            try:
+                raw = json.loads(path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError) as exc:
+                log_event(
+                    logger,
+                    logging.WARNING,
+                    "hub.resolver.view_json_unreadable",
+                    path=str(path),
+                    error=str(exc),
+                )
+                self._model = None
+                return None
+
+            try:
+                model = ViewModel.from_dict(raw, source_path=path)
+            except ResolverError as exc:
+                log_event(
+                    logger,
+                    logging.WARNING,
+                    "hub.resolver.view_json_invalid",
+                    path=str(path),
+                    error=str(exc),
+                )
+                self._model = None
+                return None
+
+            model.source_mtime_ns = mtime_ns
+            self._model = model
+            log_event(
+                logger,
+                logging.INFO,
+                "hub.resolver.view_json_loaded",
+                path=str(path),
+                top=model.top,
+                nodes=len(model.nodes_by_path),
+            )
+            return model
+
+
+def _strip_top(instance_path: str, top: str) -> str:
+    """Drop the leading ``top.`` (or bare ``top``) anchor from a view path."""
+
+    if instance_path == top:
+        return ""
+    prefix = top + "."
+    if instance_path.startswith(prefix):
+        return instance_path[len(prefix) :]
+    return instance_path
+
+
+def default_view_json_path(project_root: Path) -> Path:
+    """Where the resolver looks for view.json inside ``project_root``."""
+
+    return project_root / ".rtl-buddy" / "view.json"
+
+
+# Convenience used by tests that want to skip the lazy-load dance.
+def resolver_from_paths(
+    *,
+    view_json_path: Path | None,
+    tb_prefix: str = "tb.dut.",
+    signal_aliases: Iterable[SignalAlias] = (),
+) -> Resolver:
+    mapping = HubMappingConfig(
+        tb_prefix=tb_prefix, signal_aliases=tuple(signal_aliases)
+    )
+    return Resolver(view_json_path=view_json_path, mapping=mapping)
+
+
+__all__ = [
+    "SUPPORTED_VIEW_SCHEMA_MAJOR",
+    "Resolver",
+    "ResolverError",
+    "Node",
+    "SignalDriver",
+    "SourceAnchor",
+    "ViewModel",
+    "default_view_json_path",
+    "resolver_from_paths",
+]

--- a/src/rtl_buddy/hub/server.py
+++ b/src/rtl_buddy/hub/server.py
@@ -48,6 +48,7 @@ from .protocol import (
     make_welcome,
     new_id,
 )
+from .resolver import Resolver
 from .state import (
     CursorTime,
     HubState,
@@ -202,10 +203,12 @@ class HubServer:
         server_version: str = "0.0.0",
         dedupe_capacity: int = DEFAULT_DEDUPE_CAPACITY,
         dedupe_ttl_seconds: float = DEFAULT_DEDUPE_TTL_SECONDS,
+        resolver: Resolver | None = None,
     ) -> None:
         self.host = host
         self.requested_port = port
         self.server_version = server_version
+        self.resolver = resolver
         self._registry: dict[Origin, ClientConnection] = {}
         self._pending = _LruIdSet(
             capacity=dedupe_capacity, ttl_seconds=dedupe_ttl_seconds
@@ -522,23 +525,148 @@ class HubServer:
         await self._safe_send(target_conn, env)
 
     async def _handle_hub_request(self, env: Envelope, conn: ClientConnection) -> None:
-        """Resolver stub — PR 3 wires the real coordinate mapper.
+        """Run a hub-side ``resolve_*`` request and reply on the same socket."""
 
-        Until then every ``resolve_*`` request returns ``unresolvable``
-        so client code can compile against the request shapes without
-        silently looking like it succeeded.
-        """
+        if self.resolver is None:
+            await self._reply_unresolvable(
+                env, conn, "resolver not configured (no view.json available)"
+            )
+            return
 
+        if env.type == "resolve_view_to_wave":
+            await self._handle_resolve_view_to_wave(env, conn)
+        elif env.type == "resolve_signal_to_view":
+            await self._handle_resolve_signal_to_view(env, conn)
+        else:
+            # Shouldn't happen — HUB_HANDLED_REQUESTS gates this dispatch.
+            await self._reply_unresolvable(
+                env, conn, f"unhandled hub request {env.type}"
+            )
+
+    async def _handle_resolve_view_to_wave(
+        self, env: Envelope, conn: ClientConnection
+    ) -> None:
+        assert self.resolver is not None
+        payload = env.payload if isinstance(env.payload, dict) else {}
+        instance_path = payload.get("instance_path")
+        if not isinstance(instance_path, str) or not instance_path:
+            await self._safe_send(
+                conn,
+                make_error(
+                    origin=Origin.CLI,
+                    code="bad_request",
+                    message="resolve_view_to_wave payload missing instance_path",
+                    context={"received": payload},
+                    in_reply_to=env.id,
+                ),
+            )
+            return
+
+        wave_scope = self.resolver.view_to_wave(instance_path)
+        if wave_scope is None:
+            await self._reply_unresolvable(
+                env,
+                conn,
+                f"no wave scope matches instance {instance_path!r}",
+                context={
+                    "instance_path": instance_path,
+                    "tb_prefix": self.resolver.mapping.tb_prefix,
+                },
+            )
+            return
+
+        await self._safe_send(
+            conn,
+            Envelope(
+                origin=Origin.CLI,
+                kind=Kind.RESPONSE,
+                type="resolve_view_to_wave",
+                id=env.id,
+                payload={"wave_scope": wave_scope},
+            ),
+        )
+
+    async def _handle_resolve_signal_to_view(
+        self, env: Envelope, conn: ClientConnection
+    ) -> None:
+        assert self.resolver is not None
+        payload = env.payload if isinstance(env.payload, dict) else {}
+        signal = payload.get("signal")
+        wave_scope = payload.get("wave_scope")
+        if not (
+            isinstance(signal, str)
+            and signal
+            and isinstance(wave_scope, str)
+            and wave_scope
+        ):
+            await self._safe_send(
+                conn,
+                make_error(
+                    origin=Origin.CLI,
+                    code="bad_request",
+                    message="resolve_signal_to_view payload requires signal+wave_scope",
+                    context={"received": payload},
+                    in_reply_to=env.id,
+                ),
+            )
+            return
+
+        drivers = self.resolver.signal_drivers(signal=signal, wave_scope=wave_scope)
+        if not drivers:
+            await self._reply_unresolvable(
+                env,
+                conn,
+                f"no driver of {signal!r} found under {wave_scope!r}",
+                context={"signal": signal, "wave_scope": wave_scope},
+            )
+            return
+
+        # §7: payload.instance_path is the list of driver paths; "port"
+        # is the driven port. When drivers disagree on port name (rare)
+        # we surface the first one and log; downstream surfacing is the
+        # client's call.
+        ports = {d.port for d in drivers}
+        if len(ports) > 1:
+            log_event(
+                logger,
+                logging.INFO,
+                "hub.resolver.signal_drivers_port_mismatch",
+                signal=signal,
+                wave_scope=wave_scope,
+                ports=sorted(ports),
+            )
+
+        await self._safe_send(
+            conn,
+            Envelope(
+                origin=Origin.CLI,
+                kind=Kind.RESPONSE,
+                type="resolve_signal_to_view",
+                id=env.id,
+                payload={
+                    "instance_path": [d.instance_path for d in drivers],
+                    "port": drivers[0].port,
+                },
+            ),
+        )
+
+    async def _reply_unresolvable(
+        self,
+        env: Envelope,
+        conn: ClientConnection,
+        message: str,
+        *,
+        context: dict[str, Any] | None = None,
+    ) -> None:
         await self._safe_send(
             conn,
             make_error(
                 origin=Origin.CLI,
                 code="unresolvable",
-                message=(
-                    f"hub-side resolver for {env.type} not yet implemented "
-                    "(PR 3 of rtl-buddy/rtl_buddy#115)"
-                ),
-                context=env.payload if isinstance(env.payload, dict) else None,
+                message=message,
+                context=context
+                if context is not None
+                else (env.payload if isinstance(env.payload, dict) else None),
                 in_reply_to=env.id,
             ),
         )

--- a/tests/test_hub_resolve_e2e.py
+++ b/tests/test_hub_resolve_e2e.py
@@ -1,0 +1,291 @@
+"""End-to-end resolve_* tests: real ``HubServer`` + real ``Resolver``.
+
+These complement the unit-level ``test_hub_resolver.py`` (which pokes
+the resolver directly) and the broad ``test_hub_server.py`` (which
+runs the server without a resolver). Here we stand up both and drive
+the protocol over the wire to confirm the server's resolve dispatch
+matches the spec's request/response shapes.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from typing import AsyncIterator
+
+import pytest
+import pytest_asyncio
+
+from rtl_buddy.hub.config import HubMappingConfig
+from rtl_buddy.hub.protocol import Envelope, Kind, Origin, decode, encode, new_id
+from rtl_buddy.hub.resolver import Resolver
+from rtl_buddy.hub.server import HubServer
+
+
+pytestmark = pytest.mark.asyncio
+
+
+# Mirrors the rtl-buddy-view JSON contract today (counter fixture).
+_VIEW_JSON = {
+    "schema_version": "1.0",
+    "tool": {"name": "rtl-buddy-view", "version": "0.1.0"},
+    "design": {"top": "counter"},
+    "nodes": [
+        {
+            "instance_path": "counter",
+            "module_name": "counter",
+            "port_connections": [],
+            "location": {
+                "file": "/abs/rtl/counter.sv",
+                "start_line": 5,
+                "start_column": 1,
+                "end_line": 12,
+                "end_column": 10,
+            },
+        },
+        {
+            "instance_path": "counter.u_ff",
+            "module_name": "counter_ff",
+            "port_connections": [
+                {"port_name": "clk", "net_expr_text": "clk"},
+                {"port_name": "q", "net_expr_text": "q"},
+            ],
+            "location": {
+                "file": "/abs/rtl/counter.sv",
+                "start_line": 10,
+                "start_column": 16,
+                "end_line": 10,
+                "end_column": 39,
+            },
+        },
+    ],
+    "edges": [{"parent": "counter", "child": "counter.u_ff"}],
+}
+
+
+@pytest_asyncio.fixture
+async def server_with_resolver(tmp_path: Path) -> AsyncIterator[HubServer]:
+    view_path = tmp_path / "view.json"
+    view_path.write_text(json.dumps(_VIEW_JSON), encoding="utf-8")
+
+    resolver = Resolver(
+        view_json_path=view_path,
+        mapping=HubMappingConfig(tb_prefix="tb.dut."),
+    )
+    s = HubServer(
+        host="127.0.0.1", port=0, server_version="0.0.0+test", resolver=resolver
+    )
+    await s.start()
+    serve_task = asyncio.create_task(s.serve_forever())
+    try:
+        yield s
+    finally:
+        await s.shutdown()
+        serve_task.cancel()
+        try:
+            await serve_task
+        except (asyncio.CancelledError, Exception):
+            pass
+
+
+class _Client:
+    """Local mock client. Mirrors tests/test_hub_server.py::MockClient."""
+
+    def __init__(
+        self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
+        self.reader = reader
+        self.writer = writer
+
+    @classmethod
+    async def connect(cls, host: str, port: int) -> "_Client":
+        r, w = await asyncio.open_connection(host, port)
+        return cls(r, w)
+
+    async def send(self, env: Envelope) -> None:
+        self.writer.write(encode(env).encode("utf-8") + b"\n")
+        await self.writer.drain()
+
+    async def recv(self, *, timeout: float = 1.0) -> Envelope:
+        line = await asyncio.wait_for(self.reader.readline(), timeout=timeout)
+        return decode(line)
+
+    async def hello(self, origin: Origin) -> Envelope:
+        h = Envelope(
+            origin=origin,
+            kind=Kind.REQUEST,
+            type="hello",
+            id=new_id(),
+            payload={"client": origin.value, "version": "0.1", "capabilities": []},
+        )
+        await self.send(h)
+        return await self.recv()
+
+    async def close(self) -> None:
+        try:
+            self.writer.close()
+            await self.writer.wait_closed()
+        except Exception:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# resolve_view_to_wave
+# ---------------------------------------------------------------------------
+
+
+async def test_view_to_wave_round_trip(server_with_resolver: HubServer):
+    c = await _Client.connect(server_with_resolver.host, server_with_resolver.port)
+    try:
+        await c.hello(Origin.VIEW)
+        req = Envelope(
+            origin=Origin.VIEW,
+            kind=Kind.REQUEST,
+            type="resolve_view_to_wave",
+            id=new_id(),
+            payload={"instance_path": "counter.u_ff"},
+        )
+        await c.send(req)
+        resp = await c.recv()
+        assert resp.kind is Kind.RESPONSE
+        assert resp.id == req.id
+        assert resp.payload == {"wave_scope": "tb.dut.u_ff"}
+    finally:
+        await c.close()
+
+
+async def test_view_to_wave_unknown_path_returns_unresolvable(
+    server_with_resolver: HubServer,
+):
+    c = await _Client.connect(server_with_resolver.host, server_with_resolver.port)
+    try:
+        await c.hello(Origin.VIEW)
+        req = Envelope(
+            origin=Origin.VIEW,
+            kind=Kind.REQUEST,
+            type="resolve_view_to_wave",
+            id=new_id(),
+            payload={"instance_path": "counter.u_dbg"},
+        )
+        await c.send(req)
+        err = await c.recv()
+        assert err.type == "error"
+        assert err.payload["code"] == "unresolvable"
+        assert err.payload["context"]["tb_prefix"] == "tb.dut."
+    finally:
+        await c.close()
+
+
+async def test_view_to_wave_missing_payload_returns_bad_request(
+    server_with_resolver: HubServer,
+):
+    """Server validation path: schema-rejecting payloads → bad_request.
+
+    The codec's encode would reject this on the client side, so we send
+    the raw wire bytes — that's the exposure surface a buggy or
+    non-Python client could realistically hit.
+    """
+
+    c = await _Client.connect(server_with_resolver.host, server_with_resolver.port)
+    try:
+        await c.hello(Origin.VIEW)
+        req_id = new_id()
+        raw = (
+            json.dumps(
+                {
+                    "v": 1,
+                    "id": req_id,
+                    "origin": "view",
+                    "kind": "request",
+                    "type": "resolve_view_to_wave",
+                    "payload": {"instance_path": ""},  # empty fails schema
+                }
+            )
+            + "\n"
+        ).encode("utf-8")
+        c.writer.write(raw)
+        await c.writer.drain()
+        err = await c.recv()
+        assert err.type == "error"
+        assert err.payload["code"] == "bad_request"
+    finally:
+        await c.close()
+
+
+# ---------------------------------------------------------------------------
+# resolve_signal_to_view
+# ---------------------------------------------------------------------------
+
+
+async def test_signal_to_view_round_trip(server_with_resolver: HubServer):
+    c = await _Client.connect(server_with_resolver.host, server_with_resolver.port)
+    try:
+        await c.hello(Origin.WAVE)
+        req = Envelope(
+            origin=Origin.WAVE,
+            kind=Kind.REQUEST,
+            type="resolve_signal_to_view",
+            id=new_id(),
+            payload={"signal": "q", "wave_scope": "tb.dut."},
+        )
+        await c.send(req)
+        resp = await c.recv()
+        assert resp.kind is Kind.RESPONSE
+        assert resp.id == req.id
+        assert resp.payload == {
+            "instance_path": ["counter.u_ff"],
+            "port": "q",
+        }
+    finally:
+        await c.close()
+
+
+async def test_signal_to_view_unknown_signal_unresolvable(
+    server_with_resolver: HubServer,
+):
+    c = await _Client.connect(server_with_resolver.host, server_with_resolver.port)
+    try:
+        await c.hello(Origin.WAVE)
+        req = Envelope(
+            origin=Origin.WAVE,
+            kind=Kind.REQUEST,
+            type="resolve_signal_to_view",
+            id=new_id(),
+            payload={"signal": "ghost", "wave_scope": "tb.dut."},
+        )
+        await c.send(req)
+        err = await c.recv()
+        assert err.type == "error"
+        assert err.payload["code"] == "unresolvable"
+    finally:
+        await c.close()
+
+
+async def test_signal_to_view_missing_field_bad_request(
+    server_with_resolver: HubServer,
+):
+    c = await _Client.connect(server_with_resolver.host, server_with_resolver.port)
+    try:
+        await c.hello(Origin.WAVE)
+        req_id = new_id()
+        raw = (
+            json.dumps(
+                {
+                    "v": 1,
+                    "id": req_id,
+                    "origin": "wave",
+                    "kind": "request",
+                    "type": "resolve_signal_to_view",
+                    "payload": {"signal": "q", "wave_scope": ""},
+                }
+            )
+            + "\n"
+        ).encode("utf-8")
+        c.writer.write(raw)
+        await c.writer.drain()
+        err = await c.recv()
+        assert err.type == "error"
+        assert err.payload["code"] == "bad_request"
+    finally:
+        await c.close()

--- a/tests/test_hub_resolver.py
+++ b/tests/test_hub_resolver.py
@@ -1,0 +1,382 @@
+"""Tests for ``rtl_buddy.hub.resolver``."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from rtl_buddy.hub.config import HubMappingConfig, SignalAlias
+from rtl_buddy.hub.resolver import (
+    ResolverError,
+    SignalDriver,
+    SourceAnchor,
+    ViewModel,
+    default_view_json_path,
+    resolver_from_paths,
+)
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _sample_view_json(top: str = "counter") -> dict:
+    """Mirrors the live rtl-buddy-view JSON output shape (counter fixture)."""
+
+    return {
+        "schema_version": "1.0",
+        "tool": {"name": "rtl-buddy-view", "version": "0.1.0"},
+        "design": {"top": top},
+        "nodes": [
+            {
+                "instance_path": top,
+                "module_name": top,
+                "instance_name": None,
+                "is_blackbox": False,
+                "param_overrides": [],
+                "port_connections": [],
+                "location": {
+                    "file": "/abs/rtl/counter.sv",
+                    "start_line": 5,
+                    "start_column": 1,
+                    "end_line": 12,
+                    "end_column": 10,
+                },
+                "clock": None,
+                "crossings_in": [],
+            },
+            {
+                "instance_path": f"{top}.u_ff",
+                "module_name": "counter_ff",
+                "instance_name": "u_ff",
+                "is_blackbox": False,
+                "param_overrides": [],
+                "port_connections": [
+                    {"port_name": "clk", "net_expr_text": "clk"},
+                    {"port_name": "q", "net_expr_text": "q"},
+                ],
+                "location": {
+                    "file": "/abs/rtl/counter.sv",
+                    "start_line": 10,
+                    "start_column": 16,
+                    "end_line": 10,
+                    "end_column": 39,
+                },
+                "clock": None,
+                "crossings_in": [],
+            },
+            {
+                "instance_path": f"{top}.u_x",
+                "module_name": "sub_x",
+                "instance_name": "u_x",
+                "is_blackbox": True,
+                "param_overrides": [],
+                "port_connections": [
+                    {"port_name": "clk", "net_expr_text": "clk"},
+                ],
+                "location": {
+                    "file": "/abs/rtl/counter.sv",
+                    "start_line": 11,
+                    "start_column": 16,
+                    "end_line": 11,
+                    "end_column": 32,
+                },
+                "clock": None,
+                "crossings_in": [],
+            },
+        ],
+        "edges": [
+            {"parent": top, "child": f"{top}.u_ff"},
+            {"parent": top, "child": f"{top}.u_x"},
+        ],
+    }
+
+
+def _write_view_json(tmp_path: Path, payload: dict | None = None) -> Path:
+    if payload is None:
+        payload = _sample_view_json()
+    p = tmp_path / "view.json"
+    p.write_text(json.dumps(payload), encoding="utf-8")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# ViewModel.from_dict
+# ---------------------------------------------------------------------------
+
+
+def test_from_dict_parses_minimal_payload(tmp_path: Path):
+    model = ViewModel.from_dict(_sample_view_json())
+    assert model.top == "counter"
+    assert set(model.nodes_by_path) == {"counter", "counter.u_ff", "counter.u_x"}
+    assert model.edges_parent_to_children["counter"] == (
+        "counter.u_ff",
+        "counter.u_x",
+    )
+
+    u_ff = model.nodes_by_path["counter.u_ff"]
+    assert u_ff.port_connections == (("clk", "clk"), ("q", "q"))
+    assert u_ff.location == SourceAnchor(file="/abs/rtl/counter.sv", line=10, col=16)
+
+
+def test_from_dict_rejects_unsupported_schema_major():
+    payload = _sample_view_json()
+    payload["schema_version"] = "2.0"
+    with pytest.raises(ResolverError, match="schema major 2"):
+        ViewModel.from_dict(payload)
+
+
+def test_from_dict_rejects_unparseable_schema_version():
+    payload = _sample_view_json()
+    payload["schema_version"] = "abc"
+    with pytest.raises(ResolverError):
+        ViewModel.from_dict(payload)
+
+
+def test_from_dict_rejects_missing_top():
+    payload = _sample_view_json()
+    del payload["design"]
+    with pytest.raises(ResolverError, match="design.top"):
+        ViewModel.from_dict(payload)
+
+
+def test_from_dict_skips_malformed_node_entries():
+    payload = _sample_view_json()
+    payload["nodes"].append({"no_instance_path": True})
+    payload["nodes"].append(
+        {
+            "instance_path": "counter.u_y",
+            "port_connections": [
+                {"port_name": "clk"},  # missing net_expr_text
+                {"port_name": "rst", "net_expr_text": 42},  # wrong type
+                {"port_name": "go", "net_expr_text": "go"},  # ok
+            ],
+            "location": "not a dict",
+        }
+    )
+    model = ViewModel.from_dict(payload)
+    assert "counter.u_y" in model.nodes_by_path
+    u_y = model.nodes_by_path["counter.u_y"]
+    assert u_y.port_connections == (("go", "go"),)
+    assert u_y.location is None
+
+
+# ---------------------------------------------------------------------------
+# view ↔ wave transforms
+# ---------------------------------------------------------------------------
+
+
+def test_view_to_wave_strips_top_and_prepends_prefix(tmp_path: Path):
+    resolver = resolver_from_paths(
+        view_json_path=_write_view_json(tmp_path), tb_prefix="tb.dut."
+    )
+    assert resolver.view_to_wave("counter.u_ff") == "tb.dut.u_ff"
+    assert resolver.view_to_wave("counter") == "tb.dut."
+
+
+def test_view_to_wave_returns_none_for_unknown_path(tmp_path: Path):
+    resolver = resolver_from_paths(
+        view_json_path=_write_view_json(tmp_path), tb_prefix="tb.dut."
+    )
+    assert resolver.view_to_wave("counter.u_dbg") is None
+
+
+def test_view_to_wave_handles_empty_prefix(tmp_path: Path):
+    resolver = resolver_from_paths(
+        view_json_path=_write_view_json(tmp_path), tb_prefix=""
+    )
+    assert resolver.view_to_wave("counter.u_ff") == "u_ff"
+
+
+def test_view_to_wave_uses_aliases_before_prefix(tmp_path: Path):
+    resolver = resolver_from_paths(
+        view_json_path=_write_view_json(tmp_path),
+        tb_prefix="tb.dut.",
+        signal_aliases=[
+            SignalAlias(wave="tb.dut.legacy_ff", view="counter.u_ff"),
+        ],
+    )
+    assert resolver.view_to_wave("counter.u_ff") == "tb.dut.legacy_ff"
+
+
+def test_wave_to_view_strips_prefix_and_prepends_top(tmp_path: Path):
+    resolver = resolver_from_paths(
+        view_json_path=_write_view_json(tmp_path), tb_prefix="tb.dut."
+    )
+    assert resolver.wave_to_view("tb.dut.u_ff") == "counter.u_ff"
+
+
+def test_wave_to_view_uses_aliases(tmp_path: Path):
+    resolver = resolver_from_paths(
+        view_json_path=_write_view_json(tmp_path),
+        tb_prefix="tb.dut.",
+        signal_aliases=[
+            SignalAlias(wave="tb.dut.legacy_ff", view="counter.u_ff"),
+        ],
+    )
+    assert resolver.wave_to_view("tb.dut.legacy_ff") == "counter.u_ff"
+
+
+def test_wave_to_view_returns_none_when_prefix_mismatch(tmp_path: Path):
+    resolver = resolver_from_paths(
+        view_json_path=_write_view_json(tmp_path), tb_prefix="tb.dut."
+    )
+    assert resolver.wave_to_view("foo.bar") is None
+
+
+def test_wave_to_view_returns_none_when_path_unknown(tmp_path: Path):
+    resolver = resolver_from_paths(
+        view_json_path=_write_view_json(tmp_path), tb_prefix="tb.dut."
+    )
+    assert resolver.wave_to_view("tb.dut.u_dbg") is None
+
+
+# ---------------------------------------------------------------------------
+# view → src
+# ---------------------------------------------------------------------------
+
+
+def test_view_to_src_returns_anchor(tmp_path: Path):
+    resolver = resolver_from_paths(
+        view_json_path=_write_view_json(tmp_path), tb_prefix="tb.dut."
+    )
+    anchor = resolver.view_to_src("counter.u_ff")
+    assert anchor == SourceAnchor(file="/abs/rtl/counter.sv", line=10, col=16)
+
+
+def test_view_to_src_missing_path_returns_none(tmp_path: Path):
+    resolver = resolver_from_paths(
+        view_json_path=_write_view_json(tmp_path), tb_prefix="tb.dut."
+    )
+    assert resolver.view_to_src("counter.nope") is None
+
+
+def test_view_to_src_returns_none_without_view_json(tmp_path: Path):
+    resolver = resolver_from_paths(view_json_path=None)
+    assert resolver.view_to_src("counter.u_ff") is None
+
+
+# ---------------------------------------------------------------------------
+# signal → drivers
+# ---------------------------------------------------------------------------
+
+
+def test_signal_drivers_finds_unique_match(tmp_path: Path):
+    resolver = resolver_from_paths(
+        view_json_path=_write_view_json(tmp_path), tb_prefix="tb.dut."
+    )
+    drivers = resolver.signal_drivers(signal="q", wave_scope="tb.dut.")
+    assert drivers == (SignalDriver(instance_path="counter.u_ff", port="q"),)
+
+
+def test_signal_drivers_returns_all_drivers(tmp_path: Path):
+    """Two instances port-connected to the same signal name collapse to a list."""
+
+    payload = _sample_view_json()
+    payload["nodes"].append(
+        {
+            "instance_path": "counter.u_ff2",
+            "module_name": "counter_ff",
+            "instance_name": "u_ff2",
+            "port_connections": [
+                {"port_name": "q", "net_expr_text": "q"},
+            ],
+            "location": {
+                "file": "/abs/rtl/counter.sv",
+                "start_line": 12,
+                "start_column": 1,
+                "end_line": 12,
+                "end_column": 1,
+            },
+        }
+    )
+    payload["edges"].append({"parent": "counter", "child": "counter.u_ff2"})
+    p = _write_view_json(tmp_path, payload)
+
+    resolver = resolver_from_paths(view_json_path=p, tb_prefix="tb.dut.")
+    drivers = resolver.signal_drivers(signal="q", wave_scope="tb.dut.")
+    assert {d.instance_path for d in drivers} == {
+        "counter.u_ff",
+        "counter.u_ff2",
+    }
+    assert all(d.port == "q" for d in drivers)
+
+
+def test_signal_drivers_unknown_signal_returns_empty(tmp_path: Path):
+    resolver = resolver_from_paths(
+        view_json_path=_write_view_json(tmp_path), tb_prefix="tb.dut."
+    )
+    assert resolver.signal_drivers(signal="ghost", wave_scope="tb.dut.") == ()
+
+
+def test_signal_drivers_with_bad_wave_scope_returns_empty(tmp_path: Path):
+    resolver = resolver_from_paths(
+        view_json_path=_write_view_json(tmp_path), tb_prefix="tb.dut."
+    )
+    # Wave path that doesn't start with tb_prefix.
+    assert resolver.signal_drivers(signal="q", wave_scope="other.foo") == ()
+
+
+# ---------------------------------------------------------------------------
+# lazy loading / mtime-driven reload
+# ---------------------------------------------------------------------------
+
+
+def test_resolver_returns_none_when_file_missing(tmp_path: Path):
+    resolver = resolver_from_paths(
+        view_json_path=tmp_path / "absent.json", tb_prefix="tb.dut."
+    )
+    # No view.json → view_to_wave falls through to best-effort path.
+    # (This is the documented "no resolver loaded" fallback.)
+    assert resolver.view_to_src("counter.u_ff") is None
+    assert resolver.signal_drivers(signal="q", wave_scope="tb.dut.") == ()
+
+
+def test_resolver_reloads_on_mtime_change(tmp_path: Path):
+    p = _write_view_json(tmp_path)
+    resolver = resolver_from_paths(view_json_path=p, tb_prefix="tb.dut.")
+    assert resolver.view_to_src("counter.u_ff") is not None
+
+    # Replace the file with a different top — bump mtime to force reload.
+    new_payload = _sample_view_json(top="adder")
+    p.write_text(json.dumps(new_payload), encoding="utf-8")
+    import os, time
+
+    os.utime(p, (time.time() + 1, time.time() + 1))
+
+    assert resolver.view_to_src("counter.u_ff") is None
+    assert resolver.view_to_src("adder.u_ff") is not None
+
+
+def test_resolver_swallows_malformed_view_json(tmp_path: Path):
+    p = tmp_path / "view.json"
+    p.write_text("{not json", encoding="utf-8")
+    resolver = resolver_from_paths(view_json_path=p, tb_prefix="tb.dut.")
+    # Bad payload → resolver acts like view.json is absent.
+    assert resolver.view_to_src("counter.u_ff") is None
+
+
+def test_update_mapping_swaps_aliases_in_place(tmp_path: Path):
+    p = _write_view_json(tmp_path)
+    resolver = resolver_from_paths(
+        view_json_path=p,
+        tb_prefix="tb.dut.",
+        signal_aliases=[SignalAlias(wave="old", view="counter.u_ff")],
+    )
+    assert resolver.wave_to_view("old") == "counter.u_ff"
+
+    resolver.update_mapping(
+        HubMappingConfig(
+            tb_prefix="tb.dut.",
+            signal_aliases=(SignalAlias(wave="new", view="counter.u_ff"),),
+        )
+    )
+    assert resolver.wave_to_view("old") is None
+    assert resolver.wave_to_view("new") == "counter.u_ff"
+
+
+def test_default_view_json_path_layout(tmp_path: Path):
+    assert default_view_json_path(tmp_path) == tmp_path / ".rtl-buddy" / "view.json"

--- a/tests/test_hub_server.py
+++ b/tests/test_hub_server.py
@@ -309,7 +309,9 @@ async def test_request_to_missing_origin_returns_not_connected(server: HubServer
         await view.close()
 
 
-async def test_resolve_request_returns_stub_unresolvable(server: HubServer):
+async def test_resolve_request_without_resolver_returns_unresolvable(server: HubServer):
+    """Server with no resolver attached → resolve_* surfaces unresolvable."""
+
     view = await MockClient.connect(server.host, server.port)
     try:
         await view.hello(Origin.VIEW)
@@ -324,7 +326,7 @@ async def test_resolve_request_returns_stub_unresolvable(server: HubServer):
         err = await view.recv()
         assert err.type == "error"
         assert err.payload["code"] == "unresolvable"
-        assert "PR 3" in err.payload["message"]
+        assert "resolver not configured" in err.payload["message"]
     finally:
         await view.close()
 


### PR DESCRIPTION
## Summary

PR 3 of rtl-buddy/rtl_buddy#115. Replaces the `resolve_*` stub from #118 with a real coordinate translator backed by a `view.json` snapshot.

### New: `src/rtl_buddy/hub/resolver.py`

`Resolver` + `ViewModel`:

- Loads `<project_root>/.rtl-buddy/view.json` (or `[mapping].view_json`) lazily and reloads when the file's `mtime` changes, so a re-run of `rb hier --format json` mid-session is picked up automatically.
- `view_to_wave` / `wave_to_view` — pure prefix transforms with per-instance alias overrides applied first. Unknown view paths return `None` so the server surfaces `unresolvable` instead of guessing.
- `view_to_src` — `nodes[].location` lookup, translated to the wire shape `{file, line, col}` (view.json uses `start_line` / `start_column`; the resolver normalises).
- `signal_drivers` — walks `port_connections` of children of the node at `wave_scope` to find every driver of a named signal. Multiple drivers (bus / generate) collapse to a list per spec §7.
- Thread-safe via a lock around the lazy-load path.

### Modified: `src/rtl_buddy/hub/server.py`

`_handle_hub_request` now dispatches to per-type handlers:

- `resolve_view_to_wave` → response `{wave_scope}` or `error{code: \"unresolvable\"}` with context `{instance_path, tb_prefix}`.
- `resolve_signal_to_view` → response `{instance_path: [...], port}` or `error{code: \"unresolvable\"}` with context `{signal, wave_scope}`.
- Bad payloads → `bad_request`; missing resolver → `unresolvable`.

### Modified: `src/rtl_buddy/hub/config.py`

Adds `[mapping].view_json` option (relative path; defaults to `.rtl-buddy/view.json`).

### Modified: `src/rtl_buddy/hub/loop.py`

Constructs the resolver from project root + config and passes it to `HubServer`.

### Live smoke

```
\$ rtl-buddy-view --top counter --format json > .rtl-buddy/view.json
\$ rb hub start &
# Client sends:
{type: \"resolve_view_to_wave\", payload: {instance_path: \"counter.u_ff\"}}
# Hub responds:
{kind: \"response\", payload: {wave_scope: \"tb.dut.u_ff\"}}

{type: \"resolve_signal_to_view\", payload: {signal: \"q\", wave_scope: \"tb.dut.\"}}
# Hub responds:
{kind: \"response\", payload: {instance_path: [\"counter.u_ff\"], port: \"q\"}}
```

## What's next

- **PR 4** — `rb wave` hub integration (the WAVE-origin client; bridges WCP↔hub).
- **PR 5** — viewer HTTP/WS layer + `rb hub --serve-viewer`.

## Test plan
- [x] `uv run pytest -q --no-cov` — 506 passed (31 new: 25 resolver unit + 6 server e2e)
- [x] `uv run ruff check src tests` — clean
- [x] `uv run ruff format --check src tests` — clean
- [x] Live: `rb hub start` + real `view.json` from rtl-buddy-view round-trips `resolve_view_to_wave` and `resolve_signal_to_view`
- [x] CLI reference regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)