### PR TITLE
feat(fpv): rb wave-fpv opens SymbiYosys counterexample VCDs (#137)

### DIFF
--- a/docs/concepts/fpv.md
+++ b/docs/concepts/fpv.md
@@ -158,9 +158,18 @@ Per-run outputs land under `fpv/<run>/artefacts/`:
 
 A run is PASS when `sby` writes `PASS` to `sby_workdir/status` (or returns exit code 0 when the status file is missing).
 
-A run is FAIL when sby writes `FAIL`, `UNKNOWN`, or `ERROR`, or when it exits non-zero. The failure description points at the counterexample trace inside `sby_workdir/engine_<N>/` so the user can open it in `gtkwave` or via `rb wave`.
+A run is FAIL when sby writes `FAIL`, `UNKNOWN`, or `ERROR`, or when it exits non-zero. The failure description points at the counterexample trace inside `sby_workdir/engine_<N>/` so the user can open it in `gtkwave`, `surfer`, or via `rb wave-fpv` (below).
 
 SKIP is returned when the run's `reglvl` is above the `-l` filter passed to `rb fpv-regression`.
+
+## Opening counterexamples
+
+```bash
+# Open the CEX VCD for a failed verification in the configured surfer.
+rb wave-fpv demo_fpv_counter_safety
+```
+
+`rb wave-fpv` resolves the trace at `fpv/<suite>/artefacts/<verif>/sby_workdir/engine_<N>/trace.vcd` (first engine wins when more than one produced a trace). The configured surfer comes from the same `cfg-surfer` entry that `rb wave` uses; override with `--surfer <name>`. Raises if the verification has not been run yet or the proof passed (no CEX was produced).
 
 ## Out of scope (today)
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -49,6 +49,7 @@ Usage: rtl-buddy [OPTIONS] COMMAND [ARGS]...
 │ hier               render module hierarchy via rtl-buddy-view                        │
 │ verible            run verible cmd                                                   │
 │ wave               open waveform viewer for a test                                   │
+│ wave-fpv           open SymbiYosys counterexample VCD for a failed FPV verification  │
 │ wave-install-nvim  install nvim plugin for rb wave annotation                        │
 │ synth              run synthesis                                                     │
 │ synth-regression   run synthesis regression                                          │

--- a/src/rtl_buddy/rtl_buddy.py
+++ b/src/rtl_buddy/rtl_buddy.py
@@ -75,6 +75,7 @@ class RtlBuddy:
         "regression",
         "filelist",
         "wave",
+        "wave-fpv",
         "synth",
         "synth-regression",
         "power",
@@ -132,6 +133,10 @@ class RtlBuddy:
         self.app.command("wave", help="open waveform viewer for a test")(
             self.do_cmd_wave
         )
+        self.app.command(
+            "wave-fpv",
+            help="open SymbiYosys counterexample VCD for a failed FPV verification",
+        )(self.do_cmd_wave_fpv)
         self.app.command(
             "wave-install-nvim", help="install nvim plugin for rb wave annotation"
         )(self.do_wave_install_nvim)
@@ -2607,6 +2612,85 @@ class RtlBuddy:
             surfer_file=surfer_file if os.path.isfile(surfer_file) else None,
             scope_annotation=not focused_signal,
         ).launch()
