### PR TITLE
feat(hub): per-peer status indicators (closes #124, partial)

### DIFF
--- a/src/rtl_buddy/hub/cli.py
+++ b/src/rtl_buddy/hub/cli.py
@@ -31,6 +31,7 @@ from ..logging_utils import emit_console_text, log_event
 from . import config as hub_config
 from . import discovery
 from . import loop as hub_loop
+from . import status_client
 
 
 logger = logging.getLogger(__name__)
@@ -193,8 +194,38 @@ def cmd_status() -> None:
         emit_console_text(f"  viewer_url     : http://127.0.0.1:{record.http_port}/")
     emit_console_text(f"  server_version : {record.server_version}")
     emit_console_text(f"  started_at     : {record.started_at}")
+
     if not live:
         raise typer.Exit(code=1)
+
+    # Live hub: query the registry over TCP and render per-peer state.
+    # A connect / hello failure is a peer-level note, not a fatal — the
+    # hub may still be running but mid-shutdown, or have just accepted
+    # another CLI client (origin-cli dedup, §3.2). The user sees the
+    # underlying error verbatim either way.
+    host, _, port_str = record.tcp.rpartition(":")
+    try:
+        port = int(port_str)
+    except ValueError:
+        emit_console_text(
+            f"  peers          : (unparseable tcp address {record.tcp!r})",
+            style="yellow",
+        )
+        return
+
+    emit_console_text("  peers")
+    try:
+        registered = status_client.query_registered_origins_sync(host, port)
+    except status_client.HubStatusQueryError as exc:
+        emit_console_text(f"    (query failed: {exc})", style="yellow")
+        return
+
+    registered_set = {o for o in registered if o != "cli"}
+    for origin in status_client.DISPLAY_ORIGINS:
+        if origin in registered_set:
+            emit_console_text(f"    {origin:<6} CONNECTED", style="green")
+        else:
+            emit_console_text(f"    {origin:<6} not connected", style="yellow")
 
 
 @app.command("log", help="tail the hub log")

--- a/src/rtl_buddy/hub/status_client.py
+++ b/src/rtl_buddy/hub/status_client.py
@@ -1,0 +1,96 @@
+"""Tiny TCP client used by ``rb hub status`` to query a running hub.
+
+The hub's ``hello`` / ``welcome`` handshake (§3 of the protocol spec)
+already carries the registry — every welcome envelope lists every
+origin currently registered with the server. This module opens a
+fresh connection, runs the handshake as :attr:`Origin.CLI`, reads the
+welcome, and disconnects. Cheap, single round trip, no dependency on
+the optional HTTP layer.
+
+The hub's per-origin dedup means at most one ``cli`` query is in
+flight at a time; a second concurrent ``rb hub status`` would be
+refused with ``not_connected``. That is acceptable for v1 — status
+queries are interactive and short-lived.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Sequence
+
+from .protocol import Envelope, Kind, Origin, decode, encode, new_id
+
+DEFAULT_TIMEOUT = 3.0
+
+
+class HubStatusQueryError(Exception):
+    """Raised when the hub doesn't respond to a status query.
+
+    The message carries the underlying cause (connect failed, no
+    welcome, malformed welcome). Callers render it as a peer-state
+    line in :func:`rb hub status` rather than re-raising.
+    """
+
+
+async def query_registered_origins(
+    host: str, port: int, *, timeout: float = DEFAULT_TIMEOUT
+) -> list[str]:
+    """Run ``hello`` against the hub and return the welcome's registry.
+
+    Returns the ``registered_clients`` field from the welcome envelope
+    as a list of origin strings. The hub adds the calling CLI to the
+    registry *before* sending the welcome (§3.2 of the spec), so the
+    returned list includes ``"cli"``; callers filter that out when
+    rendering peer state.
+    """
+    try:
+        reader, writer = await asyncio.wait_for(
+            asyncio.open_connection(host, port), timeout=timeout
+        )
+    except (OSError, asyncio.TimeoutError) as exc:
+        raise HubStatusQueryError(f"connect to {host}:{port}: {exc}") from exc
+
+    try:
+        hello = Envelope(
+            origin=Origin.CLI,
+            kind=Kind.REQUEST,
+            type="hello",
+            id=new_id(),
+            payload={
+                "client": Origin.CLI.value,
+                "version": "0.1.0",
+                "capabilities": [],
+            },
+        )
+        writer.write(encode(hello).encode("utf-8") + b"\n")
+        await writer.drain()
+        line = await asyncio.wait_for(reader.readline(), timeout=timeout)
+        if not line:
+            raise HubStatusQueryError("hub closed connection before welcome")
+        env = decode(line)
+        if env.type != "welcome":
+            raise HubStatusQueryError(f"expected welcome, got {env.type!r}")
+        clients = env.payload.get("registered_clients", [])
+        if not isinstance(clients, list):
+            raise HubStatusQueryError("welcome.registered_clients is not a list")
+        return [str(c) for c in clients]
+    finally:
+        writer.close()
+        try:
+            await writer.wait_closed()
+        except Exception:
+            pass
+
+
+def query_registered_origins_sync(
+    host: str, port: int, *, timeout: float = DEFAULT_TIMEOUT
+) -> list[str]:
+    """Synchronous wrapper around :func:`query_registered_origins`."""
+    return asyncio.run(query_registered_origins(host, port, timeout=timeout))
+
+
+# Origins users of ``rb hub status`` care about. ``cli`` is excluded
+# because it represents the status query itself; the remaining three
+# are the v1 production peers (viewer SPA, ``rb wave`` bridge, editor
+# adapter — nvim today, more later — registers as ``src``).
+DISPLAY_ORIGINS: Sequence[str] = ("view", "wave", "src")

--- a/tests/test_hub_status_client.py
+++ b/tests/test_hub_status_client.py
@@ -1,0 +1,115 @@
+"""Tests for ``rtl_buddy.hub.status_client`` (issue #124).
+
+The status client opens a TCP socket against a running hub, runs the
+hello/welcome handshake as ``Origin.CLI``, reads the registry from
+the welcome envelope, and disconnects. These tests pin that round
+trip against the real :class:`HubServer` fixture and the error path
+when no hub is listening.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import AsyncIterator
+
+import pytest
+import pytest_asyncio
+
+from rtl_buddy.hub.protocol import Envelope, Kind, Origin, encode, new_id
+from rtl_buddy.hub.server import HubServer
+from rtl_buddy.hub.status_client import (
+    DISPLAY_ORIGINS,
+    HubStatusQueryError,
+    query_registered_origins,
+)
+
+
+@pytest_asyncio.fixture
+async def server() -> AsyncIterator[HubServer]:
+    s = HubServer(host="127.0.0.1", port=0, server_version="0.0.0+test")
+    await s.start()
+    serve_task = asyncio.create_task(s.serve_forever())
+    try:
+        yield s
+    finally:
+        await s.shutdown()
+        serve_task.cancel()
+        try:
+            await serve_task
+        except (asyncio.CancelledError, Exception):
+            pass
+
+
+async def _register(server: HubServer, origin: Origin) -> asyncio.StreamWriter:
+    """Background-register an origin so the next status query sees it."""
+    reader, writer = await asyncio.open_connection(server.host, server.port)
+    hello = Envelope(
+        origin=origin,
+        kind=Kind.REQUEST,
+        type="hello",
+        id=new_id(),
+        payload={
+            "client": origin.value,
+            "version": "0.1.0",
+            "capabilities": [],
+        },
+    )
+    writer.write(encode(hello).encode("utf-8") + b"\n")
+    await writer.drain()
+    await asyncio.wait_for(reader.readline(), timeout=1.0)  # consume welcome
+    return writer
+
+
+@pytest.mark.asyncio
+async def test_query_returns_registered_origins(server: HubServer):
+    """A status query against a hub with two peers registered should
+    report both alongside the calling ``cli`` origin."""
+    wave_writer = await _register(server, Origin.WAVE)
+    src_writer = await _register(server, Origin.SRC)
+    try:
+        registered = await query_registered_origins(server.host, server.port)
+    finally:
+        wave_writer.close()
+        await wave_writer.wait_closed()
+        src_writer.close()
+        await src_writer.wait_closed()
+    # The CLI origin appears because the query itself just registered.
+    assert "cli" in registered
+    assert "wave" in registered
+    assert "src" in registered
+    # The view peer is *not* connected in this fixture — confirm the
+    # query doesn't fabricate it.
+    assert "view" not in registered
+
+
+@pytest.mark.asyncio
+async def test_query_against_no_hub_raises():
+    """A connect to a dead port surfaces :class:`HubStatusQueryError`
+    rather than a bare ``OSError`` — the CLI renders the wrapped
+    message as a peer-state warning."""
+    with pytest.raises(HubStatusQueryError, match="connect to"):
+        await query_registered_origins("127.0.0.1", 1, timeout=0.5)
+
+
+@pytest.mark.asyncio
+async def test_query_disconnect_clears_cli_slot(server: HubServer):
+    """Status queries are short-lived; back-to-back queries should
+    succeed (the previous CLI client has disconnected before the next
+    hello runs). Pins the "no leaked CLI registration" guarantee."""
+    first = await query_registered_origins(server.host, server.port)
+    assert "cli" in first
+    # The hub broadcasts ``bye`` on disconnect; let the registry settle
+    # before the second hello.
+    await asyncio.sleep(0.05)
+    second = await query_registered_origins(server.host, server.port)
+    assert "cli" in second
+
+
+def test_display_origins_does_not_include_cli():
+    """``cli`` represents the status query itself; rendering it as a
+    peer would always be confusing. Pin the exclusion."""
+    assert "cli" not in DISPLAY_ORIGINS
+    # View / wave / editor (src) are the v1 production peers.
+    assert "view" in DISPLAY_ORIGINS
+    assert "wave" in DISPLAY_ORIGINS
+    assert "src" in DISPLAY_ORIGINS


### PR DESCRIPTION
Extend ``rb hub status`` to show per-peer connection state with
red/yellow/green colouring, completing the load-bearing item from
#115's original "status colour indicators" subtask. The hub itself
already rendered green-on-RUNNING / red-on-STALE; what was missing
was per-peer state (viewer, wave bridge, editor adapter).

Approach: query the running hub's registry over its existing TCP
surface. The ``hello`` / ``welcome`` handshake already carries
``registered_clients`` (server.py:366), so the new
:func:`status_client.query_registered_origins` opens a connection
as :attr:`Origin.CLI`, reads the welcome, disconnects. Single
round trip, no dependency on the optional ``--serve-viewer`` HTTP
layer, no new endpoint.

Rendering after the existing hub-state block:

```
  peers
    view   CONNECTED      (green)
    wave   not connected  (yellow)
    src    not connected  (yellow)
```

A query failure (hub mid-shutdown, another CLI client already
registered against the dedup guard, or any transport error) is
surfaced as a peer-level note in yellow, not a fatal — the hub
itself is still reported as RUNNING, the user reads the wrapped
error and retries.

New module ``src/rtl_buddy/hub/status_client.py`` (~85 LOC):

* :func:`query_registered_origins` (async) — the hello/welcome
  round-trip. Wraps ``ConnectionError`` / ``TimeoutError`` in
  :class:`HubStatusQueryError` so the CLI path doesn't leak
  asyncio internals.
* :func:`query_registered_origins_sync` — :func:`asyncio.run`
  wrapper for the typer command.
* :data:`DISPLAY_ORIGINS` — ``("view", "wave", "src")``; ``cli``
  is excluded (it represents the status query itself).

CLI: ``cmd_status`` now parses the discovery record's ``tcp``
field (``host:port``), calls the sync wrapper, and renders the
peer table. Unparseable ``tcp`` falls through to a single yellow
"unparseable" line rather than crashing.

Tests (``tests/test_hub_status_client.py``):

* Round-trip against a live :class:`HubServer` with two peers
  registered → sees both plus ``cli``; absent peers omitted.
* Connect to a dead port → :class:`HubStatusQueryError` with the
  underlying cause in the message.
* Back-to-back queries succeed (no leaked CLI registration
  between calls).
* :data:`DISPLAY_ORIGINS` excludes ``cli`` and includes the three
  v1 peers.

Validation: 4/4 new tests pass; full suite 541 passed (with a few
pre-existing flakes in ``test_wave_hub_bridge.py`` when the whole
suite runs — they pass in isolation and reproduce on ``main``
without this change). ruff / format / mypy clean; CLI reference
generator reports no drift.

Remaining acceptance items from #124:

* Origin-tag loop prevention test — already covered on ``main``
  by ``test_state_event_broadcast_skips_origin`` in
  ``test_hub_server.py`` (per the docstring "wave + src must
  receive it; view must not echo back"); confirming in this
  commit's review window.
* 50 MB RSS budget on a 500-instance design — hardware-dependent
  spot-check; recommend relaxing the criterion to "no obvious
  unbounded growth" rather than committing a benchmark script
  that varies by machine.
* ≥85% coverage on ``resolver.py`` + envelope code — better as a
  CI configuration change (``--fail-under=85`` scoped to the two
  modules) than scope creep in this PR.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>