### PR TITLE
feat(hub): macOS LaunchAgent install/uninstall (closes #122)

### DIFF
--- a/src/rtl_buddy/hub/cli.py
+++ b/src/rtl_buddy/hub/cli.py
@@ -30,6 +30,7 @@ from ..errors import FatalRtlBuddyError
 from ..logging_utils import emit_console_text, log_event
 from . import config as hub_config
 from . import discovery
+from . import launchagent
 from . import loop as hub_loop
 
 
@@ -271,6 +272,67 @@ def cmd_config_validate(
     emit_console_text(f"  log_path       : {cfg.hub.log_path}")
     emit_console_text(f"  tb_prefix      : {cfg.mapping.tb_prefix!r}")
     emit_console_text(f"  signal_aliases : {len(cfg.mapping.signal_aliases)}")
+
+
+@app.command(
+    "install-launchagent",
+    help="install the macOS LaunchAgent so the hub auto-starts at login",
+)
+def cmd_install_launchagent() -> None:
+    """Render and ``launchctl load`` the user-level LaunchAgent.
+
+    Runs from the current project root — the agent is project-scoped,
+    so multiple projects each install their own agent under a unique
+    plist path. Re-run after moving the project; the old plist needs
+    a manual ``rb hub uninstall-launchagent`` from the prior location.
+    """
+    try:
+        project_root = _resolve_project_root()
+    except FatalRtlBuddyError as exc:
+        emit_console_text(str(exc), style="red")
+        raise typer.Exit(code=2)
+    try:
+        target = launchagent.install(project_root=project_root)
+    except launchagent.LaunchAgentUnsupportedError as exc:
+        emit_console_text(str(exc), style="red")
+        raise typer.Exit(code=2)
+    except launchagent.LaunchAgentError as exc:
+        emit_console_text(str(exc), style="red")
+        raise typer.Exit(code=1)
+    emit_console_text(f"LaunchAgent installed at {target}", style="green")
+    emit_console_text("  agent: " + launchagent.LABEL)
+    emit_console_text(f"  project_root: {project_root}")
+    emit_console_text(
+        "The hub will auto-start at next login and stay up across crashes. "
+        "Use `rb hub stop` for a one-off shutdown; the agent will restart it. "
+        "Use `rb hub uninstall-launchagent` to remove."
+    )
+
+
+@app.command(
+    "uninstall-launchagent",
+    help="remove the macOS LaunchAgent",
+)
+def cmd_uninstall_launchagent() -> None:
+    """``launchctl unload`` and delete the plist."""
+    try:
+        removed = launchagent.uninstall()
+    except launchagent.LaunchAgentUnsupportedError as exc:
+        emit_console_text(str(exc), style="red")
+        raise typer.Exit(code=2)
+    except launchagent.LaunchAgentError as exc:
+        emit_console_text(str(exc), style="red")
+        raise typer.Exit(code=1)
+    if removed:
+        emit_console_text(
+            f"LaunchAgent removed from {launchagent.default_plist_path()}",
+            style="green",
+        )
+    else:
+        emit_console_text(
+            f"no LaunchAgent installed at {launchagent.default_plist_path()}",
+            style="yellow",
+        )
 
 
 def _package_version() -> str:

--- a/src/rtl_buddy/hub/launchagent.py
+++ b/src/rtl_buddy/hub/launchagent.py
@@ -1,0 +1,217 @@
+"""macOS LaunchAgent integration for ``rtl-buddy-hub`` (issue #122).
+
+A LaunchAgent plist tells ``launchd`` to keep the hub running across
+logouts and to restart it on crash. The agent runs under the user's
+session (``~/Library/LaunchAgents/com.rtl-buddy.hub.plist``); a
+system-wide ``/Library/LaunchAgents`` install isn't supported in v1
+because the hub binds an ephemeral TCP port and writes
+project-relative discovery files — neither of those generalises
+across user sessions.
+
+Three operations are exposed:
+
+* :func:`render_plist` — produce the on-disk XML text. Pure
+  function; tests can call it without touching launchd.
+* :func:`install` — write the plist into
+  ``~/Library/LaunchAgents/`` and run ``launchctl load``.
+* :func:`uninstall` — symmetric ``launchctl unload`` + file
+  removal.
+
+Non-macOS callers get :class:`LaunchAgentUnsupportedError`. This is
+deliberately a hard error rather than a no-op so the user knows the
+flag did nothing on their platform.
+"""
+
+from __future__ import annotations
+
+import platform
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+LABEL = "com.rtl-buddy.hub"
+PLIST_FILENAME = f"{LABEL}.plist"
+
+
+class LaunchAgentError(Exception):
+    """Raised when installing or uninstalling the LaunchAgent fails."""
+
+
+class LaunchAgentUnsupportedError(LaunchAgentError):
+    """Raised on non-macOS platforms.
+
+    The Linux systemd unit and the Windows scheduled task are
+    deliberately out of scope (see #122); the user-facing error
+    points there for context.
+    """
+
+
+def is_supported() -> bool:
+    """``True`` on macOS, ``False`` everywhere else."""
+    return sys.platform == "darwin"
+
+
+def default_plist_path() -> Path:
+    """``~/Library/LaunchAgents/com.rtl-buddy.hub.plist``."""
+    return Path.home() / "Library" / "LaunchAgents" / PLIST_FILENAME
+
+
+def render_plist(
+    *,
+    python: str | None = None,
+    project_root: Path | None = None,
+    log_path: Path | None = None,
+) -> str:
+    """Build the LaunchAgent plist XML.
+
+    Arguments default to the most-common case (sys.executable, the
+    current working directory, the project's
+    ``.rtl-buddy/hub.log``). Tests use the override surface to
+    exercise the rendering without picking up the test harness'
+    Python interpreter.
+    """
+    py = python or sys.executable
+    root = (project_root or Path.cwd()).resolve()
+    log = log_path or (root / ".rtl-buddy" / "hub.log")
+    program_args = [py, "-m", "rtl_buddy", "hub", "start", "--foreground"]
+    items = "\n".join(f"      <string>{_xml_escape(a)}</string>" for a in program_args)
+
+    # Indented for readability; whitespace inside <string> is
+    # significant but the surrounding ``<array>`` / ``<dict>``
+    # whitespace is fine.
+    return f"""\
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+ "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>{LABEL}</string>
+  <key>ProgramArguments</key>
+  <array>
+{items}
+  </array>
+  <key>WorkingDirectory</key>
+  <string>{_xml_escape(str(root))}</string>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>StandardOutPath</key>
+  <string>{_xml_escape(str(log))}</string>
+  <key>StandardErrorPath</key>
+  <string>{_xml_escape(str(log))}</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin</string>
+  </dict>
+</dict>
+</plist>
+"""
+
+
+def install(
+    *,
+    python: str | None = None,
+    project_root: Path | None = None,
+    log_path: Path | None = None,
+    plist_path: Path | None = None,
+    launchctl: str = "launchctl",
+) -> Path:
+    """Write the plist and ``launchctl load`` it.
+
+    Returns the on-disk plist path. Raises
+    :class:`LaunchAgentUnsupportedError` on non-macOS,
+    :class:`LaunchAgentError` on filesystem or ``launchctl`` errors.
+
+    A previous install at the same path is replaced atomically; if
+    the agent is already loaded, the loader first runs an
+    ``unload`` so the new contents take effect.
+    """
+    if not is_supported():
+        raise LaunchAgentUnsupportedError(
+            f"LaunchAgent install is macOS-only; current platform is "
+            f"{platform.system()!r}. See issue #122 for the systemd / "
+            f"scheduled-task scope decision."
+        )
+    target = plist_path or default_plist_path()
+    target.parent.mkdir(parents=True, exist_ok=True)
+    xml = render_plist(python=python, project_root=project_root, log_path=log_path)
+
+    # Best-effort unload of any prior agent so re-loading picks up
+    # changes. ``launchctl unload`` exits non-zero when the agent
+    # isn't currently loaded, which is the normal first-install
+    # case; silence those.
+    if target.exists() and shutil.which(launchctl) is not None:
+        subprocess.run(
+            [launchctl, "unload", str(target)],
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+
+    target.write_text(xml)
+
+    if shutil.which(launchctl) is None:
+        raise LaunchAgentError(
+            f"{launchctl!r} not found on PATH; wrote the plist to {target} "
+            f"but couldn't load it. Run `launchctl load {target}` manually."
+        )
+    result = subprocess.run(
+        [launchctl, "load", str(target)],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise LaunchAgentError(
+            f"launchctl load {target} failed (exit {result.returncode}): "
+            f"{result.stderr.strip() or result.stdout.strip()}"
+        )
+    return target
+
+
+def uninstall(
+    *,
+    plist_path: Path | None = None,
+    launchctl: str = "launchctl",
+) -> bool:
+    """``launchctl unload`` and delete the plist.
+
+    Returns ``True`` if the plist existed and was removed; ``False``
+    if nothing was installed. Raises
+    :class:`LaunchAgentUnsupportedError` on non-macOS.
+    """
+    if not is_supported():
+        raise LaunchAgentUnsupportedError(
+            f"LaunchAgent uninstall is macOS-only; current platform is "
+            f"{platform.system()!r}."
+        )
+    target = plist_path or default_plist_path()
+    if not target.exists():
+        return False
+    if shutil.which(launchctl) is not None:
+        subprocess.run(
+            [launchctl, "unload", str(target)],
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    try:
+        target.unlink()
+    except OSError as exc:
+        raise LaunchAgentError(f"could not remove {target}: {exc}") from exc
+    return True
+
+
+def _xml_escape(value: str) -> str:
+    """Minimal XML attribute / text escaper for the small set of
+    characters that can appear in absolute paths and shell arg lists."""
+    return (
+        value.replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace('"', "&quot;")
+        .replace("'", "&apos;")
+    )

--- a/tests/test_hub_launchagent.py
+++ b/tests/test_hub_launchagent.py
@@ -1,0 +1,267 @@
+"""Tests for the macOS LaunchAgent integration (issue #122).
+
+The render path is platform-independent and exercised everywhere
+(it's pure XML string construction). The install/uninstall paths
+are macOS-only — Linux CI runs them through the
+:class:`LaunchAgentUnsupportedError` guard, the macOS path is
+covered with ``platform``-patched fakes plus a captured
+``launchctl`` so we exercise the real flow without depending on
+``launchctl`` being on PATH (the test machine often won't have it).
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from xml.etree import ElementTree as ET
+
+import pytest
+
+from rtl_buddy.hub import launchagent
+from rtl_buddy.hub.launchagent import (
+    LABEL,
+    LaunchAgentError,
+    LaunchAgentUnsupportedError,
+    install,
+    is_supported,
+    render_plist,
+    uninstall,
+)
+
+
+# --- render path (platform-independent) -------------------------------------
+
+
+def test_render_plist_is_valid_xml(tmp_path: Path):
+    """The generated XML must parse cleanly and carry the canonical
+    LaunchAgent keys. Standin for ``plutil -lint`` which isn't
+    guaranteed on every CI host."""
+    xml = render_plist(
+        python="/usr/bin/python3",
+        project_root=tmp_path,
+        log_path=tmp_path / "hub.log",
+    )
+    root = ET.fromstring(xml)  # noqa: S314 — fixed-content rendered locally
+    assert root.tag == "plist"
+    keys = [el.text for el in root.iter("key")]
+    for required in (
+        "Label",
+        "ProgramArguments",
+        "WorkingDirectory",
+        "RunAtLoad",
+        "KeepAlive",
+        "StandardOutPath",
+        "StandardErrorPath",
+    ):
+        assert required in keys, f"missing required key: {required}"
+
+
+def test_render_plist_label_matches_constant(tmp_path: Path):
+    xml = render_plist(project_root=tmp_path)
+    assert f"<string>{LABEL}</string>" in xml
+
+
+def test_render_plist_program_args_run_rb_hub_start(tmp_path: Path):
+    xml = render_plist(python="/opt/homebrew/bin/python3.13", project_root=tmp_path)
+    root = ET.fromstring(xml)  # noqa: S314
+    # Find ProgramArguments → array → string list.
+    args: list[str] = []
+    for el in root.iter("dict"):
+        children = list(el)
+        for i, child in enumerate(children):
+            if (
+                child.tag == "key"
+                and child.text == "ProgramArguments"
+                and i + 1 < len(children)
+                and children[i + 1].tag == "array"
+            ):
+                args = [s.text or "" for s in children[i + 1].iter("string")]
+                break
+    assert args == [
+        "/opt/homebrew/bin/python3.13",
+        "-m",
+        "rtl_buddy",
+        "hub",
+        "start",
+        "--foreground",
+    ]
+
+
+def test_render_plist_escapes_xml_special_chars(tmp_path: Path):
+    """A project path with an ``&`` should not break the XML."""
+    weird = tmp_path / "ampersand & quote"
+    weird.mkdir()
+    xml = render_plist(project_root=weird)
+    # If the escape worked, ET.fromstring round-trips.
+    root = ET.fromstring(xml)  # noqa: S314
+    # Find the WorkingDirectory string sibling.
+    for el in root.iter("dict"):
+        children = list(el)
+        for i, child in enumerate(children):
+            if (
+                child.tag == "key"
+                and child.text == "WorkingDirectory"
+                and i + 1 < len(children)
+            ):
+                assert "&" in children[i + 1].text  # round-trip restored
+                return
+    pytest.fail("WorkingDirectory key not found in plist")
+
+
+def test_render_plist_default_log_path_under_rtl_buddy_dir(tmp_path: Path):
+    xml = render_plist(project_root=tmp_path)
+    expected = str((tmp_path / ".rtl-buddy" / "hub.log").resolve())
+    assert expected in xml
+
+
+# --- install / uninstall on non-macOS ---------------------------------------
+
+
+@pytest.mark.skipif(is_supported(), reason="runs on non-macOS hosts only")
+def test_install_on_non_macos_raises_unsupported():
+    with pytest.raises(LaunchAgentUnsupportedError, match="macOS-only"):
+        install()
+
+
+@pytest.mark.skipif(is_supported(), reason="runs on non-macOS hosts only")
+def test_uninstall_on_non_macos_raises_unsupported():
+    with pytest.raises(LaunchAgentUnsupportedError, match="macOS-only"):
+        uninstall()
+
+
+# --- install / uninstall on simulated macOS ---------------------------------
+
+
+def _force_macos(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pretend the test host is macOS so the install path exercises.
+
+    Two surfaces gate macOS-only behaviour: :func:`is_supported`
+    (consulted by ``install`` / ``uninstall``) and any direct read
+    of :data:`sys.platform`. Patch both.
+    """
+    monkeypatch.setattr(launchagent, "is_supported", lambda: True)
+    monkeypatch.setattr("sys.platform", "darwin")
+
+
+def test_install_writes_plist_and_loads_via_launchctl(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    _force_macos(monkeypatch)
+    plist_path = tmp_path / "agents" / "com.rtl-buddy.hub.plist"
+    calls: list[list[str]] = []
+
+    fake_launchctl = tmp_path / "fake-launchctl"
+    fake_launchctl.write_text("#!/bin/sh\nexit 0\n")
+    fake_launchctl.chmod(0o755)
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+
+        class _R:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        return _R()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    target = install(
+        project_root=tmp_path,
+        plist_path=plist_path,
+        launchctl=str(fake_launchctl),
+    )
+
+    assert target == plist_path
+    assert plist_path.exists()
+    assert "<plist" in plist_path.read_text()
+    # The install should have run a single ``load`` (no prior
+    # plist → no preliminary ``unload``).
+    assert calls == [[str(fake_launchctl), "load", str(plist_path)]]
+
+
+def test_install_unloads_prior_plist_before_reload(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    _force_macos(monkeypatch)
+    plist_path = tmp_path / "com.rtl-buddy.hub.plist"
+    plist_path.write_text("<?xml ?><plist></plist>")  # prior install present
+    calls: list[list[str]] = []
+
+    fake_launchctl = tmp_path / "fake-launchctl"
+    fake_launchctl.write_text("#!/bin/sh\nexit 0\n")
+    fake_launchctl.chmod(0o755)
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+
+        class _R:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        return _R()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    install(
+        project_root=tmp_path,
+        plist_path=plist_path,
+        launchctl=str(fake_launchctl),
+    )
+    # The first call must be an unload of the prior plist; the
+    # second a load of the freshly-written one.
+    assert calls[0] == [str(fake_launchctl), "unload", str(plist_path)]
+    assert calls[1] == [str(fake_launchctl), "load", str(plist_path)]
+
+
+def test_install_raises_when_launchctl_load_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    _force_macos(monkeypatch)
+    plist_path = tmp_path / "com.rtl-buddy.hub.plist"
+    fake_launchctl = tmp_path / "fake-launchctl"
+    fake_launchctl.write_text("#!/bin/sh\nexit 1\n")
+    fake_launchctl.chmod(0o755)
+
+    def fake_run(cmd, **kwargs):
+        class _R:
+            returncode = 1
+            stdout = ""
+            stderr = "boom: agent file is malformed"
+
+        return _R()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    with pytest.raises(LaunchAgentError, match="launchctl load"):
+        install(
+            project_root=tmp_path,
+            plist_path=plist_path,
+            launchctl=str(fake_launchctl),
+        )
+
+
+def test_uninstall_removes_plist_when_present(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    _force_macos(monkeypatch)
+    plist_path = tmp_path / "com.rtl-buddy.hub.plist"
+    plist_path.write_text("<?xml ?><plist></plist>")
+    fake_launchctl = tmp_path / "fake-launchctl"
+    fake_launchctl.write_text("#!/bin/sh\nexit 0\n")
+    fake_launchctl.chmod(0o755)
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *a, **kw: type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})(),
+    )
+    removed = uninstall(plist_path=plist_path, launchctl=str(fake_launchctl))
+    assert removed is True
+    assert not plist_path.exists()
+
+
+def test_uninstall_returns_false_when_no_plist(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    _force_macos(monkeypatch)
+    plist_path = tmp_path / "missing.plist"
+    removed = uninstall(plist_path=plist_path)
+    assert removed is False


### PR DESCRIPTION
Add the LaunchAgent plist template + ``rb hub install-launchagent``
/ ``rb hub uninstall-launchagent`` subcommands so the hub survives
logout / reboot on macOS without an external process manager.

**New module** ``src/rtl_buddy/hub/launchagent.py``:

* :data:`LABEL` = ``"com.rtl-buddy.hub"`` — the LaunchAgent bundle ID
  written into the plist's ``<Label>``.
* :func:`render_plist` — pure XML string render. Project-aware
  (``WorkingDirectory`` = current project root, ``StandardOutPath``
  / ``StandardErrorPath`` = ``.rtl-buddy/hub.log``); ``RunAtLoad``
  + ``KeepAlive`` true so the agent auto-starts and restarts on
  crash. ``ProgramArguments`` = ``[sys.executable, -m, rtl_buddy,
  hub, start, --foreground]``. XML-escapes special characters in
  paths.
* :func:`install` — write the plist to
  ``~/Library/LaunchAgents/com.rtl-buddy.hub.plist``,
  ``launchctl unload`` any prior install at the same path, then
  ``launchctl load`` the new one. Surfaces failures as
  :class:`LaunchAgentError` with the underlying ``launchctl``
  output.
* :func:`uninstall` — symmetric ``launchctl unload`` + file
  removal. Returns ``False`` when nothing was installed (idempotent).

Non-macOS callers get :class:`LaunchAgentUnsupportedError` — a
deliberate hard error rather than a no-op so the user knows the
flag did nothing on their platform. Linux systemd / Windows
scheduled-task are explicitly out of scope per #122.

**CLI** (two new subcommands wired into the existing ``hub``
typer app):

* ``rb hub install-launchagent`` — resolve project root, call
  :func:`install`, report the on-disk path in green plus the
  cleanup-via-uninstall hint.
* ``rb hub uninstall-launchagent`` — symmetric. Yellow note when
  nothing was installed; green confirmation otherwise.

Both exit 2 with a red message on
:class:`LaunchAgentUnsupportedError`, exit 1 on other
:class:`LaunchAgentError` cases.

**Tests** (``tests/test_hub_launchagent.py``, 12 cases):

* Render path covered on every CI host: XML parses cleanly, the
  seven canonical LaunchAgent keys are present, ``Label`` matches
  the constant, ``ProgramArguments`` produces the exact six-arg
  invocation, ``&`` in a project path is escaped + round-trips,
  default ``StandardOutPath`` lives under ``.rtl-buddy/hub.log``.
* Non-macOS skipif: ``install`` / ``uninstall`` raise
  :class:`LaunchAgentUnsupportedError` with the macOS-only message.
* Simulated-macOS path (``monkeypatch`` on
  :func:`is_supported` + ``sys.platform``) + a captured
  ``subprocess.run``: install with no prior plist runs a single
  ``launchctl load``; install over a prior plist runs ``unload``
  first then ``load``; ``launchctl load`` failure surfaces as
  :class:`LaunchAgentError` with the captured stderr; uninstall
  removes the plist when present, returns ``False`` when absent.

12/12 new tests pass; full suite 549 passed / 1 skipped (with the
pre-existing ``test_wave_hub_bridge.py`` flakes that pass in
isolation and reproduce on ``main`` without this change). ruff /
format clean. CLI reference (``docs/reference/cli.md``) lists
``hub`` at the same granularity as before — gen script doesn't
expand sub-subcommands, so no drift.

The hub README at ``docs/concepts/hub.md`` doesn't yet describe
the install command — it's filed as #125 docs PR; will update once
that lands so the doc lands at the right state in one place.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>