### PR TITLE
Phase 10b: rb wave hub adapter (#115)

### DIFF
--- a/src/rtl_buddy/tools/surfer_wcp.py
+++ b/src/rtl_buddy/tools/surfer_wcp.py
@@ -23,7 +23,7 @@ import socket
 import socket as _socket_mod
 import subprocess
 import threading
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable
 
 if TYPE_CHECKING:
     from ..config.surfer import SurferConfig
@@ -667,6 +667,9 @@ class SurferWcpListener:
         self._wcp_conn: socket.socket | None = (
             None  # live connection to Surfer for sending commands
         )
+        self.event_observer: "Callable[[str, dict], None] | None" = None
+        """Optional callback invoked for relevant WCP events. The hub-bridge
+        adapter sets this; the listener stays free of hub awareness."""
 
     def send_to_surfer(self, obj: dict) -> None:
         """Send a WCP command frame to Surfer if connected."""
@@ -773,15 +776,27 @@ class SurferWcpListener:
                     self._editor.open(filepath, lineno, value)
                     if self._scope_annotation and self._value_reader is not None:
                         self._build_scope_cache(variable, timestamp)
+                self._notify_observer("goto_declaration", msg)
             elif msg.get("type") == "event" and msg.get("event") == "cursor_moved":
                 timestamp = msg.get("timestamp")
                 if timestamp is not None:
                     self._last_timestamp = timestamp
                 self._on_cursor_moved(timestamp)
+                self._notify_observer("cursor_moved", msg)
             elif msg.get("type") == "event" and msg.get("event") == "scope_changed":
                 scope = msg.get("scope", "")
                 if scope:
                     self._on_scope_changed(scope)
+                self._notify_observer("scope_changed", msg)
+
+    def _notify_observer(self, event_name: str, msg: dict) -> None:
+        observer = self.event_observer
+        if observer is None:
+            return
+        try:
+            observer(event_name, msg)
+        except Exception:
+            logger.exception("wave.event_observer.unhandled_error event=%s", event_name)
 
     def _emit_value(self, variable: str, timestamp: int | None) -> str | None:
         """Log the signal value at *timestamp* to the console. Returns the display string or None."""

--- a/src/rtl_buddy/tools/wave_hub_bridge.py
+++ b/src/rtl_buddy/tools/wave_hub_bridge.py
@@ -1,0 +1,555 @@
+"""Bridges the ``rb wave`` WCP listener to the rtl-buddy-hub.
+
+When ``rb wave`` runs inside a project that has a live hub, this
+adapter registers as the ``wave``-origin client and shuttles
+information in both directions:
+
+  surfer  ── WCP event ─►  bridge  ── hub event ─►  viewer + nvim
+  viewer  ── hub req  ─►  bridge  ── WCP cmd  ─►  surfer
+
+The bridge opens its own TCP connection to the hub (separate from the
+WCP listener's connection to surfer) and runs in a dedicated thread.
+The existing ``rb wave`` codebase is threaded, so a sync TCP + reader
+thread matches the existing style; no asyncio runs inside the wave
+adapter.
+
+Discovery is per-project per §4.2 of the protocol spec:
+
+* honour ``$RTL_BUDDY_HUB`` (``host:port``) when present,
+* otherwise walk up from CWD looking for ``.rtl-buddy/hub.json``.
+
+When no hub is reachable, :func:`maybe_connect_bridge` returns
+``None`` and ``rb wave`` continues standalone — the spec's "graceful
+degradation" requirement.
+"""
+
+from __future__ import annotations
+
+import logging
+import socket
+import threading
+from pathlib import Path
+from typing import Any
+
+from ..hub.discovery import (
+    HubDiscoveryError,
+    env_override,
+    find_project_root_with_hub,
+    read_record,
+    _pid_is_live,
+)
+from ..hub.protocol import (
+    Envelope,
+    HubProtocolError,
+    Kind,
+    Origin,
+    decode,
+    encode,
+    make_hello,
+    new_id,
+)
+from ..logging_utils import log_event
+from .surfer_wcp import SurferWcpListener
+
+
+logger = logging.getLogger(__name__)
+
+
+HELLO_TIMEOUT_SECONDS = 2.0
+"""Read deadline for the welcome reply during connect."""
+
+WAVE_CAPABILITIES: tuple[str, ...] = (
+    "wave_add_variables",
+    "wave_set_cursor",
+    "wave_set_scope",
+    "signal_selected",
+    "cursor_time_changed",
+    "scope_changed",
+)
+
+
+class WaveHubBridgeError(Exception):
+    """Raised on unrecoverable bridge setup errors (kept narrow on purpose)."""
+
+
+def _parse_hub_addr(spec: str) -> tuple[str, int]:
+    """Parse ``host:port`` (the ``$RTL_BUDDY_HUB`` form, also ``hub.json.tcp``)."""
+
+    host, _, port_s = spec.rpartition(":")
+    if not host or not port_s:
+        raise WaveHubBridgeError(f"malformed hub address {spec!r}")
+    try:
+        return host, int(port_s)
+    except ValueError as exc:
+        raise WaveHubBridgeError(f"non-integer port in hub address {spec!r}") from exc
+
+
+def _discover_hub_addr(*, project_root: Path | None) -> tuple[str, int] | None:
+    """Resolve the hub address per §4.2 lookup order.
+
+    Order:
+    1. ``$RTL_BUDDY_HUB`` env var.
+    2. Walk up from ``project_root`` (or CWD) for ``.rtl-buddy/hub.json``.
+    """
+
+    env = env_override()
+    if env:
+        return _parse_hub_addr(env)
+
+    start = project_root or Path.cwd()
+    root = find_project_root_with_hub(start)
+    if root is None:
+        return None
+    try:
+        record = read_record(root)
+    except HubDiscoveryError as exc:
+        log_event(
+            logger,
+            logging.WARNING,
+            "wave.hub.discovery_unreadable",
+            error=str(exc),
+        )
+        return None
+    if record is None:
+        return None
+    if not _pid_is_live(record.pid):
+        log_event(
+            logger,
+            logging.INFO,
+            "wave.hub.stale_record",
+            pid=record.pid,
+        )
+        return None
+    return _parse_hub_addr(record.tcp)
+
+
+class WaveHubBridge:
+    """Owns the bridge connection between ``rb wave`` and the hub.
+
+    Constructed by :func:`maybe_connect_bridge`; the constructor is for
+    tests that want to inject a pre-connected socket.
+
+    Thread model:
+    * The constructor connects + runs the hello/welcome handshake on
+      the calling thread.
+    * :meth:`start` launches the bridge reader thread.
+    * :meth:`on_wcp_event` is called from the WCP listener thread to
+      translate outbound WCP events into hub events.
+    * :meth:`stop` signals exit, attempts a polite ``bye``, closes the
+      socket, and joins the reader thread.
+    """
+
+    def __init__(
+        self,
+        sock: socket.socket,
+        *,
+        listener: SurferWcpListener,
+        client_version: str = "0.1.0",
+    ) -> None:
+        self._sock = sock
+        self._listener = listener
+        self._client_version = client_version
+        self._stop = threading.Event()
+        self._send_lock = threading.Lock()
+        self._reader_thread: threading.Thread | None = None
+
+    # ------------------------------------------------------------------
+    # connection
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def connect(
+        cls,
+        addr: tuple[str, int],
+        *,
+        listener: SurferWcpListener,
+        client_version: str = "0.1.0",
+    ) -> "WaveHubBridge":
+        """Open a TCP connection, run hello/welcome, return the bridge.
+
+        Raises :class:`WaveHubBridgeError` on connect / handshake failure.
+        """
+
+        try:
+            sock = socket.create_connection(addr, timeout=HELLO_TIMEOUT_SECONDS)
+        except OSError as exc:
+            raise WaveHubBridgeError(
+                f"hub at {addr[0]}:{addr[1]} refused connection: {exc}"
+            ) from exc
+
+        bridge = cls(sock, listener=listener, client_version=client_version)
+        try:
+            bridge._do_handshake()
+        except Exception:
+            sock.close()
+            raise
+
+        sock.settimeout(None)
+        return bridge
+
+    def _do_handshake(self) -> None:
+        hello = make_hello(
+            client=Origin.WAVE,
+            version=self._client_version,
+            capabilities=list(WAVE_CAPABILITIES),
+        )
+        self._send_envelope(hello)
+        try:
+            welcome = self._recv_envelope()
+        except OSError as exc:
+            raise WaveHubBridgeError(f"hub did not reply to hello: {exc}") from exc
+
+        if welcome.type != "welcome" or welcome.kind is not Kind.RESPONSE:
+            raise WaveHubBridgeError(
+                f"unexpected handshake reply: kind={welcome.kind.value} "
+                f"type={welcome.type}"
+            )
+        if welcome.id != hello.id:
+            raise WaveHubBridgeError(
+                f"handshake id mismatch: hello={hello.id} welcome={welcome.id}"
+            )
+        log_event(
+            logger,
+            logging.INFO,
+            "wave.hub.connected",
+            server_version=welcome.payload.get("server_version", ""),
+            registered=welcome.payload.get("registered_clients", []),
+        )
+
+    # ------------------------------------------------------------------
+    # lifecycle
+    # ------------------------------------------------------------------
+
+    def start(self) -> None:
+        if self._reader_thread is not None:
+            return
+        # Wire the listener observer first so we never miss an event
+        # between thread start and the listener loop entering ``run()``.
+        self._listener.event_observer = self.on_wcp_event
+        thread = threading.Thread(
+            target=self._read_loop, daemon=True, name="hub-bridge-reader"
+        )
+        thread.start()
+        self._reader_thread = thread
+
+    def stop(self) -> None:
+        if self._listener.event_observer is self.on_wcp_event:
+            self._listener.event_observer = None
+        if self._stop.is_set():
+            return
+        self._stop.set()
+
+        # Best-effort polite bye, then close.
+        try:
+            bye = Envelope(
+                origin=Origin.WAVE,
+                kind=Kind.EVENT,
+                type="bye",
+                id=new_id(),
+                payload={},
+            )
+            self._send_envelope(bye)
+        except (OSError, HubProtocolError):
+            pass
+
+        try:
+            self._sock.shutdown(socket.SHUT_RDWR)
+        except OSError:
+            pass
+        try:
+            self._sock.close()
+        except OSError:
+            pass
+        if self._reader_thread is not None:
+            self._reader_thread.join(timeout=1.0)
+            self._reader_thread = None
+
+    # ------------------------------------------------------------------
+    # outbound — WCP → hub
+    # ------------------------------------------------------------------
+
+    def on_wcp_event(self, event_name: str, msg: dict) -> None:
+        """Called from the WCP listener thread per relevant WCP event."""
+
+        if self._stop.is_set():
+            return
+        try:
+            envelope = self._wcp_to_hub_event(event_name, msg)
+        except Exception:
+            logger.exception("wave.hub.wcp_translate_failed event=%s", event_name)
+            return
+        if envelope is None:
+            return
+        try:
+            self._send_envelope(envelope)
+        except (OSError, HubProtocolError) as exc:
+            log_event(
+                logger,
+                logging.WARNING,
+                "wave.hub.send_failed",
+                type=envelope.type,
+                error=str(exc),
+            )
+
+    def _wcp_to_hub_event(self, event_name: str, msg: dict) -> Envelope | None:
+        if event_name == "cursor_moved":
+            ts = msg.get("timestamp")
+            if not isinstance(ts, int):
+                return None
+            return Envelope(
+                origin=Origin.WAVE,
+                kind=Kind.EVENT,
+                type="cursor_time_changed",
+                id=new_id(),
+                payload={"t_fs": str(ts)},
+            )
+        if event_name == "scope_changed":
+            scope = msg.get("scope")
+            if not isinstance(scope, str) or not scope:
+                return None
+            return Envelope(
+                origin=Origin.WAVE,
+                kind=Kind.EVENT,
+                type="scope_changed",
+                id=new_id(),
+                payload={"wave_scope": scope},
+            )
+        if event_name == "goto_declaration":
+            variable = msg.get("variable")
+            if not isinstance(variable, str) or "." not in variable:
+                return None
+            scope, _, signal = variable.rpartition(".")
+            if not scope or not signal:
+                return None
+            return Envelope(
+                origin=Origin.WAVE,
+                kind=Kind.EVENT,
+                type="signal_selected",
+                id=new_id(),
+                payload={"signal": signal, "wave_scope": scope},
+            )
+        return None
+
+    # ------------------------------------------------------------------
+    # inbound — hub → WCP
+    # ------------------------------------------------------------------
+
+    def _read_loop(self) -> None:
+        buf = b""
+        sock = self._sock
+        while not self._stop.is_set():
+            try:
+                chunk = sock.recv(4096)
+            except OSError:
+                return
+            if not chunk:
+                return
+            buf += chunk
+            while b"\n" in buf:
+                line, _, buf = buf.partition(b"\n")
+                if not line.strip():
+                    continue
+                try:
+                    env = decode(line)
+                except HubProtocolError as exc:
+                    log_event(
+                        logger,
+                        logging.WARNING,
+                        "wave.hub.bad_envelope",
+                        error=str(exc),
+                    )
+                    continue
+                try:
+                    self._handle_inbound(env)
+                except Exception:
+                    logger.exception(
+                        "wave.hub.inbound_unhandled type=%s kind=%s",
+                        env.type,
+                        env.kind.value,
+                    )
+
+    def _handle_inbound(self, env: Envelope) -> None:
+        if env.kind is Kind.REQUEST:
+            self._handle_request(env)
+        # Hub-side events (selection_changed from view, source_focused from
+        # src, etc.) are not surfer-actionable in v1; logged at DEBUG.
+        elif env.kind is Kind.EVENT and env.type != "bye":
+            log_event(
+                logger,
+                logging.DEBUG,
+                "wave.hub.event_ignored",
+                type=env.type,
+                origin=env.origin.value,
+            )
+        # responses / errors → unused in v1, just log.
+        elif env.kind in (Kind.RESPONSE, Kind.ERROR):
+            log_event(
+                logger,
+                logging.DEBUG,
+                "wave.hub.response_ignored",
+                type=env.type,
+                kind=env.kind.value,
+            )
+
+    def _handle_request(self, env: Envelope) -> None:
+        if env.type == "wave_add_variables":
+            self._handle_add_variables(env)
+        elif env.type == "wave_set_cursor":
+            self._handle_set_cursor(env)
+        elif env.type == "wave_set_scope":
+            self._handle_set_scope(env)
+        else:
+            self._reply_bad_request(env, f"unhandled wave request {env.type}")
+
+    def _handle_add_variables(self, env: Envelope) -> None:
+        payload = env.payload if isinstance(env.payload, dict) else {}
+        variables = payload.get("variables")
+        if not isinstance(variables, list) or not all(
+            isinstance(v, str) and v for v in variables
+        ):
+            return self._reply_bad_request(env, "missing/invalid variables")
+        self._send_to_surfer(
+            {
+                "type": "command",
+                "command": "add_variables",
+                "variables": variables,
+            }
+        )
+        # WCP response correlation isn't tracked in v1; respond optimistically
+        # with empty ids list. Clients that need the surfer-assigned ids back
+        # can issue a fresh query path once that's wired (post-v1).
+        self._reply_response(env, type_=env.type, payload={"ids": []})
+
+    def _handle_set_cursor(self, env: Envelope) -> None:
+        payload = env.payload if isinstance(env.payload, dict) else {}
+        t_fs = payload.get("t_fs")
+        if not isinstance(t_fs, str) or not t_fs:
+            return self._reply_bad_request(env, "missing t_fs")
+        try:
+            ts = int(t_fs)
+        except ValueError:
+            return self._reply_bad_request(env, f"non-numeric t_fs: {t_fs!r}")
+        self._send_to_surfer(
+            {"type": "command", "command": "set_cursor", "timestamp": ts}
+        )
+        self._reply_response(env, type_=env.type, payload={"ok": True})
+
+    def _handle_set_scope(self, env: Envelope) -> None:
+        payload = env.payload if isinstance(env.payload, dict) else {}
+        scope = payload.get("wave_scope")
+        if not isinstance(scope, str) or not scope:
+            return self._reply_bad_request(env, "missing wave_scope")
+        # §9.3 documents `set_scope` as a fork addition; surfer's current
+        # close match is `add_scope` (which also adds variables). Until the
+        # fork ships `set_scope`, use `add_scope` and document the gap.
+        self._send_to_surfer(
+            {"type": "command", "command": "add_scope", "scope": scope}
+        )
+        self._reply_response(env, type_=env.type, payload={"ok": True})
+
+    # ------------------------------------------------------------------
+    # internals
+    # ------------------------------------------------------------------
+
+    def _send_to_surfer(self, frame: dict[str, Any]) -> None:
+        try:
+            self._listener.send_to_surfer(frame)
+        except Exception:
+            logger.exception(
+                "wave.hub.surfer_send_failed command=%s", frame.get("command")
+            )
+
+    def _send_envelope(self, env: Envelope) -> None:
+        payload = encode(env).encode("utf-8") + b"\n"
+        with self._send_lock:
+            self._sock.sendall(payload)
+
+    def _recv_envelope(self) -> Envelope:
+        buf = b""
+        while True:
+            chunk = self._sock.recv(4096)
+            if not chunk:
+                raise OSError("hub closed the connection mid-message")
+            buf += chunk
+            if b"\n" in buf:
+                line, _, _rest = buf.partition(b"\n")
+                return decode(line)
+
+    def _reply_response(
+        self, env: Envelope, *, type_: str, payload: dict[str, Any]
+    ) -> None:
+        reply = Envelope(
+            origin=Origin.WAVE,
+            kind=Kind.RESPONSE,
+            type=type_,
+            id=env.id,
+            payload=payload,
+        )
+        try:
+            self._send_envelope(reply)
+        except (OSError, HubProtocolError) as exc:
+            log_event(
+                logger,
+                logging.WARNING,
+                "wave.hub.reply_failed",
+                id=env.id,
+                error=str(exc),
+            )
+
+    def _reply_bad_request(self, env: Envelope, message: str) -> None:
+        from ..hub.protocol import make_error
+
+        err = make_error(
+            origin=Origin.WAVE,
+            code="bad_request",
+            message=message,
+            context=env.payload if isinstance(env.payload, dict) else None,
+            in_reply_to=env.id,
+        )
+        try:
+            self._send_envelope(err)
+        except (OSError, HubProtocolError):
+            pass
+
+
+def maybe_connect_bridge(
+    *,
+    listener: SurferWcpListener,
+    project_root: Path | None = None,
+    client_version: str = "0.1.0",
+) -> WaveHubBridge | None:
+    """Discover the project hub and connect a bridge, or ``None``.
+
+    The return value is the live bridge (with the reader thread
+    running) when a hub was reachable. ``None`` means "no hub for this
+    project / standalone mode" — the spec's graceful-degradation path.
+    """
+
+    addr = _discover_hub_addr(project_root=project_root)
+    if addr is None:
+        log_event(logger, logging.INFO, "wave.hub.absent")
+        return None
+    try:
+        bridge = WaveHubBridge.connect(
+            addr, listener=listener, client_version=client_version
+        )
+    except WaveHubBridgeError as exc:
+        log_event(
+            logger,
+            logging.WARNING,
+            "wave.hub.connect_failed",
+            host=addr[0],
+            port=addr[1],
+            error=str(exc),
+        )
+        return None
+
+    bridge.start()
+    return bridge
+
+
+__all__ = [
+    "WaveHubBridge",
+    "WaveHubBridgeError",
+    "maybe_connect_bridge",
+]

--- a/src/rtl_buddy/tools/wave_launcher.py
+++ b/src/rtl_buddy/tools/wave_launcher.py
@@ -29,6 +29,7 @@ from .surfer_wcp import (
     WaveControlServer,
     WaveformValueReader,
 )
+from .wave_hub_bridge import maybe_connect_bridge
 
 logger = logging.getLogger(__name__)
 
@@ -116,6 +117,11 @@ class WaveLauncher:
             ctrl = WaveControlServer(self._surfer_cfg.resolved_ctrl_sock, listener)
             ctrl.start()
 
+        # Opportunistic hub adapter: registers as the `wave` origin client
+        # when a project hub is running. Standalone behavior is unchanged
+        # when no hub is reachable (the bridge is None).
+        hub_bridge = maybe_connect_bridge(listener=listener)
+
         emit_console_text(
             f"Surfer open (PID {proc.pid}). "
             f"Right-click a signal → Go to declaration. "
@@ -131,6 +137,8 @@ class WaveLauncher:
             except subprocess.TimeoutExpired:
                 proc.kill()
         finally:
+            if hub_bridge is not None:
+                hub_bridge.stop()
             listener.stop()
             if ctrl:
                 ctrl.stop()

--- a/tests/test_wave_hub_bridge.py
+++ b/tests/test_wave_hub_bridge.py
@@ -1,0 +1,458 @@
+"""End-to-end tests for ``WaveHubBridge`` against a real HubServer.
+
+The bridge runs in a worker thread, connects to a live asyncio hub
+running in another thread, and we drive the WCP-side events through
+its public observer hook. A fake ``SurferWcpListener`` stand-in
+captures the WCP commands the bridge would send to surfer.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from rtl_buddy.hub import discovery
+from rtl_buddy.hub.protocol import Envelope, Kind, Origin, decode, encode, new_id
+from rtl_buddy.hub.server import HubServer
+from rtl_buddy.tools.wave_hub_bridge import (
+    WaveHubBridge,
+    WaveHubBridgeError,
+    _discover_hub_addr,
+    _parse_hub_addr,
+    maybe_connect_bridge,
+)
+
+
+class _FakeListener:
+    """Captures `send_to_surfer` calls; mirrors the listener observer hook."""
+
+    def __init__(self) -> None:
+        self.sent: list[dict] = []
+        self.event_observer = None
+
+    def send_to_surfer(self, frame: dict) -> None:
+        self.sent.append(frame)
+
+
+# ---------------------------------------------------------------------------
+# asyncio HubServer fixture in its own background thread
+# ---------------------------------------------------------------------------
+
+
+class _HubInThread:
+    """Spin a HubServer on a dedicated asyncio loop in a thread.
+
+    The bridge uses sync TCP; the hub is asyncio. Running the hub in a
+    background thread is the cleanest way to exercise both from one
+    test process.
+    """
+
+    def __init__(self) -> None:
+        self.server: HubServer | None = None
+        self.loop: asyncio.AbstractEventLoop | None = None
+        self.thread: threading.Thread | None = None
+        self.started = threading.Event()
+
+    def start(self) -> tuple[str, int]:
+        ready: dict = {}
+
+        def _runner():
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+            self.loop = loop
+            server = HubServer(host="127.0.0.1", port=0, server_version="0.0.0+test")
+            self.server = server
+
+            async def _async_start():
+                host, port = await server.start()
+                ready["host"] = host
+                ready["port"] = port
+                self.started.set()
+                await server.serve_forever()
+
+            try:
+                loop.run_until_complete(_async_start())
+            except Exception:
+                self.started.set()
+                raise
+            finally:
+                loop.close()
+
+        self.thread = threading.Thread(target=_runner, daemon=True, name="hub-thread")
+        self.thread.start()
+        if not self.started.wait(timeout=5.0):
+            raise TimeoutError("HubServer did not start in time")
+        return ready["host"], ready["port"]
+
+    def stop(self) -> None:
+        if self.server is None or self.loop is None:
+            return
+        future = asyncio.run_coroutine_threadsafe(self.server.shutdown(), self.loop)
+        try:
+            future.result(timeout=5.0)
+        except Exception:
+            pass
+        self.loop.call_soon_threadsafe(self.loop.stop)
+        if self.thread is not None:
+            self.thread.join(timeout=5.0)
+
+
+@pytest.fixture
+def hub_in_thread():
+    h = _HubInThread()
+    h.start()
+    try:
+        yield h
+    finally:
+        h.stop()
+
+
+# ---------------------------------------------------------------------------
+# parse / discovery
+# ---------------------------------------------------------------------------
+
+
+def test_parse_hub_addr_round_trip():
+    assert _parse_hub_addr("127.0.0.1:54321") == ("127.0.0.1", 54321)
+
+
+def test_parse_hub_addr_rejects_no_port():
+    with pytest.raises(WaveHubBridgeError):
+        _parse_hub_addr("no-port-here")
+
+
+def test_parse_hub_addr_rejects_non_integer_port():
+    with pytest.raises(WaveHubBridgeError):
+        _parse_hub_addr("127.0.0.1:abc")
+
+
+def test_discover_uses_env_override(monkeypatch):
+    monkeypatch.setenv("RTL_BUDDY_HUB", "127.0.0.1:7777")
+    assert _discover_hub_addr(project_root=Path("/nonexistent")) == (
+        "127.0.0.1",
+        7777,
+    )
+
+
+def test_discover_returns_none_when_absent(tmp_path: Path, monkeypatch):
+    monkeypatch.delenv("RTL_BUDDY_HUB", raising=False)
+    monkeypatch.chdir(tmp_path)
+    assert _discover_hub_addr(project_root=tmp_path) is None
+
+
+def test_discover_uses_project_root_hub_json(tmp_path: Path, monkeypatch):
+    import os
+
+    monkeypatch.delenv("RTL_BUDDY_HUB", raising=False)
+    discovery.write_record(
+        tmp_path,
+        pid=os.getpid(),
+        tcp="127.0.0.1:65432",
+        server_version="0.0.0+test",
+    )
+    monkeypatch.chdir(tmp_path)
+    assert _discover_hub_addr(project_root=tmp_path) == ("127.0.0.1", 65432)
+
+
+def test_discover_skips_stale_record(tmp_path: Path, monkeypatch):
+    monkeypatch.delenv("RTL_BUDDY_HUB", raising=False)
+    cfg_dir = tmp_path / ".rtl-buddy"
+    cfg_dir.mkdir()
+    (cfg_dir / "hub.json").write_text(
+        '{"v": 1, "pid": 999999, "tcp": "127.0.0.1:1",'
+        ' "server_version": "0.0",'
+        f' "project_root": "{tmp_path}",'
+        ' "started_at": "2026-01-01T00:00:00+00:00"}',
+        encoding="utf-8",
+    )
+    assert _discover_hub_addr(project_root=tmp_path) is None
+
+
+# ---------------------------------------------------------------------------
+# connect / handshake
+# ---------------------------------------------------------------------------
+
+
+def test_connect_hello_welcome(hub_in_thread: _HubInThread):
+    host, port = hub_in_thread.server.host, hub_in_thread.server.port  # type: ignore[union-attr]
+    listener = _FakeListener()
+    bridge = WaveHubBridge.connect((host, port), listener=listener)
+    try:
+        # Hub should now have `wave` in its registry.
+        deadline = time.monotonic() + 1.0
+        while time.monotonic() < deadline:
+            if Origin.WAVE in hub_in_thread.server.registered_origins:  # type: ignore[union-attr]
+                break
+            time.sleep(0.02)
+        assert Origin.WAVE in hub_in_thread.server.registered_origins  # type: ignore[union-attr]
+    finally:
+        bridge.stop()
+
+
+def test_connect_refused_when_hub_down():
+    listener = _FakeListener()
+    with pytest.raises(WaveHubBridgeError):
+        WaveHubBridge.connect(("127.0.0.1", 1), listener=listener)
+
+
+def test_maybe_connect_bridge_none_when_no_hub(tmp_path: Path, monkeypatch):
+    monkeypatch.delenv("RTL_BUDDY_HUB", raising=False)
+    monkeypatch.chdir(tmp_path)
+    listener = _FakeListener()
+    assert maybe_connect_bridge(listener=listener, project_root=tmp_path) is None
+
+
+# ---------------------------------------------------------------------------
+# WCP → hub event translation
+# ---------------------------------------------------------------------------
+
+
+def _connect_observer(hub_in_thread: _HubInThread, origin: Origin):
+    """Helper: open a second client to observe broadcasts."""
+
+    import socket
+
+    host, port = hub_in_thread.server.host, hub_in_thread.server.port  # type: ignore[union-attr]
+    sock = socket.create_connection((host, port), timeout=2.0)
+    hello = Envelope(
+        origin=origin,
+        kind=Kind.REQUEST,
+        type="hello",
+        id=new_id(),
+        payload={"client": origin.value, "version": "0.1", "capabilities": []},
+    )
+    sock.sendall(encode(hello).encode("utf-8") + b"\n")
+    buf = b""
+    while b"\n" not in buf:
+        buf += sock.recv(4096)
+    sock.settimeout(2.0)
+    return sock
+
+
+def _recv_line(sock) -> Envelope:
+    buf = b""
+    while b"\n" not in buf:
+        chunk = sock.recv(4096)
+        if not chunk:
+            raise OSError("closed")
+        buf += chunk
+    line, _, _ = buf.partition(b"\n")
+    return decode(line)
+
+
+def test_cursor_moved_becomes_cursor_time_changed(hub_in_thread: _HubInThread):
+    host, port = hub_in_thread.server.host, hub_in_thread.server.port  # type: ignore[union-attr]
+    listener = _FakeListener()
+    bridge = WaveHubBridge.connect((host, port), listener=listener)
+    view_sock = _connect_observer(hub_in_thread, Origin.VIEW)
+    try:
+        bridge.on_wcp_event(
+            "cursor_moved",
+            {"type": "event", "event": "cursor_moved", "timestamp": 12500000},
+        )
+        env = _recv_line(view_sock)
+        assert env.type == "cursor_time_changed"
+        assert env.origin is Origin.WAVE
+        assert env.payload == {"t_fs": "12500000"}
+    finally:
+        view_sock.close()
+        bridge.stop()
+
+
+def test_scope_changed_event_broadcast(hub_in_thread: _HubInThread):
+    host, port = hub_in_thread.server.host, hub_in_thread.server.port  # type: ignore[union-attr]
+    listener = _FakeListener()
+    bridge = WaveHubBridge.connect((host, port), listener=listener)
+    view_sock = _connect_observer(hub_in_thread, Origin.VIEW)
+    try:
+        bridge.on_wcp_event(
+            "scope_changed",
+            {"type": "event", "event": "scope_changed", "scope": "tb.dut.u_fifo"},
+        )
+        env = _recv_line(view_sock)
+        assert env.type == "scope_changed"
+        assert env.payload == {"wave_scope": "tb.dut.u_fifo"}
+    finally:
+        view_sock.close()
+        bridge.stop()
+
+
+def test_goto_declaration_becomes_signal_selected(hub_in_thread: _HubInThread):
+    host, port = hub_in_thread.server.host, hub_in_thread.server.port  # type: ignore[union-attr]
+    listener = _FakeListener()
+    bridge = WaveHubBridge.connect((host, port), listener=listener)
+    view_sock = _connect_observer(hub_in_thread, Origin.VIEW)
+    try:
+        bridge.on_wcp_event(
+            "goto_declaration",
+            {
+                "type": "event",
+                "event": "goto_declaration",
+                "variable": "tb.dut.u_fifo.wr_ptr_q",
+            },
+        )
+        env = _recv_line(view_sock)
+        assert env.type == "signal_selected"
+        assert env.payload == {"signal": "wr_ptr_q", "wave_scope": "tb.dut.u_fifo"}
+    finally:
+        view_sock.close()
+        bridge.stop()
+
+
+def test_malformed_wcp_event_is_dropped(hub_in_thread: _HubInThread):
+    """Bridge swallows malformed events rather than crashing the WCP thread."""
+
+    host, port = hub_in_thread.server.host, hub_in_thread.server.port  # type: ignore[union-attr]
+    listener = _FakeListener()
+    bridge = WaveHubBridge.connect((host, port), listener=listener)
+    try:
+        # No timestamp field — bridge translates to None and drops.
+        bridge.on_wcp_event("cursor_moved", {})
+        # No exception, no message — success.
+    finally:
+        bridge.stop()
+
+
+# ---------------------------------------------------------------------------
+# hub → WCP request handling
+# ---------------------------------------------------------------------------
+
+
+def test_wave_add_variables_translates_to_wcp_command(hub_in_thread: _HubInThread):
+    host, port = hub_in_thread.server.host, hub_in_thread.server.port  # type: ignore[union-attr]
+    listener = _FakeListener()
+    bridge = WaveHubBridge.connect((host, port), listener=listener)
+    bridge.start()
+    view_sock = _connect_observer(hub_in_thread, Origin.VIEW)
+    try:
+        req = Envelope(
+            origin=Origin.VIEW,
+            kind=Kind.REQUEST,
+            type="wave_add_variables",
+            id=new_id(),
+            payload={"variables": ["tb.dut.x", "tb.dut.y"]},
+        )
+        view_sock.sendall(encode(req).encode("utf-8") + b"\n")
+        resp = _recv_line(view_sock)
+        assert resp.kind is Kind.RESPONSE
+        assert resp.id == req.id
+        assert resp.payload == {"ids": []}
+        # And the bridge translated the request into a WCP command.
+        deadline = time.monotonic() + 1.0
+        while time.monotonic() < deadline and not listener.sent:
+            time.sleep(0.02)
+        assert listener.sent == [
+            {
+                "type": "command",
+                "command": "add_variables",
+                "variables": ["tb.dut.x", "tb.dut.y"],
+            }
+        ]
+    finally:
+        view_sock.close()
+        bridge.stop()
+
+
+def test_wave_set_cursor_translates_to_wcp_command(hub_in_thread: _HubInThread):
+    host, port = hub_in_thread.server.host, hub_in_thread.server.port  # type: ignore[union-attr]
+    listener = _FakeListener()
+    bridge = WaveHubBridge.connect((host, port), listener=listener)
+    bridge.start()
+    view_sock = _connect_observer(hub_in_thread, Origin.VIEW)
+    try:
+        req = Envelope(
+            origin=Origin.VIEW,
+            kind=Kind.REQUEST,
+            type="wave_set_cursor",
+            id=new_id(),
+            payload={"t_fs": "12500000"},
+        )
+        view_sock.sendall(encode(req).encode("utf-8") + b"\n")
+        resp = _recv_line(view_sock)
+        assert resp.kind is Kind.RESPONSE
+        assert resp.payload == {"ok": True}
+
+        deadline = time.monotonic() + 1.0
+        while time.monotonic() < deadline and not listener.sent:
+            time.sleep(0.02)
+        assert listener.sent == [
+            {
+                "type": "command",
+                "command": "set_cursor",
+                "timestamp": 12500000,
+            }
+        ]
+    finally:
+        view_sock.close()
+        bridge.stop()
+
+
+def test_wave_set_scope_translates_to_add_scope_until_fork(
+    hub_in_thread: _HubInThread,
+):
+    """Per §9.3, surfer's fork will add `set_scope`; until then, `add_scope`."""
+
+    host, port = hub_in_thread.server.host, hub_in_thread.server.port  # type: ignore[union-attr]
+    listener = _FakeListener()
+    bridge = WaveHubBridge.connect((host, port), listener=listener)
+    bridge.start()
+    view_sock = _connect_observer(hub_in_thread, Origin.VIEW)
+    try:
+        req = Envelope(
+            origin=Origin.VIEW,
+            kind=Kind.REQUEST,
+            type="wave_set_scope",
+            id=new_id(),
+            payload={"wave_scope": "tb.dut.u_fifo"},
+        )
+        view_sock.sendall(encode(req).encode("utf-8") + b"\n")
+        resp = _recv_line(view_sock)
+        assert resp.kind is Kind.RESPONSE
+        assert resp.payload == {"ok": True}
+
+        deadline = time.monotonic() + 1.0
+        while time.monotonic() < deadline and not listener.sent:
+            time.sleep(0.02)
+        assert listener.sent == [
+            {
+                "type": "command",
+                "command": "add_scope",
+                "scope": "tb.dut.u_fifo",
+            }
+        ]
+    finally:
+        view_sock.close()
+        bridge.stop()
+
+
+# ---------------------------------------------------------------------------
+# bye / cleanup
+# ---------------------------------------------------------------------------
+
+
+def test_stop_unregisters_from_hub(hub_in_thread: _HubInThread):
+    host, port = hub_in_thread.server.host, hub_in_thread.server.port  # type: ignore[union-attr]
+    listener = _FakeListener()
+    bridge = WaveHubBridge.connect((host, port), listener=listener)
+    bridge.start()
+    deadline = time.monotonic() + 1.0
+    while (
+        time.monotonic() < deadline
+        and Origin.WAVE not in hub_in_thread.server.registered_origins
+    ):  # type: ignore[union-attr]
+        time.sleep(0.02)
+    assert Origin.WAVE in hub_in_thread.server.registered_origins  # type: ignore[union-attr]
+
+    bridge.stop()
+
+    deadline = time.monotonic() + 1.0
+    while (
+        time.monotonic() < deadline
+        and Origin.WAVE in hub_in_thread.server.registered_origins
+    ):  # type: ignore[union-attr]
+        time.sleep(0.02)
+    assert Origin.WAVE not in hub_in_thread.server.registered_origins  # type: ignore[union-attr]


### PR DESCRIPTION
## Summary

PR 4 of rtl-buddy/rtl_buddy#115. Wires \`rb wave\` to the rtl-buddy-hub as the wave-origin client. **Opportunistic** — when no hub is running, \`rb wave\` continues standalone exactly as before (spec §4.5's graceful-degradation guarantee).

### New: \`src/rtl_buddy/tools/wave_hub_bridge.py\`

\`WaveHubBridge\`:

- **Discovery** — \`\$RTL_BUDDY_HUB\` override, then walk-up \`.rtl-buddy/hub.json\` with stale-pid filter.
- **Handshake** — TCP connect + \`hello\`/\`welcome\` with the WAVE origin and capability list.
- **WCP → hub event translation**:
  | WCP event | Hub event | Payload |
  |---|---|---|
  | \`cursor_moved\` | \`cursor_time_changed\` | \`{t_fs: str(int)}\` |
  | \`scope_changed\` | \`scope_changed\` | \`{wave_scope}\` |
  | \`goto_declaration\` | \`signal_selected\` | \`{signal, wave_scope}\` |

  The hub then synthesizes the §7 \`selection_changed\` broadcast.

- **hub → WCP command translation**:
  | Hub request | WCP command | Response |
  |---|---|---|
  | \`wave_add_variables\` | \`add_variables\` | \`{ids: []}\` |
  | \`wave_set_cursor\` | \`set_cursor\` | \`{ok: true}\` |
  | \`wave_set_scope\` | \`add_scope\` | \`{ok: true}\` |

  \`set_scope\` is documented as a §9.3 fork addition; until it ships, the bridge maps onto \`add_scope\` and the docstring flags the upgrade path.

- Polite \`bye\` + socket close on \`stop()\`.

### Modified: \`src/rtl_buddy/tools/surfer_wcp.py\`

Adds one hook to \`SurferWcpListener\`:

\`\`\`python
self.event_observer: Callable[[str, dict], None] | None = None
\`\`\`

The bridge attaches itself; the WCP listener stays hub-agnostic.

### Modified: \`src/rtl_buddy/tools/wave_launcher.py\`

Calls \`maybe_connect_bridge(listener=...)\` after the WCP listener thread starts. \`None\` return → no hub in this project, run standalone.

## Sequence (full happy path)

```
1. rb hub start &                 (PR 1 + 2 + 3)
2. rb wave my_test
     → spawns surfer + WCP listener thread
     → discovers hub via .rtl-buddy/hub.json
     → connects, hello/welcome as WAVE
     → attaches event_observer to WCP listener
3. User right-clicks a signal in surfer
     → WCP goto_declaration {variable: \"tb.dut.u_fifo.wr_ptr_q\"}
     → bridge emits hub signal_selected {signal: \"wr_ptr_q\", wave_scope: \"tb.dut.u_fifo\"}
     → hub broadcasts to view + src clients
4. Viewer clicks an instance
     → hub forwards wave_add_variables {variables: [...]} to bridge
     → bridge sends WCP add_variables to surfer
     → bridge responds {ids: []} to hub → viewer
```

## What's next

- **PR 5** — viewer HTTP/WS layer + \`rb hub --serve-viewer\` (browser-side hub client).
- Future — WCP response correlation for \`wave_add_variables\` (currently optimistic-ids); end-to-end test once viewer client lands.

## Test plan
- [x] \`uv run pytest -q --no-cov\` — 524 passed (18 new)
- [x] \`uv run ruff check src tests\` — clean
- [x] \`uv run ruff format --check src tests\` — clean
- [x] Test harness spins a real HubServer in a background asyncio thread so the bridge's sync TCP exercises real wire traffic
- [x] Standalone-mode regression: \`maybe_connect_bridge\` returns \`None\` cleanly when no hub is reachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)