### PR TITLE
feat(fpv): optional constraints: field in fpv.yaml (#138)

### DIFF
--- a/docs/concepts/fpv.md
+++ b/docs/concepts/fpv.md
@@ -58,6 +58,7 @@ verifications:
     model: "demo_fifo"
     model_path: "../../design/demo_fifo/models.yaml"
     top: "demo_fifo"
+    constraints: "shared_clock_reset.sv"     # optional
     properties:
       - "demo_fifo_props.sv"
     mode: "bmc"
@@ -78,6 +79,7 @@ verifications:
 | `model_path` | Path to `models.yaml`, resolved relative to `fpv.yaml` |
 | `top` | Top module passed to `prep -top`; defaults to `model` when omitted |
 | `properties` | List of `.sv` files containing SVA properties / bound checker modules, resolved relative to `fpv.yaml`. Optional when properties are in-RTL under `` `ifdef FORMAL `` guards |
+| `constraints` | Optional path to a single `.sv` file containing environment `assume property` statements (clock toggle, reset sequence, etc.) — analogous to `constraints:` in `pnr.yaml`. Read into the sby script *before* `properties:` so the assumes are in scope when the asserts elaborate. Lets multiple verifications share one clock/reset boilerplate file instead of duplicating it across every bound checker. |
 | `mode` | One of `bmc` (bounded), `prove` (k-induction), `cover`, `live` |
 | `depth` | Cycle depth passed to sby; defaults to 20 |
 | `engines` | List of sby engine specs (e.g. `smtbmc yices`, `abc pdr`); defaults to `["smtbmc yices"]` |
@@ -86,7 +88,7 @@ verifications:
 
 ### Where inputs come from
 
-The runner reads the model's filelist via `VlogFilelist` (the same helper `rb synth` and `rb cdc` use), extracts source files and `+incdir+` entries, and emits them under the sby config's `[files]` and `[script]` sections respectively. Property files are appended to the same `read -sv -formal` block — they can be in-RTL with `` `ifdef FORMAL `` guards or standalone bound checker modules.
+The runner reads the model's filelist via `VlogFilelist` (the same helper `rb synth` and `rb cdc` use), extracts source files and `+incdir+` entries, and emits them under the sby config's `[files]` and `[script]` sections respectively. The script reads, in order: design sources → `constraints:` (if set) → `properties:`. Putting constraints before properties ensures their `assume property` statements are in scope when the assertions are elaborated. Property files can be in-RTL with `` `ifdef FORMAL `` guards or standalone bound checker modules.
 
 ## Root config: `cfg-fpv-tools`
 

--- a/docs/reference/yaml.md
+++ b/docs/reference/yaml.md
@@ -621,6 +621,7 @@ verifications:
     model: "demo_fifo"
     model_path: "../../design/demo_fifo/models.yaml"
     top: "demo_fifo"
+    constraints: "shared_clock_reset.sv"   # optional environment assumes
     properties:
       - "demo_fifo_props.sv"
     mode: "bmc"
@@ -661,6 +662,7 @@ verifications:
 | `model_path` | string | Path to `models.yaml`, resolved relative to the `fpv.yaml` file |
 | `top` | string | Top module name passed to `prep -top`; defaults to `model` |
 | `properties` | list | SystemVerilog files containing SVA properties / bound checkers, resolved relative to `fpv.yaml`. Optional when properties are in-RTL under `` `ifdef FORMAL `` guards |
+| `constraints` | string | Optional path to a single `.sv` file with environment `assume property` statements (clock toggle, reset sequence, etc.). Read into the sby script *before* `properties:` so the assumes are in scope when asserts elaborate. Resolved relative to `fpv.yaml`. Analogous to `constraints:` in `pnr.yaml` — separates "environment" from "what to prove" and lets multiple verifications share one clock/reset boilerplate. |
 | `mode` | string | One of `bmc`, `prove`, `cover`, `live`; defaults to `bmc` |
 | `depth` | int | Cycle depth for the proof; defaults to 20 |
 | `engines` | list | Sby engine specs (e.g. `smtbmc yices`, `abc pdr`); defaults to `["smtbmc yices"]` |

--- a/src/rtl_buddy/config/fpv.py
+++ b/src/rtl_buddy/config/fpv.py
@@ -81,6 +81,13 @@ class FpvConfigFile:
     tool: str
     top: str | None = None
     properties: list[str] = field(default_factory=list)
+    # Optional SVA/Verilog file with clock and reset `assume property`
+    # statements (and any other environment constraints). Read into the
+    # sby script *before* `properties:` so the assumes are in scope
+    # when the assertions are elaborated. Analogous to `constraints:`
+    # in `pnr.yaml` — separating intent ("environment") from "what to
+    # prove" lets multiple verifications share one boilerplate file.
+    constraints: str | None = None
     mode: str = "bmc"
     depth: int = 20
     engines: list[str] = field(default_factory=lambda: ["smtbmc yices"])
@@ -92,6 +99,9 @@ class FpvConfigFile:
             self.model
         )
         properties = [os.path.join(config_dir, p) for p in self.properties]
