### PR TITLE
feat(hub): auto-discover SPA bundle from installed rtl-buddy-view

### DIFF
--- a/docs/concepts/hub.md
+++ b/docs/concepts/hub.md
@@ -54,7 +54,7 @@ uv run rb hub stop                    # graceful shutdown via SIGTERM
 
 `--daemon` is reserved; today it warns and runs in the foreground. Treat the explicit `--foreground` as load-bearing; future versions may detach when `--daemon` is given.
 
-`--serve-viewer` enables the HTTP + WebSocket layer (`/`, `/ws`) used by the browser SPA. Without `--viewer-bundle PATH` it serves a small placeholder page that proves the transport works — pass the path to a built rtl-buddy-view SPA (a directory containing `index.html` or a single `index.html`) to serve the real UI.
+`--serve-viewer` enables the HTTP + WebSocket layer (`/`, `/ws`) used by the browser SPA. When you omit `--viewer-bundle`, the hub auto-discovers the SPA shipped by [`rtl-buddy-view`](https://github.com/rtl-buddy/rtl-buddy-view) via `importlib.resources` — install it alongside rtl-buddy and `rb hub start --serve-viewer` is all you need. If rtl-buddy-view isn't installed (or you're on a checkout without a staged bundle), the hub falls back to a small placeholder page that proves the transport works. Pass `--viewer-bundle PATH` to override the auto-discovered bundle — useful when iterating on the SPA from a working tree (`viewer/dist/`) and you don't want the in-wheel copy from the installed package.
 
 ## Discovery (`.rtl-buddy/hub.json`)
 

--- a/src/rtl_buddy/hub/cli.py
+++ b/src/rtl_buddy/hub/cli.py
@@ -76,8 +76,9 @@ def cmd_start(
             "--serve-viewer/--no-serve-viewer",
             help=(
                 "Also serve the viewer HTTP+WebSocket layer at the http_port. "
-                "When no --viewer-bundle is given, a placeholder page proves "
-                "the transport works."
+                "When no --viewer-bundle is given, the hub auto-discovers the "
+                "SPA shipped by rtl-buddy-view (if installed) and falls back "
+                "to a placeholder page if neither is available."
             ),
         ),
     ] = False,
@@ -86,9 +87,12 @@ def cmd_start(
         typer.Option(
             "--viewer-bundle",
             help=(
-                "Path to a rtl-buddy-view SPA build (directory containing "
-                "index.html, or a path to a single index.html). Only used "
-                "with --serve-viewer."
+                "Override the auto-discovered SPA with this path (directory "
+                "containing index.html, or a path to a single index.html). "
+                "Use this when iterating on the SPA from a checkout — the "
+                "auto-discovered bundle ships with the installed wheel and "
+                "won't reflect uncommitted viewer/ changes. Only used with "
+                "--serve-viewer."
             ),
         ),
     ] = None,

--- a/src/rtl_buddy/hub/loop.py
+++ b/src/rtl_buddy/hub/loop.py
@@ -38,6 +38,25 @@ def _server_version() -> str:
         return "0.0.0+unknown"
 
 