+
+    def do_cmd_wave_fpv(
+        self,
+        verif_name: Annotated[
+            str,
+            typer.Argument(help="name of FPV verification to open CEX for"),
+        ],
+        fpv_config: Annotated[
+            str,
+            typer.Option("-c", "--fpv-config", help="fpv.yaml to use"),
+        ] = "fpv.yaml",
+        surfer_name: Annotated[
+            str, typer.Option("--surfer", help="cfg-surfer entry name")
+        ] = "surfer-default",
+    ):
+        """
+        open SymbiYosys counterexample VCD for a failed FPV verification
+
+        Resolves the CEX VCD by convention at
+        ``fpv/<suite>/artefacts/<verif>/sby_workdir/engine_<N>/trace.vcd`` and
+        opens it in the configured surfer. Raises if the verification has
+        not been run, the proof passed (no CEX produced), or no engine
+        emitted a trace.
+        """
+        from .tools.fpv_cex_finder import find_cex_vcd
+
+        surfer_cfg = self.root_cfg.get_surfer_cfg(surfer_name)
+        if surfer_cfg is None:
+            raise FatalRtlBuddyError(
+                f'No cfg-surfer entry named "{surfer_name}" in root_config.yaml. '
+                f"Add a cfg-surfer section to enable waveform viewing."
+            )
+        if not surfer_cfg.available:
+            raise FatalRtlBuddyError(
+                f'Surfer not found at "{surfer_cfg.path}". '
+                f"Check cfg-surfer.path in root_config.yaml or install surfer on PATH."
+            )
+
+        suite_cfg = FpvSuiteConfig(path=fpv_config)
+        suite_dir = os.path.dirname(os.path.abspath(fpv_config))
+        # Validate the verification name resolves; raises FatalRtlBuddyError otherwise.
+        suite_cfg.get_verifications(verif_name)
+
+        cex_path = find_cex_vcd(suite_dir, verif_name)
+        if cex_path is None:
+            raise FatalRtlBuddyError(
+                f'No counterexample VCD found for FPV verification "{verif_name}". '
+                f"Either the proof passed (no CEX produced), or `rb fpv {verif_name}` "
+                f"has not been run yet."
+            )
+
+        log_event(
+            logger,
+            logging.INFO,
+            "command.wave_fpv",
+            command="wave-fpv",
+            verification=verif_name,
+            cex=cex_path,
+        )
+
+        cmd = [surfer_cfg.get_surfer_exe(), cex_path]
+        emit_console_text(
+            f"Opening CEX for {verif_name} in surfer (Ctrl-C to exit).",
+        )
+        proc = subprocess.Popen(cmd)
+        try:
+            proc.wait()
+        except KeyboardInterrupt:
+            proc.terminate()
+            try:
+                proc.wait(timeout=3)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+        log_event(
+            logger,
+            logging.INFO,
+            "wave_fpv.done",
+            verification=verif_name,
+        )
 
     def do_wave_install_nvim(
         self,

--- a/src/rtl_buddy/tools/fpv_cex_finder.py
+++ b/src/rtl_buddy/tools/fpv_cex_finder.py
@@ -1,0 +1,31 @@
+"""Resolve SymbiYosys counterexample VCD paths for ``rb wave-fpv``.
+
+Sby writes a CEX VCD at ``<workdir>/engine_<N>/trace.vcd`` whenever the
+proof disproves a property. Multiple engines can each produce a trace —
+we return the first one found (sorted by engine name) since they all
+witness the same property failure.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def find_cex_vcd(suite_dir: str, verif_name: str) -> str | None:
+    """Return the CEX VCD path for an FPV verification, or ``None``.
+
+    Looks for ``<suite_dir>/artefacts/<verif_name>/sby_workdir/engine_<N>/trace.vcd``.
+    Returns the first match in sorted engine order. ``None`` when the
+    workdir is absent (verification has not run) or no engine produced
+    a trace (the proof passed, or sby died before any engine started).
+    """
+    workdir = Path(suite_dir) / "artefacts" / verif_name / "sby_workdir"
+    if not workdir.is_dir():
+        return None
+    for entry in sorted(workdir.iterdir()):
+        if not entry.name.startswith("engine_") or not entry.is_dir():
+            continue
+        trace = entry / "trace.vcd"
+        if trace.is_file():
+            return str(trace)
+    return None

--- a/tests/test_fpv.py
+++ b/tests/test_fpv.py
@@ -478,3 +478,80 @@ def test_fpv_runner_dispatches_to_sby_backend(tmp_path):
     assert mocked.called
     assert result.results["result"] == "PASS"
     assert result.results["mode"] == "bmc"
+
+
+# ---------------------------------------------------------------------------
+# fpv_cex_finder — CEX VCD path resolution for `rb wave-fpv`
+# ---------------------------------------------------------------------------
+
+
+def test_find_cex_vcd_returns_trace_from_first_engine(tmp_path):
+    from rtl_buddy.tools.fpv_cex_finder import find_cex_vcd
+
+    workdir = tmp_path / "artefacts" / "demo_safety" / "sby_workdir"
+    (workdir / "engine_0").mkdir(parents=True)
+    (workdir / "engine_0" / "trace.vcd").write_text("$dummy\n")
+
+    assert find_cex_vcd(str(tmp_path), "demo_safety") == str(
+        workdir / "engine_0" / "trace.vcd"
+    )
+
+
+def test_find_cex_vcd_prefers_lowest_engine_number(tmp_path):
+    """Multiple engines can each emit a trace; the sorted-first one wins."""
+    from rtl_buddy.tools.fpv_cex_finder import find_cex_vcd
+
+    workdir = tmp_path / "artefacts" / "demo_safety" / "sby_workdir"
+    for engine in ("engine_0", "engine_1", "engine_2"):
+        (workdir / engine).mkdir(parents=True)
+        (workdir / engine / "trace.vcd").write_text("$dummy\n")
+
+    assert find_cex_vcd(str(tmp_path), "demo_safety") == str(
+        workdir / "engine_0" / "trace.vcd"
+    )
+
+
+def test_find_cex_vcd_skips_engines_without_trace(tmp_path):
+    """Engine dirs without trace.vcd (e.g. proof passed in that engine)
+    should be skipped, not returned as a hit."""
+    from rtl_buddy.tools.fpv_cex_finder import find_cex_vcd
+
+    workdir = tmp_path / "artefacts" / "demo_safety" / "sby_workdir"
+    (workdir / "engine_0").mkdir(parents=True)  # no trace.vcd
+    (workdir / "engine_1").mkdir(parents=True)
+    (workdir / "engine_1" / "trace.vcd").write_text("$dummy\n")
+
+    assert find_cex_vcd(str(tmp_path), "demo_safety") == str(
+        workdir / "engine_1" / "trace.vcd"
+    )
+
+
+def test_find_cex_vcd_returns_none_when_workdir_missing(tmp_path):
+    """Verification hasn't been run yet -> no workdir -> None."""
+    from rtl_buddy.tools.fpv_cex_finder import find_cex_vcd
+
+    assert find_cex_vcd(str(tmp_path), "never_ran") is None
+
+
+def test_find_cex_vcd_returns_none_when_no_engine_has_trace(tmp_path):
+    """Proof passed (no CEX emitted) -> engine dirs present but no trace -> None."""
+    from rtl_buddy.tools.fpv_cex_finder import find_cex_vcd
+
+    workdir = tmp_path / "artefacts" / "demo_safety" / "sby_workdir"
+    (workdir / "engine_0").mkdir(parents=True)  # no trace.vcd
+    (workdir / "engine_1").mkdir(parents=True)  # no trace.vcd
+
+    assert find_cex_vcd(str(tmp_path), "demo_safety") is None
+
+
+def test_find_cex_vcd_ignores_non_engine_dirs(tmp_path):
+    """Sby writes `src/`, `model/`, etc. alongside `engine_N/` — those
+    should not be probed for trace files."""
+    from rtl_buddy.tools.fpv_cex_finder import find_cex_vcd
+
+    workdir = tmp_path / "artefacts" / "demo_safety" / "sby_workdir"
+    (workdir / "src").mkdir(parents=True)
+    (workdir / "src" / "trace.vcd").write_text("$dummy\n")
+    (workdir / "model").mkdir(parents=True)
+
+    assert find_cex_vcd(str(tmp_path), "demo_safety") is None


### PR DESCRIPTION
## Summary

- Adds `rb wave-fpv <verif>` — a sibling to `rb wave` that resolves the SymbiYosys counterexample VCD by convention and opens it in the configured surfer.
- Trace path: `fpv/<suite>/artefacts/<verif>/sby_workdir/engine_<N>/trace.vcd`; first engine (sorted) wins when more than one emitted a trace.
- Pure rtl_buddy code change — no sby dependency at test time.

Closes #137.

## Why

After an `rb fpv` FAIL, users had to manually navigate `sby_workdir/engine_<N>/trace.vcd` and invoke `gtkwave` / `surfer` themselves. `rb wave` already handles this for `rb test` outputs; the symmetric extension closes the loop for formal.

A new sibling command rather than a flag on `rb wave` because the existing `rb wave` is heavily test-context aware (loads `tests.yaml`, drives WCP for source nav, can re-run debug sim). The FPV path is much simpler: open trace in surfer, done.

## Changes

- `src/rtl_buddy/tools/fpv_cex_finder.py` — new helper, ~25 LOC. Sorted engine walk; returns first `trace.vcd` or `None`.
- `src/rtl_buddy/rtl_buddy.py` — registers `wave-fpv`, adds to `_GIT_COMMANDS`, implements `do_cmd_wave_fpv` (surfer + suite-config lookups, ctrl-c-aware subprocess).
- `tests/test_fpv.py` — 6 new tests for the finder: happy path, multiple-engine sort, skipping engines without trace, missing workdir, no-trace-anywhere, non-engine sibling dirs.
- `docs/concepts/fpv.md` — new "Opening counterexamples" subsection.
- `docs/reference/cli.md` — regenerated.

## Test plan

- [x] `uv run ruff check` — clean
- [x] `uv run pytest` — 566 pass, 3 pre-existing skips
- [ ] Manual: `rb fpv <verif>` to FAIL, then `rb wave-fpv <verif>` opens trace in surfer (requires sby + a failing demo locally; finder unit tests cover the path resolution)

🤖 Generated with [Claude Code](https://claude.com/claude-code)