+        constraints = (
+            os.path.join(config_dir, self.constraints) if self.constraints else None
+        )
         if self.mode not in _VALID_MODES:
             raise FatalRtlBuddyError(
                 f"{self.name}: fpv mode '{self.mode}' is not one of "
@@ -104,6 +114,7 @@ class FpvConfigFile:
             tool=self.tool,
             top=self.top or self.model,
             properties=properties,
+            constraints=constraints,
             mode=self.mode,
             depth=self.depth,
             engines=list(self.engines),
@@ -124,6 +135,7 @@ class FpvConfig:
     depth: int
     engines: list[str]
     _reglvl: int | dict | None
+    constraints: str | None = dc_field(default=None)
     tool_overrides: dict | None = dc_field(default=None)
 
     def get_name(self) -> str:
@@ -140,6 +152,9 @@ class FpvConfig:
 
     def get_properties(self) -> list[str]:
         return self.properties
+
+    def get_constraints(self) -> str | None:
+        return self.constraints
 
     def get_mode(self) -> str:
         return self.mode

--- a/src/rtl_buddy/tools/sby_fpv.py
+++ b/src/rtl_buddy/tools/sby_fpv.py
@@ -156,10 +156,14 @@ class SbyFpv:
         lines.append("")
 
         # [script]
+        # Order: design sources -> constraints (assumes in scope first) ->
+        # properties (asserts that depend on those assumes).
         lines.append("[script]")
         for inc in incdirs:
             lines.append(f"verilog_defaults -add -I {inc}")
-        all_sources = list(sources) + list(cfg.get_properties())
+        constraints = cfg.get_constraints()
+        constraint_files = [constraints] if constraints else []
+        all_sources = list(sources) + constraint_files + list(cfg.get_properties())
         for src in all_sources:
             # Use basename — files are dropped into the sby workdir under [files].
             lines.append(f"read -sv -formal {os.path.basename(src)}")
@@ -196,6 +200,12 @@ class SbyFpv:
                 raise FatalRtlBuddyError(
                     f"{cfg.get_name()}: property file not found: {prop}"
                 )
+
+        constraints = cfg.get_constraints()
+        if constraints is not None and not os.path.isfile(constraints):
+            raise FatalRtlBuddyError(
+                f"{cfg.get_name()}: constraints file not found: {constraints}"
+            )
 
         sby_path = self._write_sby_file(sources, incdirs)
         log_path = self._log_path()

--- a/tests/test_fpv.py
+++ b/tests/test_fpv.py
@@ -272,7 +272,8 @@ def test_fpv_suite_config_constraints_resolved_relative_to_yaml(tmp_path):
     """A `constraints:` field in fpv.yaml is resolved relative to the yaml."""
     (tmp_path / "models.yaml").write_text(_MODELS_YAML)
     suite_yaml = tmp_path / "fpv.yaml"
-    suite_yaml.write_text(dedent("""\
+    suite_yaml.write_text(
+        dedent("""\
         rtl-buddy-filetype: fpv_config
 
         verifications:
@@ -290,7 +291,8 @@ def test_fpv_suite_config_constraints_resolved_relative_to_yaml(tmp_path):
             engines:
               - "smtbmc yices"
             reglvl: 0
-    """))
+    """)
+    )
     cfg = FpvSuiteConfig(str(suite_yaml))
     verif = cfg.get_verifications("fpv_with_constraints")[0]
     assert Path(verif.get_constraints()) == tmp_path / "shared_clock_reset.sv"

--- a/tests/test_fpv.py
+++ b/tests/test_fpv.py
@@ -36,6 +36,7 @@ def _make_fpv_cfg(
     tool="sby",
     top=None,
     properties=None,
+    constraints=None,
     mode="bmc",
     depth=20,
     engines=None,
@@ -52,6 +53,7 @@ def _make_fpv_cfg(
         tool=tool,
         top=top or model_name,
         properties=list(properties or []),
+        constraints=constraints,
         mode=mode,
         depth=depth,
         engines=list(engines or ["smtbmc yices"]),
@@ -256,6 +258,44 @@ def test_fpv_suite_config_paths_resolved_relative_to_yaml(tmp_path):
     assert Path(fpv_b.get_properties()[0]) == tmp_path / "mod_b_props.sv"
 
 
+def test_fpv_config_constraints_default_none():
+    cfg = _make_fpv_cfg()
+    assert cfg.get_constraints() is None
+
+
+def test_fpv_config_constraints_set_via_make():
+    cfg = _make_fpv_cfg(constraints="/abs/clock_reset.sv")
+    assert cfg.get_constraints() == "/abs/clock_reset.sv"
+
+
+def test_fpv_suite_config_constraints_resolved_relative_to_yaml(tmp_path):
+    """A `constraints:` field in fpv.yaml is resolved relative to the yaml."""
+    (tmp_path / "models.yaml").write_text(_MODELS_YAML)
+    suite_yaml = tmp_path / "fpv.yaml"
+    suite_yaml.write_text(dedent("""\
+        rtl-buddy-filetype: fpv_config
+
+        verifications:
+          - name: "fpv_with_constraints"
+            desc: "Has a shared constraints file"
+            model: "mod_a"
+            model_path: "models.yaml"
+            tool: "sby"
+            top: "mod_a"
+            constraints: "shared_clock_reset.sv"
+            properties:
+              - "mod_a_props.sv"
+            mode: "bmc"
+            depth: 16
+            engines:
+              - "smtbmc yices"
+            reglvl: 0
+    """))
+    cfg = FpvSuiteConfig(str(suite_yaml))
+    verif = cfg.get_verifications("fpv_with_constraints")[0]
+    assert Path(verif.get_constraints()) == tmp_path / "shared_clock_reset.sv"
+
+
 def test_fpv_suite_config_missing_name_raises(tmp_path):
     from rtl_buddy.errors import FatalRtlBuddyError
 
@@ -371,6 +411,85 @@ def test_sby_fpv_writes_sby_file_with_expected_sections(tmp_path):
     assert "[files]" in content
     assert str(src) in content
     assert str(props) in content
+
+
+def test_sby_fpv_writes_constraints_before_properties(tmp_path):
+    """When `constraints:` is set, it must be read into the sby script
+    BEFORE properties so the assumes are in scope when the asserts
+    elaborate."""
+    from rtl_buddy.tools.sby_fpv import SbyFpv
+
+    src = tmp_path / "design.sv"
+    src.write_text("module design(); endmodule\n")
+    constraints = tmp_path / "clock_reset.sv"
+    constraints.write_text("// clock + reset assumes\n")
+    props = tmp_path / "props.sv"
+    props.write_text("// SVA properties\n")
+    fl = tmp_path / "artefacts" / "demo" / "fpv.f"
+    fl.parent.mkdir(parents=True)
+    fl.write_text(f"{src}\n")
+
+    fpv_cfg = _make_fpv_cfg(
+        name="demo",
+        top="design",
+        properties=[str(props)],
+        constraints=str(constraints),
+    )
+    sby = SbyFpv(
+        name="t/sby",
+        fpv_cfg=fpv_cfg,
+        tool_cfg=_tool_cfg(),
+        suite_dir=str(tmp_path),
+    )
+    sources, incdirs = sby._parse_filelist(str(fl))
+    sby_path = sby._write_sby_file(sources, incdirs)
+    content = Path(sby_path).read_text()
+
+    # All three files appear in [script] and [files].
+    assert "read -sv -formal design.sv" in content
+    assert "read -sv -formal clock_reset.sv" in content
+    assert "read -sv -formal props.sv" in content
+    assert str(constraints) in content
+    # Constraints come before properties.
+    script_section = content.split("[script]")[1].split("[files]")[0]
+    constraints_pos = script_section.index("read -sv -formal clock_reset.sv")
+    props_pos = script_section.index("read -sv -formal props.sv")
+    assert constraints_pos < props_pos
+    # Files section preserves the same order.
+    files_section = content.split("[files]")[1]
+    files_constraints_pos = files_section.index(str(constraints))
+    files_props_pos = files_section.index(str(props))
+    assert files_constraints_pos < files_props_pos
+
+
+def test_sby_fpv_constraints_optional_default_unchanged(tmp_path):
+    """Without `constraints:` the script must not gain an extra read."""
+    from rtl_buddy.tools.sby_fpv import SbyFpv
+
+    src = tmp_path / "design.sv"
+    src.write_text("module design(); endmodule\n")
+    props = tmp_path / "props.sv"
+    props.write_text("// SVA properties\n")
+    fl = tmp_path / "artefacts" / "demo" / "fpv.f"
+    fl.parent.mkdir(parents=True)
+    fl.write_text(f"{src}\n")
+
+    fpv_cfg = _make_fpv_cfg(
+        name="demo",
+        top="design",
+        properties=[str(props)],
+        constraints=None,
+    )
+    sby = SbyFpv(
+        name="t/sby",
+        fpv_cfg=fpv_cfg,
+        tool_cfg=_tool_cfg(),
+        suite_dir=str(tmp_path),
+    )
+    sources, incdirs = sby._parse_filelist(str(fl))
+    content = Path(sby._write_sby_file(sources, incdirs)).read_text()
+    # Exactly two read statements: design + props.
+    assert content.count("read -sv -formal ") == 2
 
 
 def test_sby_fpv_parse_filelist_extracts_incdirs(tmp_path):


### PR DESCRIPTION
## Summary

- New optional `constraints:` field in `fpv.yaml` — single `.sv` file path, resolved relative to the yaml.
- Read into the sby `[script]` block **before** `properties:` so environment `assume property` statements (clock toggle, reset sequence, etc.) are in scope when assertions elaborate.
- File-exists validation before invoking sby (same shape as the existing property-file validation).
- Purely additive. The existing in-bound-checker pattern still works when `constraints:` is omitted.

Closes #138.

## Why

When you have multiple FPV suites in a project, the clock toggle and reset sequence assumes end up duplicated across every bound checker module. The `constraints:` field is analogous to `constraints:` in `pnr.yaml` — separates "environment" from "what to prove" and lets you share one boilerplate file across verifications.

This is the **minimal interpretation** of the issue: a schema-level escape hatch with deterministic file ordering, no auto-generation magic. The alternative (declarative `clock:` / `reset:` fields that the backend translates to Tcl) is much larger scope and overlaps the existing `properties:` list in semantically awkward ways. The lightweight `constraints:` field gives users the deduplication win the issue actually called out without growing schema we'd have to maintain.

## Schema

```yaml
verifications:
  - name: "demo_fpv_fifo"
    tool: "sby"
    model: "demo_fifo"
    model_path: "../../design/demo_fifo/models.yaml"
    top: "demo_fifo"
    constraints: "shared_clock_reset.sv"   # NEW — optional
    properties:
      - "demo_fifo_props.sv"
    mode: "bmc"
    depth: 32
    engines:
      - "smtbmc yices"
```

Reading order in the generated sby script: design sources → constraints → properties → `prep -top`.

## Changes

- `src/rtl_buddy/config/fpv.py` — `FpvConfigFile.constraints: str | None`; `FpvConfig.constraints`; `get_constraints()`. Path resolved against `config_dir` in `initialise()`.
- `src/rtl_buddy/tools/sby_fpv.py` — `_write_sby_file` interleaves the constraints file between sources and properties; `run()` validates the file exists with a clear error.
- `tests/test_fpv.py` — 5 new tests: default-None accessor, constructor passthrough, suite-config path resolution, write-sby-file ordering (constraints before properties in both `[script]` and `[files]`), and the no-constraints baseline.
- `docs/concepts/fpv.md` + `docs/reference/yaml.md` — schema example + field description + reading-order note.

## Test plan

- [x] `uv run ruff check` — clean
- [x] `uv run pytest` — 565 pass + 1 pre-existing hub-bridge flake (passes in isolation; same flake as PR #143)
- [ ] Manual: point `constraints:` at a real clock/reset .sv from a downstream project and confirm `rb fpv` still passes (requires live sby + a shared-constraints reference)

🤖 Generated with [Claude Code](https://claude.com/claude-code)