### PR TITLE
feat(hub): diagnostics_set event for CDC/RDC/lint broadcasts

### DIFF
--- a/src/rtl_buddy/hub/protocol.py
+++ b/src/rtl_buddy/hub/protocol.py
@@ -275,11 +275,76 @@ def make_welcome(
     )
 
 
+@dataclass(frozen=True, slots=True)
+class Diagnostic:
+    """One finding inside a ``diagnostics_set`` event payload.
+
+    The fields mirror the v1 schema; optional ones default to ``None``
+    and are stripped on the wire by :func:`make_diagnostics_set`.
+    """
+
+    file: str
+    line: int
+    severity: str  # "error" | "warning" | "info" | "hint"
+    message: str
+    col: int | None = None
+    end_line: int | None = None
+    end_col: int | None = None
+    code: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {
+            "file": self.file,
+            "line": self.line,
+            "severity": self.severity,
+            "message": self.message,
+        }
+        if self.col is not None:
+            out["col"] = self.col
+        if self.end_line is not None:
+            out["end_line"] = self.end_line
+        if self.end_col is not None:
+            out["end_col"] = self.end_col
+        if self.code is not None:
+            out["code"] = self.code
+        return out
+
+
+def make_diagnostics_set(
+    *,
+    origin: Origin,
+    source: str,
+    items: list[Diagnostic] | list[dict[str, Any]],
+) -> Envelope:
+    """Construct a ``diagnostics_set`` event envelope.
+
+    ``items`` may be a list of :class:`Diagnostic` dataclasses (which
+    get serialised) or already-dict-shaped payloads (passed through).
+    An empty list is the legal "clear all diagnostics for this source"
+    signal — see the v1 schema description for ``diagnostics_set``.
+    """
+
+    payload_items: list[dict[str, Any]] = []
+    for item in items:
+        if isinstance(item, Diagnostic):
+            payload_items.append(item.to_dict())
+        else:
+            payload_items.append(dict(item))
+    return Envelope(
+        origin=origin,
+        kind=Kind.EVENT,
+        type="diagnostics_set",
+        id=new_id(),
+        payload={"source": source, "items": payload_items},
+    )
+
+
 __all__ = [
     "PROTOCOL_VERSION",
     "Origin",
     "Kind",
     "Envelope",
+    "Diagnostic",
     "HubProtocolError",
     "decode",
     "encode",
@@ -288,4 +353,5 @@ __all__ = [
     "make_error",
     "make_hello",
     "make_welcome",
+    "make_diagnostics_set",
 ]

--- a/src/rtl_buddy/hub/schema/hub-protocol-v1.json
+++ b/src/rtl_buddy/hub/schema/hub-protocol-v1.json
@@ -399,6 +399,45 @@
       }
     },
     {
+      "if": { "properties": { "type": { "const": "diagnostics_set" } }, "required": ["type"] },
+      "then": {
+        "properties": {
+          "kind": { "const": "event" },
+          "payload": {
+            "type": "object",
+            "required": ["source", "items"],
+            "additionalProperties": false,
+            "properties": {
+              "source": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Producer key — e.g. `rtl-buddy-cdc`. Latest-writer-wins per source on the hub's in-memory cache."
+              },
+              "items": {
+                "type": "array",
+                "description": "Full diagnostic set for this source. An empty array clears the source's diagnostics on all clients.",
+                "items": {
+                  "type": "object",
+                  "required": ["file", "line", "severity", "message"],
+                  "additionalProperties": false,
+                  "properties": {
+                    "file":     { "type": "string", "minLength": 1, "description": "Absolute path." },
+                    "line":     { "type": "integer", "minimum": 1, "description": "1-based start line." },
+                    "col":      { "type": "integer", "minimum": 1, "description": "1-based start column; defaults to 1 if absent." },
+                    "end_line": { "type": "integer", "minimum": 1 },
+                    "end_col":  { "type": "integer", "minimum": 1 },
+                    "severity": { "enum": ["error", "warning", "info", "hint"] },
+                    "code":     { "type": "string", "minLength": 1, "description": "Producer-defined rule code, e.g. `CDC-001`." },
+                    "message":  { "type": "string", "minLength": 1 }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
       "if": { "properties": { "type": { "const": "error" } }, "required": ["type"] },
       "then": {
         "properties": {

--- a/src/rtl_buddy/hub/server.py
+++ b/src/rtl_buddy/hub/server.py
@@ -44,6 +44,7 @@ from .protocol import (
     Origin,
     decode,
     encode,
+    make_diagnostics_set,
     make_error,
     make_welcome,
     new_id,
@@ -51,6 +52,7 @@ from .protocol import (
 from .resolver import Resolver
 from .state import (
     CursorTime,
+    DiagnosticsBundle,
     HubState,
     Selection,
     SignalSelection,
@@ -68,6 +70,7 @@ STATE_EVENT_TYPES: frozenset[str] = frozenset(
         "cursor_time_changed",
         "scope_changed",
         "source_focused",
+        "diagnostics_set",
     }
 )
 """Event ``type`` strings that broadcast to all clients except origin.
@@ -366,6 +369,22 @@ class HubServer:
                 registered_clients=self.registered_origins,
             )
         )
+
+        # Replay cached diagnostics so this client sees the same set
+        # everyone else does. Empty-items bundles are replayed too so
+        # a "cleared" source remains visible as "cleared" to late
+        # joiners. We replay using each bundle's original origin so
+        # the loop-prevention origin tag is preserved.
+        for source, bundle in self.state.diagnostics.items():
+            await self._safe_send(
+                conn,
+                make_diagnostics_set(
+                    origin=bundle.origin,
+                    source=source,
+                    items=list(bundle.items),
+                ),
+            )
+
         log_event(
             logger,
             logging.INFO,
@@ -444,6 +463,12 @@ class HubServer:
             elif env.type == "scope_changed":
                 self.state.wave_scope = WaveScope(
                     wave_scope=env.payload["wave_scope"], origin=env.origin
+                )
+            elif env.type == "diagnostics_set":
+                source = env.payload["source"]
+                items = tuple(env.payload["items"])
+                self.state.diagnostics[source] = DiagnosticsBundle(
+                    items=items, origin=env.origin
                 )
         except (KeyError, TypeError) as exc:
             log_event(

--- a/src/rtl_buddy/hub/state.py
+++ b/src/rtl_buddy/hub/state.py
@@ -15,7 +15,7 @@ on top.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Optional
+from typing import Any, Optional
 
 from .protocol import Origin
 
@@ -63,6 +63,20 @@ class WaveScope:
     origin: Origin
 
 
+@dataclass(frozen=True, slots=True)
+class DiagnosticsBundle:
+    """Last ``diagnostics_set`` payload for one producer ``source``.
+
+    Stored as the raw on-wire items so the server can replay them to
+    newly-connected clients verbatim. The empty-tuple case is a "this
+    source has been cleared" record — replaying it tells late joiners
+    to clear the source on their side too.
+    """
+
+    items: tuple[dict[str, Any], ...]
+    origin: Origin
+
+
 @dataclass
 class HubState:
     """One-slot cache per coordinate type.
@@ -77,6 +91,7 @@ class HubState:
     signal_selection: Optional[SignalSelection] = None
     cursor_time: Optional[CursorTime] = None
     wave_scope: Optional[WaveScope] = None
+    diagnostics: dict[str, DiagnosticsBundle] = field(default_factory=dict)
 
     registered_clients: set[Origin] = field(default_factory=set)
 
@@ -87,6 +102,7 @@ class HubState:
         self.signal_selection = None
         self.cursor_time = None
         self.wave_scope = None
+        self.diagnostics = {}
 
 
 __all__ = [
@@ -94,5 +110,6 @@ __all__ = [
     "SignalSelection",
     "CursorTime",
     "WaveScope",
+    "DiagnosticsBundle",
     "HubState",
 ]

--- a/tests/test_hub_protocol.py
+++ b/tests/test_hub_protocol.py
@@ -10,12 +10,14 @@ import pytest
 
 from rtl_buddy.hub import protocol
 from rtl_buddy.hub.protocol import (
+    Diagnostic,
     Envelope,
     HubProtocolError,
     Kind,
     Origin,
     decode,
     encode,
+    make_diagnostics_set,
     make_error,
     make_hello,
     make_welcome,
@@ -291,8 +293,126 @@ def test_vendored_schema_has_expected_types():
         "welcome",
         "bye",
         "error",
+        "diagnostics_set",
     }
     assert types_seen == expected
+
+
+# ---------------------------------------------------------------------------
+# diagnostics_set
+# ---------------------------------------------------------------------------
+
+
+def test_make_diagnostics_set_round_trips_minimal_and_full_items():
+    env = make_diagnostics_set(
+        origin=Origin.CLI,
+        source="rtl-buddy-cdc",
+        items=[
+            Diagnostic(file="/abs/a.sv", line=1, severity="error", message="m"),
+            Diagnostic(
+                file="/abs/b.sv",
+                line=10,
+                col=4,
+                end_line=10,
+                end_col=18,
+                severity="warning",
+                code="CDC-002",
+                message="depth too shallow",
+            ),
+        ],
+    )
+    line = encode(env)
+    back = decode(line)
+    assert back.type == "diagnostics_set"
+    assert back.kind is Kind.EVENT
+    assert back.payload["source"] == "rtl-buddy-cdc"
+    assert len(back.payload["items"]) == 2
+    minimal, full = back.payload["items"]
+    assert minimal == {
+        "file": "/abs/a.sv",
+        "line": 1,
+        "severity": "error",
+        "message": "m",
+    }
+    assert full["code"] == "CDC-002"
+    assert full["end_col"] == 18
+
+
+def test_make_diagnostics_set_accepts_dict_items():
+    env = make_diagnostics_set(
+        origin=Origin.CLI,
+        source="manual",
+        items=[{"file": "/x.sv", "line": 5, "severity": "info", "message": "ok"}],
+    )
+    assert encode(env)  # validates via schema
+
+
+def test_diagnostics_set_empty_items_is_legal_clear():
+    env = make_diagnostics_set(origin=Origin.CLI, source="rtl-buddy-cdc", items=[])
+    back = decode(encode(env))
+    assert back.payload == {"source": "rtl-buddy-cdc", "items": []}
+
+
+def test_diagnostics_set_rejects_bad_severity():
+    with pytest.raises(HubProtocolError):
+        encode(
+            Envelope(
+                origin=Origin.CLI,
+                kind=Kind.EVENT,
+                type="diagnostics_set",
+                id=new_id(),
+                payload={
+                    "source": "x",
+                    "items": [
+                        {
+                            "file": "/x.sv",
+                            "line": 1,
+                            "severity": "fatal",
+                            "message": "m",
+                        }
+                    ],
+                },
+            )
+        )
+
+
+def test_diagnostics_set_rejects_missing_required_item_field():
+    with pytest.raises(HubProtocolError):
+        encode(
+            Envelope(
+                origin=Origin.CLI,
+                kind=Kind.EVENT,
+                type="diagnostics_set",
+                id=new_id(),
+                payload={
+                    "source": "x",
+                    "items": [{"file": "/x.sv", "severity": "error", "message": "m"}],
+                },
+            )
+        )
+
+
+def test_diagnostics_set_rejects_line_zero():
+    with pytest.raises(HubProtocolError):
+        encode(
+            Envelope(
+                origin=Origin.CLI,
+                kind=Kind.EVENT,
+                type="diagnostics_set",
+                id=new_id(),
+                payload={
+                    "source": "x",
+                    "items": [
+                        {
+                            "file": "/x.sv",
+                            "line": 0,
+                            "severity": "error",
+                            "message": "m",
+                        }
+                    ],
+                },
+            )
+        )
 
 
 def test_vendored_schema_matches_source_when_view_repo_present():

--- a/tests/test_hub_server.py
+++ b/tests/test_hub_server.py
@@ -261,6 +261,123 @@ async def test_unknown_event_type_silently_dropped(server: HubServer):
 
 
 # ---------------------------------------------------------------------------
+# diagnostics_set
+# ---------------------------------------------------------------------------
+
+
+def _diag_evt(origin: Origin, source: str, items: list[dict]) -> Envelope:
+    return Envelope(
+        origin=origin,
+        kind=Kind.EVENT,
+        type="diagnostics_set",
+        id=new_id(),
+        payload={"source": source, "items": items},
+    )
+
+
+async def test_diagnostics_set_broadcasts_and_caches(server: HubServer):
+    publisher = await MockClient.connect(server.host, server.port)
+    subscriber = await MockClient.connect(server.host, server.port)
+    try:
+        await publisher.hello(Origin.CLI)
+        await subscriber.hello(Origin.SRC)
+
+        items = [
+            {"file": "/abs/a.sv", "line": 4, "severity": "error", "message": "x"},
+            {
+                "file": "/abs/b.sv",
+                "line": 9,
+                "col": 3,
+                "severity": "warning",
+                "code": "CDC-002",
+                "message": "depth",
+            },
+        ]
+        evt = _diag_evt(Origin.CLI, "rtl-buddy-cdc", items)
+        await publisher.send(evt)
+
+        got = await subscriber.recv()
+        assert got.type == "diagnostics_set"
+        assert got.payload["source"] == "rtl-buddy-cdc"
+        assert got.payload["items"] == items
+        await publisher.expect_no_message()  # origin gets suppressed
+
+        await asyncio.sleep(0.05)
+        bundle = server.state.diagnostics["rtl-buddy-cdc"]
+        assert bundle.origin is Origin.CLI
+        assert len(bundle.items) == 2
+    finally:
+        await publisher.close()
+        await subscriber.close()
+
+
+async def test_diagnostics_set_replayed_to_late_joiner(server: HubServer):
+    publisher = await MockClient.connect(server.host, server.port)
+    try:
+        await publisher.hello(Origin.CLI)
+        await publisher.send(
+            _diag_evt(
+                Origin.CLI,
+                "src-a",
+                [{"file": "/x.sv", "line": 1, "severity": "info", "message": "m"}],
+            )
+        )
+        await publisher.send(
+            _diag_evt(
+                Origin.CLI,
+                "src-b",
+                [{"file": "/y.sv", "line": 2, "severity": "warning", "message": "n"}],
+            )
+        )
+        await asyncio.sleep(0.05)
+
+        # Late joiner connects after the diagnostics were broadcast.
+        late = await MockClient.connect(server.host, server.port)
+        try:
+            await late.hello(Origin.SRC)
+            seen: dict[str, Envelope] = {}
+            for _ in range(2):
+                env = await late.recv()
+                assert env.type == "diagnostics_set"
+                seen[env.payload["source"]] = env
+            assert set(seen.keys()) == {"src-a", "src-b"}
+            assert seen["src-a"].payload["items"][0]["file"] == "/x.sv"
+        finally:
+            await late.close()
+    finally:
+        await publisher.close()
+
+
+async def test_diagnostics_set_empty_items_is_cache_clear(server: HubServer):
+    publisher = await MockClient.connect(server.host, server.port)
+    subscriber = await MockClient.connect(server.host, server.port)
+    try:
+        await publisher.hello(Origin.CLI)
+        await subscriber.hello(Origin.SRC)
+
+        await publisher.send(
+            _diag_evt(
+                Origin.CLI,
+                "rtl-buddy-cdc",
+                [{"file": "/x.sv", "line": 1, "severity": "error", "message": "boom"}],
+            )
+        )
+        first = await subscriber.recv()
+        assert len(first.payload["items"]) == 1
+
+        # Empty items is the legal "clear all" — must still broadcast.
+        await publisher.send(_diag_evt(Origin.CLI, "rtl-buddy-cdc", []))
+        second = await subscriber.recv()
+        assert second.payload["items"] == []
+
+        await asyncio.sleep(0.05)
+        assert server.state.diagnostics["rtl-buddy-cdc"].items == ()
+    finally:
+        await publisher.close()
+        await subscriber.close()
+
+
+# ---------------------------------------------------------------------------
 # requests
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Extend the v1 hub protocol with a `diagnostics_set` event so hub-attached producers (`rb cdc`, future linters, the schematic viewer) can publish findings that downstream clients pick up through their existing connections. Forward-compatible — old clients silently drop unknown types per §11 of `docs/hub-protocol.md`.

Unblocks acceptance criterion #7 on #113 on the hub side; the matching nvim adapter handler will land in a follow-up PR on rtl-buddy/rtl-buddy-nvim.

## Wire shape

```jsonc
{
  \"v\": 1, \"id\": \"<uuid>\",
  \"origin\": \"cli\",            // or any origin that owns the finding source
  \"kind\": \"event\",
  \"type\": \"diagnostics_set\",
  \"payload\": {
    \"source\": \"rtl-buddy-cdc\",     // unique key per producer; latest-writer-wins
    \"items\": [
      {
        \"file\": \"/abs/path.sv\",
        \"line\": 42, \"col\": 7,
        \"end_line\": 42, \"end_col\": 18,
        \"severity\": \"error\",        // error | warning | info | hint
        \"code\":     \"CDC-001\",
        \"message\":  \"Unsynchronized clock-domain crossing\"
      }
    ]
  }
}
```

Empty \`items\` is the legal "clear all diagnostics for this source" signal — sent through the same pipeline so cleared state replays correctly to late joiners.

## Hub behaviour

- Routed via the existing \`STATE_EVENT_TYPES\` path: broadcast to every client except origin, suppressed echo-back via the existing \`origin\` rule.
- Cached per \`source\` in \`HubState.diagnostics\` (\`dict[str, DiagnosticsBundle]\`). Subsequent sends for the same source replace.
- Replayed to a newly-welcomed client right after the \`welcome\` response, using each bundle's original origin so the loop-prevention tag is preserved.
- No persistence — restarting the daemon clears the cache.

## Test plan

- [x] \`uv run pytest tests/test_hub_protocol.py\` — schema round-trip, missing required item field, bad severity, line<1
- [x] \`uv run pytest tests/test_hub_server.py\` — broadcast suppresses origin + caches, replay-to-late-joiner, empty-items clear
- [x] Full hub suite: \`uv run pytest tests/test_hub_*.py\` (80 passed, 1 skipped — unchanged baseline)
- [x] \`uv run ruff check src/rtl_buddy/hub tests/test_hub_*.py\` clean
- [x] \`uv run ruff format --check\` clean

## Out of scope

- \`rb cdc\` → hub publisher pipeline. The wire is testable via raw envelopes for now; a \`rb hub publish-diagnostics --from <json>\` (or direct integration into \`rb cdc analyze\`) is a follow-up.
- Multi-buffer viewer-side overlay rendering (Phase 7b territory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)