+def _discover_viewer_bundle() -> Path | None:
+    """Return the SPA bundle shipped by rtl-buddy-view, or ``None``.
+
+    Lets ``rb hub start --serve-viewer`` work without ``--viewer-bundle``
+    when the user has rtl-buddy-view installed alongside rtl-buddy. The
+    package is an optional runtime peer — the hub doesn't declare it as
+    a hard dep, so the import is wrapped and a missing module is just
+    "no bundle here, use the placeholder."
+    """
+    try:
+        from rtl_buddy_view import viewer_bundle  # type: ignore[import-not-found]
+    except ImportError:
+        return None
+    try:
+        return viewer_bundle.path()
+    except Exception:  # noqa: BLE001 - defensive against API drift in the peer package
+        return None
+
+
 async def _run(
     project_root: Path,
     config: HubConfig,
@@ -62,11 +81,21 @@ async def _run(
     viewer: ViewerServer | None = None
     http_port: int | None = None
     if serve_viewer:
+        resolved_bundle = viewer_bundle
+        if resolved_bundle is None:
+            resolved_bundle = _discover_viewer_bundle()
+            if resolved_bundle is not None:
+                log_event(
+                    logger,
+                    logging.INFO,
+                    "hub.viewer.bundle_auto_discovered",
+                    path=str(resolved_bundle),
+                )
         viewer = ViewerServer(
             hub_host=host,
             hub_port=port,
             http_port=config.hub.http_port,
-            viewer_bundle=viewer_bundle,
+            viewer_bundle=resolved_bundle,
         )
         _vhost, vport = await viewer.start()
         http_port = vport

--- a/tests/test_hub_viewer_bundle_discovery.py
+++ b/tests/test_hub_viewer_bundle_discovery.py
@@ -1,0 +1,85 @@
+"""Tests for ``rtl_buddy.hub.loop._discover_viewer_bundle``.
+
+The discovery helper lets ``rb hub start --serve-viewer`` find the SPA
+shipped inside the installed ``rtl-buddy-view`` package, so users don't
+have to pass ``--viewer-bundle PATH`` for the common case.
+
+The helper is a *soft* dependency: rtl-buddy-view is not a hard runtime
+dep of rtl-buddy. If the package isn't installed, or its API drifts and
+``viewer_bundle.path()`` raises unexpectedly, the helper returns
+``None`` and the hub falls back to its placeholder page. These tests
+exercise both branches by feeding a fake ``rtl_buddy_view`` module into
+``sys.modules`` for the duration of each test.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+from rtl_buddy.hub.loop import _discover_viewer_bundle
+
+
+@pytest.fixture
+def fake_viewer_pkg(monkeypatch):
+    """Install a stub ``rtl_buddy_view`` package backed by an in-memory
+    ``viewer_bundle`` submodule with a configurable ``path()`` callable."""
+
+    pkg = types.ModuleType("rtl_buddy_view")
+    submod = types.ModuleType("rtl_buddy_view.viewer_bundle")
+
+    # Default to "no bundle"; individual tests override.
+    submod.path = lambda: None  # type: ignore[attr-defined]
+    pkg.viewer_bundle = submod  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "rtl_buddy_view", pkg)
+    monkeypatch.setitem(sys.modules, "rtl_buddy_view.viewer_bundle", submod)
+    return submod
+
+
+def test_returns_none_when_rtl_buddy_view_not_installed(monkeypatch):
+    """Import fails (peer package absent) → None.
+
+    Most CI environments installing only rtl-buddy will hit this path.
+    The hub must not crash; it must fall through to the placeholder.
+    """
+
+    # Hide any real install so the import lookup actually fails.
+    monkeypatch.setitem(sys.modules, "rtl_buddy_view", None)
+    monkeypatch.setitem(sys.modules, "rtl_buddy_view.viewer_bundle", None)
+    assert _discover_viewer_bundle() is None
+
+
+def test_returns_none_when_package_reports_no_bundle(fake_viewer_pkg):
+    """rtl-buddy-view installed but no bundle staged (e.g. running from
+    a clean checkout without scripts/prebuild_viewer.py) → None."""
+
+    fake_viewer_pkg.path = lambda: None  # type: ignore[attr-defined]
+    assert _discover_viewer_bundle() is None
+
+
+def test_returns_bundle_path_when_package_ships_it(fake_viewer_pkg, tmp_path: Path):
+    """rtl-buddy-view returns a real bundle path → helper forwards it."""
+
+    bundle = tmp_path / "_viewer_bundle"
+    bundle.mkdir()
+    (bundle / "index.html").write_text("<html>shipped</html>")
+    fake_viewer_pkg.path = lambda: bundle  # type: ignore[attr-defined]
+    assert _discover_viewer_bundle() == bundle
+
+
+def test_swallows_unexpected_exception_from_peer(fake_viewer_pkg):
+    """Defensive: if the peer package's path() raises (API drift, broken
+    install, …) we return None rather than crashing the hub.
+
+    Without this, a future rename in rtl-buddy-view would break every
+    rtl-buddy install that has both packages.
+    """
+
+    def boom() -> Path:
+        raise RuntimeError("simulated API drift")
+
+    fake_viewer_pkg.path = boom  # type: ignore[attr-defined]
+    assert _discover_viewer_bundle() is None


### PR DESCRIPTION
## Summary

Replaces the friction of `rb hub start --serve-viewer --viewer-bundle .../viewer/dist` with `rb hub start --serve-viewer`. The hub now imports the SPA path from the installed `rtl-buddy-view` package via `importlib.resources` and uses that automatically.

- **`src/rtl_buddy/hub/loop.py`** — new `_discover_viewer_bundle()` helper that imports `rtl_buddy_view.viewer_bundle` (soft dep, wrapped in try/except), calls `path()`, returns the result. Wired into the `serve_viewer` path so user-supplied `--viewer-bundle PATH` still wins when provided.
- **`src/rtl_buddy/hub/cli.py`** — updated `--serve-viewer` and `--viewer-bundle` help text to document the new auto-discovery + override semantics.
- **`docs/concepts/hub.md`** — describes the auto-discovery, the fallback to the placeholder, and when to use the explicit override (iterating on the SPA from a working tree).
- **`tests/test_hub_viewer_bundle_discovery.py`** — 4 unit tests covering: peer package not installed, peer reports no bundle, peer returns a real path, peer raises (API drift).

## Why a soft dependency

rtl-buddy-view ships its own Python wheel with its own release cadence. The hub doesn't need it to function — only to serve the real SPA instead of the placeholder. Making it a hard dep would pull a 1.4 MB JS bundle into every install of `rtl-buddy` (including pure-CLI uses like `rb regression`). The soft-dep pattern keeps `rb hier`-without-`rb hub` users on a slim install and gives the rest a one-step "install both" experience.

Companion PR rtl-buddy/rtl-buddy-view#52 (ships the SPA bundle inside the rtl-buddy-view wheel) is the upstream half; this PR is meaningless without it. Order of merging: rtl-buddy-view#52 → publish a wheel → this PR.

## Test plan

- [x] `uv run pytest tests/test_hub_viewer_bundle_discovery.py -v` — 4/4 pass
- [x] `uv run pytest tests/ -k hub` — 153 pass / 2 skipped (no regressions)
- [x] `uv run ruff check && uv run ruff format --check` — clean
- [x] `uv run python scripts/check_docs_frontmatter.py --check` — clean
- [x] End-to-end with the companion PR's branch: `uv pip install -e .../rtl-buddy-view` then `python -c "from rtl_buddy.hub.loop import _discover_viewer_bundle; print(_discover_viewer_bundle())"` returns the staged bundle path
- [x] Negative path verified: without rtl-buddy-view installed, the helper returns `None` and the hub falls through to the placeholder

## Failure modes covered

- **rtl-buddy-view not installed** → `ImportError` caught, returns `None`. Falls back to placeholder.
- **rtl-buddy-view installed but no bundle staged** (running from a clean checkout) → `viewer_bundle.path()` returns `None`. Hub uses placeholder.
- **rtl-buddy-view installed, future API change renames or breaks `path()`** → bare `Exception` catch returns `None`. Hub doesn't crash for a peer-package issue; logs nothing (silent fall-through is correct here — `--viewer-bundle` always-works escape hatch is documented in the CLI help).

## Out of scope

- Logging the placeholder fallback as a warning. The placeholder is a valid output (drives the transport smoke test); a warning would be noise for the `--no-viewer-bundle no-rtl-buddy-view` case. The hub already emits `hub.viewer.bundle_auto_discovered` when discovery succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)