### PR TITLE
feat(fpv): solver version pinning for reproducible CI (#139)

### DIFF
--- a/docs/concepts/fpv.md
+++ b/docs/concepts/fpv.md
@@ -99,6 +99,9 @@ cfg-fpv-tools:
     opts:
       timeout: 600       # seconds per task; optional
       extra-args: ""     # appended to sby invocation; optional
+      solver-versions:   # optional pins for reproducible CI; map
+        yices: "2.6.4"   # solver name -> exact version string
+        z3: "4.13.0"
 ```
 
 | Field | Description |
@@ -107,6 +110,11 @@ cfg-fpv-tools:
 | `tool` | Binary name (PATH-resolved) or absolute path |
 | `opts.timeout` | Per-task timeout in seconds, written to the sby `[options]` block |
 | `opts.extra-args` | Passed through verbatim to the sby command line |
+| `opts.solver-versions` | Optional map of solver name → exact version. Probed before every run; hard-fails on mismatch. Known solvers: `yices`, `z3`, `boolector`, `bitwuzla`, `btormc`, `abc` |
+
+### Solver version pinning
+
+`sby` happily picks whatever solver binary it finds on PATH. On CI, different runners can resolve to different versions and silently change proof outcomes — a proof that passes at depth 32 on one machine can time out on another. Set `opts.solver-versions` to lock the resolution: before each run, each pinned solver is probed (`yices-smt2 --version` etc.) and the run hard-fails with a one-shot summary of every mismatch if any pin doesn't match exactly. Resolved versions are logged as `fpv.solver_pins_resolved` so the run artefacts capture exactly what was used.
 
 ## Running FPV
 

--- a/docs/reference/yaml.md
+++ b/docs/reference/yaml.md
@@ -148,6 +148,9 @@ cfg-fpv-tools:
     opts:
       timeout: 600           # per-task timeout in seconds; written to sby [options]
       extra-args: ""         # appended verbatim to every sby invocation
+      solver-versions:       # optional pins; map solver name → exact version
+        yices: "2.6.4"       # known names: yices, z3, boolector, bitwuzla,
+        z3: "4.13.0"         # btormc, abc. Hard-fails on mismatch.
 
 cfg-rtl-reg:
   reg-cfg-path: "design/regression.yaml"
@@ -168,7 +171,7 @@ cfg-rtl-reg:
 - `cfg-synth-efforts` defines named synthesis effort levels referenced by `synth.yaml` `effort` fields or the `--effort` CLI flag. Each entry has optional `yosys.synth-args` / `yosys.abc-args` (merged into the Yosys stage) and an `openroad` block. When `openroad.run: false`, the runner falls back to the Yosys-only backend even if `tool: openroad` was selected — useful for a fast quick-look path that needs no LEF/STA. `openroad.pre-sta-tcl` is a raw Tcl snippet injected into `synth.tcl` between `read_sdc` and `report_checks`; use it to insert floorplan/placement/parasitic-estimation steps before timing analysis. When no `cfg-synth-efforts` entries are configured or no effort is selected, a built-in `standard` effort with all defaults is used. Precedence for the same knob: per-synthesis `tool_overrides` > `cfg-synth-efforts` > `cfg-synth-tools`.
 - `cfg-pnr-tools` defines P&R tool entries selected by `pnr.yaml` `tool` fields. `tool` is the path to the executable, or a bare name if it is available on `PATH`. When `pnr.yaml` `tool` does not match a `cfg-pnr-tools` entry, the value is used as the executable name directly (bare-name on `PATH` semantics).
 - `cfg-cdc-tools` defines CDC tool entries selected by `cdc.yaml` `tool` fields. `tool` is the path to the executable, or a bare name if it is available on `PATH`. `opts.sync-depth` is forwarded as `--sync-depth N` and controls CDC-002's required synchronizer depth. `opts.extra-args` is appended verbatim to every analyzer invocation.
-- `cfg-fpv-tools` defines FPV tool entries selected by `fpv.yaml` `tool` fields. `tool` is the path to the executable, or a bare name if it is available on `PATH`. `opts.timeout` is written to the generated `.sby` `[options]` block as a per-task timeout in seconds. `opts.extra-args` is appended verbatim to every sby invocation.
+- `cfg-fpv-tools` defines FPV tool entries selected by `fpv.yaml` `tool` fields. `tool` is the path to the executable, or a bare name if it is available on `PATH`. `opts.timeout` is written to the generated `.sby` `[options]` block as a per-task timeout in seconds. `opts.extra-args` is appended verbatim to every sby invocation. `opts.solver-versions` is an optional map of solver short name → exact version string (e.g. `yices: "2.6.4"`); known solvers are `yices`, `z3`, `boolector`, `bitwuzla`, `btormc`, `abc`. Each pinned solver is probed before every run and the run hard-fails with a single multi-line summary if any version does not match — protects CI reproducibility against drift in locally-installed solvers.
 - `cfg-rtl-reg.reg-cfg-path` is the fallback regression file for `rtl-buddy regression` when no `./regression.yaml` exists in the cwd.
 - `cfg-verible[].path` is the directory containing Verible executables. Absolute paths are used as-is; relative paths are resolved from the directory containing `root_config.yaml`.
 

--- a/src/rtl_buddy/config/fpv.py
+++ b/src/rtl_buddy/config/fpv.py
@@ -30,12 +30,20 @@ logger = logging.getLogger(__name__)
 class FpvToolOpts:
     timeout: int | None = None
     extra_args: str = ""
+    solver_versions: dict[str, str] = dc_field(default_factory=dict)
 
 
 @serde
 class FpvToolOptsFile:
     timeout: int | None = field(rename="timeout", default=None)
     extra_args: str = field(rename="extra-args", default="")
+    # Optional pins so CI proofs reproduce across machines. Map solver
+    # name (yices / z3 / boolector / btormc / abc) -> exact version
+    # string. SbyFpv probes each before running and hard-fails on
+    # mismatch.
+    solver_versions: dict[str, str] = field(
+        rename="solver-versions", default_factory=dict
+    )
 
 
 @serde
@@ -60,10 +68,17 @@ class FpvToolConfig:
     def get_opts(self, overrides: dict | None = None) -> FpvToolOpts:
         timeout = self._cfg.opts.timeout
         extra_args = self._cfg.opts.extra_args
+        solver_versions = dict(self._cfg.opts.solver_versions)
         if overrides:
             timeout = overrides.get("timeout", timeout)
             extra_args = overrides.get("extra_args", extra_args)
-        return FpvToolOpts(timeout=timeout, extra_args=extra_args)
+            if "solver_versions" in overrides:
+                solver_versions = dict(overrides["solver_versions"])
+        return FpvToolOpts(
+            timeout=timeout,
+            extra_args=extra_args,
+            solver_versions=solver_versions,
+        )
 
 
 # ---- per-verification config ----------------------------------------------

--- a/src/rtl_buddy/tools/fpv_solver_pin.py
+++ b/src/rtl_buddy/tools/fpv_solver_pin.py
@@ -96,9 +96,7 @@ def check_solver_pins(pins: dict[str, str]) -> dict[str, str]:
             )
             continue
         if got != expected:
-            failures.append(
-                f"  {solver}: pinned {expected!r}, found {got!r}"
-            )
+            failures.append(f"  {solver}: pinned {expected!r}, found {got!r}")
             continue
         resolved[solver] = got
     if failures:

--- a/src/rtl_buddy/tools/fpv_solver_pin.py
+++ b/src/rtl_buddy/tools/fpv_solver_pin.py
@@ -1,0 +1,108 @@
+"""Solver version probing + pin enforcement for ``rb fpv``.
+
+When a user pins solver versions via ``cfg-fpv-tools.opts.solver-versions``
+(e.g. ``{yices: "2.6.4", z3: "4.13.0"}``), this module probes each
+binary on PATH and raises :class:`FatalRtlBuddyError` if the resolved
+version does not match the pin exactly.
+
+The motivation is reproducible CI: ``sby`` happily picks whatever
+solver binary it finds locally, and a runner with a different version
+can silently change proof outcomes (passes at depth N on one machine,
+times out on another). Pinning + hard-fail surfaces the drift instead
+of letting it ride.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import subprocess
+
+from ..errors import FatalRtlBuddyError
+from ..logging_utils import log_event
+
+logger = logging.getLogger(__name__)
+
+
+# How to probe each known solver. Each entry: (binary name, args,
+# regex that captures the version string from stdout+stderr). Add
+# entries here as new engines are exercised.
+_PROBES: dict[str, tuple[str, list[str], str]] = {
+    "yices": ("yices-smt2", ["--version"], r"Yices\s+(\S+)"),
+    "z3": ("z3", ["--version"], r"Z3 version\s+(\S+)"),
+    "boolector": ("boolector", ["--version"], r"^(\d+\.\d+\.\d+)"),
+    "bitwuzla": ("bitwuzla", ["--version"], r"^(\d+\.\d+\.\d+)"),
+    "btormc": ("btormc", ["--version"], r"^(\d+\.\d+\.\d+)"),
+    "abc": ("yosys-abc", ["-h"], r"UC Berkeley, ABC\s+(\S+)"),
+}
+
+
+def probe_solver_version(solver: str) -> str | None:
+    """Return the installed version of ``solver`` or ``None`` if absent.
+
+    ``solver`` is the short name used in the ``solver-versions`` pin
+    map (yices / z3 / boolector / bitwuzla / btormc / abc). Returns
+    ``None`` when the binary is missing, the probe times out, or the
+    version regex does not match — the caller treats all three as a
+    pin-check failure.
+    """
+    if solver not in _PROBES:
+        log_event(
+            logger,
+            logging.WARNING,
+            "fpv.solver_probe_unknown",
+            solver=solver,
+        )
+        return None
+    binary, args, pattern = _PROBES[solver]
+    try:
+        res = subprocess.run(
+            [binary, *args],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired) as e:
+        log_event(
+            logger,
+            logging.WARNING,
+            "fpv.solver_probe_failed",
+            solver=solver,
+            binary=binary,
+            error=str(e),
+        )
+        return None
+    out = (res.stdout or "") + (res.stderr or "")
+    m = re.search(pattern, out, re.MULTILINE)
+    return m.group(1) if m else None
+
+
+def check_solver_pins(pins: dict[str, str]) -> dict[str, str]:
+    """Probe every pinned solver and raise on mismatch.
+
+    Returns a map of resolved versions on success (useful for logging
+    into the run artefacts). Raises :class:`FatalRtlBuddyError` with a
+    single error listing every mismatch / missing solver — users want
+    one report, not N failures across reruns.
+    """
+    resolved: dict[str, str] = {}
+    failures: list[str] = []
+    for solver, expected in pins.items():
+        got = probe_solver_version(solver)
+        if got is None:
+            failures.append(
+                f"  {solver}: pinned {expected!r}, but probe failed "
+                f"(binary missing or unrecognized output)"
+            )
+            continue
+        if got != expected:
+            failures.append(
+                f"  {solver}: pinned {expected!r}, found {got!r}"
+            )
+            continue
+        resolved[solver] = got
+    if failures:
+        raise FatalRtlBuddyError(
+            "FPV solver version pin check failed:\n" + "\n".join(failures)
+        )
+    return resolved

--- a/src/rtl_buddy/tools/sby_fpv.py
+++ b/src/rtl_buddy/tools/sby_fpv.py
@@ -197,6 +197,24 @@ class SbyFpv:
                     f"{cfg.get_name()}: property file not found: {prop}"
                 )
 
+        opts = self.tool_cfg.get_opts(
+            cfg.get_tool_overrides_for(self.tool_cfg.get_name())
+        )
+        if opts.solver_versions:
+            # Raises FatalRtlBuddyError on any mismatch so the user
+            # sees the drift before sby produces a wrong-looking
+            # PASS or timeout on a different solver version.
+            from .fpv_solver_pin import check_solver_pins
+
+            resolved = check_solver_pins(opts.solver_versions)
+            log_event(
+                logger,
+                logging.INFO,
+                "fpv.solver_pins_resolved",
+                verification=cfg.get_name(),
+                resolved=resolved,
+            )
+
         sby_path = self._write_sby_file(sources, incdirs)
         log_path = self._log_path()
         workdir = self._workdir_path()

--- a/tests/test_fpv.py
+++ b/tests/test_fpv.py
@@ -492,9 +492,7 @@ def test_fpv_tool_config_solver_versions_default_empty():
 
 def test_fpv_tool_config_solver_versions_round_trip():
     opts_file = FpvToolOptsFile(solver_versions={"yices": "2.6.4"})
-    tool_cfg = FpvToolConfig(
-        FpvToolConfigFile(name="sby", tool="sby", opts=opts_file)
-    )
+    tool_cfg = FpvToolConfig(FpvToolConfigFile(name="sby", tool="sby", opts=opts_file))
     assert tool_cfg.get_opts().solver_versions == {"yices": "2.6.4"}
 
 
@@ -502,9 +500,7 @@ def test_fpv_tool_config_solver_versions_override_replaces_base():
     """Per-verification overrides should replace, not merge — the pin
     semantics are "use exactly this set", not "add to whatever's pinned"."""
     opts_file = FpvToolOptsFile(solver_versions={"yices": "2.6.4", "z3": "4.13.0"})
-    tool_cfg = FpvToolConfig(
-        FpvToolConfigFile(name="sby", tool="sby", opts=opts_file)
-    )
+    tool_cfg = FpvToolConfig(FpvToolConfigFile(name="sby", tool="sby", opts=opts_file))
     opts = tool_cfg.get_opts({"solver_versions": {"z3": "4.12.0"}})
     assert opts.solver_versions == {"z3": "4.12.0"}
 
@@ -596,9 +592,7 @@ def test_check_solver_pins_all_match_returns_resolved():
         "probe_solver_version",
         side_effect=lambda s: {"yices": "2.6.4", "z3": "4.13.0"}[s],
     ):
-        resolved = fpv_solver_pin.check_solver_pins(
-            {"yices": "2.6.4", "z3": "4.13.0"}
-        )
+        resolved = fpv_solver_pin.check_solver_pins({"yices": "2.6.4", "z3": "4.13.0"})
     assert resolved == {"yices": "2.6.4", "z3": "4.13.0"}
 
 
@@ -613,9 +607,7 @@ def test_check_solver_pins_mismatch_raises_with_all_failures():
         side_effect=lambda s: {"yices": "2.6.3", "z3": "4.13.0"}[s],
     ):
         with pytest.raises(FatalRtlBuddyError) as exc_info:
-            fpv_solver_pin.check_solver_pins(
-                {"yices": "2.6.4", "z3": "4.12.0"}
-            )
+            fpv_solver_pin.check_solver_pins({"yices": "2.6.4", "z3": "4.12.0"})
     msg = str(exc_info.value)
     assert "yices" in msg and "2.6.3" in msg and "2.6.4" in msg
     assert "z3" in msg and "4.12.0" in msg
@@ -625,9 +617,7 @@ def test_check_solver_pins_missing_solver_raises():
     from rtl_buddy.errors import FatalRtlBuddyError
     from rtl_buddy.tools import fpv_solver_pin
 
-    with patch.object(
-        fpv_solver_pin, "probe_solver_version", return_value=None
-    ):
+    with patch.object(fpv_solver_pin, "probe_solver_version", return_value=None):
         with pytest.raises(FatalRtlBuddyError, match="yices"):
             fpv_solver_pin.check_solver_pins({"yices": "2.6.4"})
 

--- a/tests/test_fpv.py
+++ b/tests/test_fpv.py
@@ -478,3 +478,161 @@ def test_fpv_runner_dispatches_to_sby_backend(tmp_path):
     assert mocked.called
     assert result.results["result"] == "PASS"
     assert result.results["mode"] == "bmc"
+
+
+# ---------------------------------------------------------------------------
+# FpvToolOpts — solver_versions pin field carries through
+# ---------------------------------------------------------------------------
+
+
+def test_fpv_tool_config_solver_versions_default_empty():
+    cfg = _tool_cfg()
+    assert cfg.get_opts().solver_versions == {}
+
+
+def test_fpv_tool_config_solver_versions_round_trip():
+    opts_file = FpvToolOptsFile(solver_versions={"yices": "2.6.4"})
+    tool_cfg = FpvToolConfig(
+        FpvToolConfigFile(name="sby", tool="sby", opts=opts_file)
+    )
+    assert tool_cfg.get_opts().solver_versions == {"yices": "2.6.4"}
+
+
+def test_fpv_tool_config_solver_versions_override_replaces_base():
+    """Per-verification overrides should replace, not merge — the pin
+    semantics are "use exactly this set", not "add to whatever's pinned"."""
+    opts_file = FpvToolOptsFile(solver_versions={"yices": "2.6.4", "z3": "4.13.0"})
+    tool_cfg = FpvToolConfig(
+        FpvToolConfigFile(name="sby", tool="sby", opts=opts_file)
+    )
+    opts = tool_cfg.get_opts({"solver_versions": {"z3": "4.12.0"}})
+    assert opts.solver_versions == {"z3": "4.12.0"}
+
+
+def test_fpv_tool_config_solver_versions_yaml_dash_separator(tmp_path):
+    """The YAML key is `solver-versions` (dash); confirm round-trip from
+    a real fpv.yaml-style cfg loads it into the dict."""
+    from serde.yaml import from_yaml
+
+    yaml_text = dedent("""\
+        name: sby
+        tool: sby
+        opts:
+          solver-versions:
+            yices: "2.6.4"
+            z3: "4.13.0"
+    """)
+    parsed = from_yaml(FpvToolConfigFile, yaml_text)
+    assert parsed.opts.solver_versions == {"yices": "2.6.4", "z3": "4.13.0"}
+
+
+# ---------------------------------------------------------------------------
+# fpv_solver_pin — version probe + pin enforcement
+# ---------------------------------------------------------------------------
+
+
+def _fake_completed(stdout="", stderr="", returncode=0):
+    """Minimal stand-in for subprocess.CompletedProcess."""
+    from types import SimpleNamespace
+
+    return SimpleNamespace(stdout=stdout, stderr=stderr, returncode=returncode)
+
+
+def test_probe_solver_version_yices_extracts_first_token():
+    from rtl_buddy.tools import fpv_solver_pin
+
+    with patch.object(
+        fpv_solver_pin.subprocess,
+        "run",
+        return_value=_fake_completed(stdout="Yices 2.6.4\nCopyright ..."),
+    ):
+        assert fpv_solver_pin.probe_solver_version("yices") == "2.6.4"
+
+
+def test_probe_solver_version_z3_extracts_version():
+    from rtl_buddy.tools import fpv_solver_pin
+
+    with patch.object(
+        fpv_solver_pin.subprocess,
+        "run",
+        return_value=_fake_completed(stdout="Z3 version 4.13.0 - 64 bit\n"),
+    ):
+        assert fpv_solver_pin.probe_solver_version("z3") == "4.13.0"
+
+
+def test_probe_solver_version_unknown_returns_none():
+    from rtl_buddy.tools import fpv_solver_pin
+
+    assert fpv_solver_pin.probe_solver_version("not-a-real-solver") is None
+
+
+def test_probe_solver_version_binary_missing_returns_none():
+    from rtl_buddy.tools import fpv_solver_pin
+
+    with patch.object(
+        fpv_solver_pin.subprocess,
+        "run",
+        side_effect=FileNotFoundError("yices-smt2"),
+    ):
+        assert fpv_solver_pin.probe_solver_version("yices") is None
+
+
+def test_probe_solver_version_unparseable_output_returns_none():
+    from rtl_buddy.tools import fpv_solver_pin
+
+    with patch.object(
+        fpv_solver_pin.subprocess,
+        "run",
+        return_value=_fake_completed(stdout="garbage output"),
+    ):
+        assert fpv_solver_pin.probe_solver_version("yices") is None
+
+
+def test_check_solver_pins_all_match_returns_resolved():
+    from rtl_buddy.tools import fpv_solver_pin
+
+    with patch.object(
+        fpv_solver_pin,
+        "probe_solver_version",
+        side_effect=lambda s: {"yices": "2.6.4", "z3": "4.13.0"}[s],
+    ):
+        resolved = fpv_solver_pin.check_solver_pins(
+            {"yices": "2.6.4", "z3": "4.13.0"}
+        )
+    assert resolved == {"yices": "2.6.4", "z3": "4.13.0"}
+
+
+def test_check_solver_pins_mismatch_raises_with_all_failures():
+    """All failures should be listed in one error so the user reruns once."""
+    from rtl_buddy.errors import FatalRtlBuddyError
+    from rtl_buddy.tools import fpv_solver_pin
+
+    with patch.object(
+        fpv_solver_pin,
+        "probe_solver_version",
+        side_effect=lambda s: {"yices": "2.6.3", "z3": "4.13.0"}[s],
+    ):
+        with pytest.raises(FatalRtlBuddyError) as exc_info:
+            fpv_solver_pin.check_solver_pins(
+                {"yices": "2.6.4", "z3": "4.12.0"}
+            )
+    msg = str(exc_info.value)
+    assert "yices" in msg and "2.6.3" in msg and "2.6.4" in msg
+    assert "z3" in msg and "4.12.0" in msg
+
+
+def test_check_solver_pins_missing_solver_raises():
+    from rtl_buddy.errors import FatalRtlBuddyError
+    from rtl_buddy.tools import fpv_solver_pin
+
+    with patch.object(
+        fpv_solver_pin, "probe_solver_version", return_value=None
+    ):
+        with pytest.raises(FatalRtlBuddyError, match="yices"):
+            fpv_solver_pin.check_solver_pins({"yices": "2.6.4"})
+
+
+def test_check_solver_pins_empty_is_noop():
+    from rtl_buddy.tools import fpv_solver_pin
+
+    assert fpv_solver_pin.check_solver_pins({}) == {}


### PR DESCRIPTION
## Summary

- Adds `opts.solver-versions` to `cfg-fpv-tools` — optional map of solver short name → exact version string.
- Pinned solvers are probed before every `rb fpv` run via the relevant `--version` flag (yices-smt2, z3, boolector, etc.); hard-fails on mismatch with a one-shot summary of every failure.
- Resolved versions land in `rtl_buddy.log` as `fpv.solver_pins_resolved`.

Closes #139.

## Why

sby happily picks whatever solver binary it finds on PATH. On CI, runners with different versions can silently change proof outcomes (passes at depth 32 on one machine, times out on another) — and there is no record of which version produced a given verdict. Pinning + hard-fail surfaces the drift instead of letting it ride.

## Schema

```yaml
cfg-fpv-tools:
  - name: "sby"
    tool: "sby"
    opts:
      timeout: 600
      solver-versions:
        yices: "2.6.4"
        z3: "4.13.0"
```

Known solver short names: `yices`, `z3`, `boolector`, `bitwuzla`, `btormc`, `abc`. Adding more is a one-line entry in `_PROBES`.

Per-verification `tool_overrides.<tool>.solver_versions` **replaces** the pinned set (not merges) — semantics is "use exactly this set", not "add to base".

## Failure behaviour

```
FPV solver version pin check failed:
  yices: pinned '2.6.4', found '2.6.3'
  z3: pinned '4.13.0', found '4.12.0'
```

All mismatches surface in one error so the user reruns once after fixing.

## Changes

- `src/rtl_buddy/tools/fpv_solver_pin.py` — new, ~100 LOC. `_PROBES` map of (binary, args, regex), `probe_solver_version()`, `check_solver_pins()`.
- `src/rtl_buddy/config/fpv.py` — `FpvToolOpts` gains `solver_versions: dict[str,str]`; `FpvToolOptsFile.solver_versions` deserializes from the `solver-versions` YAML key.
- `src/rtl_buddy/tools/sby_fpv.py` — `SbyFpv.run()` calls `check_solver_pins()` when pins are configured; logs `fpv.solver_pins_resolved` on success.
- `tests/test_fpv.py` — 11 new tests: config schema round-trip, override semantics, probe success/failure modes per solver, pin-check aggregation, missing-solver and empty-pins paths.
- `docs/concepts/fpv.md` — new "Solver version pinning" subsection + example in the `cfg-fpv-tools` schema block.
- `docs/reference/yaml.md` — schema example + description bullet updated for `cfg-fpv-tools`.

## Test plan

- [x] `uv run ruff check` — clean
- [x] `uv run pytest` — 573 pass + 1 pre-existing flake (test_wave_hub_bridge::test_scope_changed_event_broadcast, hub-server lifecycle artifact unrelated to this PR; passes in isolation)
- [ ] Manual: set `solver-versions: {yices: "0.0.0"}` in a real `root_config.yaml` and confirm `rb fpv <verif>` fails fast with the pin summary (requires a live sby setup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)