### PR TITLE
feat(hub): print connection info on rb hub start

### DIFF
--- a/src/rtl_buddy/hub/loop.py
+++ b/src/rtl_buddy/hub/loop.py
@@ -20,7 +20,7 @@ from importlib.metadata import version as _pkg_version
 from pathlib import Path
 from typing import Any
 
-from ..logging_utils import log_event
+from ..logging_utils import emit_console_text, log_event
 from .config import HubConfig
 from .discovery import delete_record_if_owner, write_record
 from .resolver import Resolver, default_view_json_path
@@ -36,6 +36,40 @@ def _server_version() -> str:
         return _pkg_version("rtl-buddy")
     except PackageNotFoundError:
         return "0.0.0+unknown"
+
+
+def _print_startup_banner(
+    *,
+    tcp_host: str,
+    tcp_port: int,
+    http_port: int | None,
+    view_json_path: Path | None,
+    log_path: Path | None,
+) -> None:
+    """Print connection info to stdout so the user isn't left guessing
+    after ``rb hub start`` blocks the terminal.
+
+    Adapter peers (nvim, ``rb wave``) auto-discover the hub via
+    ``.rtl-buddy/hub.json`` so they don't need this output — the
+    browser-bound viewer URL is the main thing we're surfacing. The
+    explicit "Press Ctrl-C" line documents that the foregrounded
+    process is by design (``--daemon`` warns and stays in foreground).
+    """
+    lines = ["rtl-buddy-hub running."]
+    if http_port is not None:
+        url = f"http://127.0.0.1:{http_port}/"
+        # Append the auto-load query string only when the view.json is
+        # actually servable — otherwise it'd 404 and the SPA would land
+        # in the empty state with a misleading URL on the user's first
+        # click.
+        if view_json_path is not None and view_json_path.is_file():
+            url += "?view=/view.json"
+        lines.append(f"  Viewer:   {url}")
+    lines.append(f"  TCP:      {tcp_host}:{tcp_port}")
+    if log_path is not None:
+        lines.append(f"  Logs:     {log_path}")
+    lines.append("Press Ctrl-C to stop.")
+    emit_console_text("\n".join(lines))
 
 
 def _discover_viewer_bundle() -> Path | None:
@@ -113,6 +147,16 @@ async def _run(
         tcp=f"{host}:{port}",
         server_version=server.server_version,
         http_port=http_port,
+    )
+
+    _print_startup_banner(
+        tcp_host=host,
+        tcp_port=port,
+        http_port=http_port,
+        view_json_path=view_json_path,
+        log_path=(project_root / config.hub.log_path).resolve()
+        if config.hub.log_path
+        else None,
     )
 
     loop = asyncio.get_running_loop()

--- a/tests/test_hub_startup_banner.py
+++ b/tests/test_hub_startup_banner.py
@@ -1,0 +1,103 @@
+"""Tests for ``rtl_buddy.hub.loop._print_startup_banner``.
+
+The banner is the first thing a user sees after ``rb hub start``;
+silently blocking the terminal was the #1 papercut in early demos.
+Exercise the conditional pieces:
+
+* viewer URL only when ``--serve-viewer`` provided an http_port
+* ``?view=/view.json`` suffix only when view_json_path resolves to
+  an existing file (don't dangle a 404 URL)
+* logs line only when ``[hub].log_path`` is configured
+* TCP + the Ctrl-C hint are always present
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from rtl_buddy.hub.loop import _print_startup_banner
+
+
+def test_banner_tcp_only_no_viewer(capfd):
+    """Without --serve-viewer there's no HTTP port — only TCP."""
+
+    _print_startup_banner(
+        tcp_host="127.0.0.1",
+        tcp_port=12345,
+        http_port=None,
+        view_json_path=None,
+        log_path=None,
+    )
+    out = capfd.readouterr().err
+    assert "rtl-buddy-hub running." in out
+    assert "TCP:      127.0.0.1:12345" in out
+    assert "Viewer:" not in out
+    assert "Logs:" not in out
+    assert "Press Ctrl-C to stop." in out
+
+
+def test_banner_with_viewer_but_no_view_json(capfd):
+    """With --serve-viewer but no view.json on disk, the viewer URL
+    omits the ?view=/view.json suffix so the user doesn't click into
+    a 404."""
+
+    _print_startup_banner(
+        tcp_host="127.0.0.1",
+        tcp_port=12345,
+        http_port=54321,
+        view_json_path=None,
+        log_path=None,
+    )
+    out = capfd.readouterr().err
+    assert "Viewer:   http://127.0.0.1:54321/" in out
+    assert "?view=" not in out
+
+
+def test_banner_view_json_path_set_but_file_missing(capfd, tmp_path: Path):
+    """view_json_path configured but file doesn't exist → no ?view=
+    suffix (matches the /view.json 404 behaviour from #141)."""
+
+    missing = tmp_path / "view.json"
+    _print_startup_banner(
+        tcp_host="127.0.0.1",
+        tcp_port=12345,
+        http_port=54321,
+        view_json_path=missing,
+        log_path=None,
+    )
+    out = capfd.readouterr().err
+    assert "Viewer:   http://127.0.0.1:54321/" in out
+    assert "?view=" not in out
+
+
+def test_banner_view_json_present_appends_query(capfd, tmp_path: Path):
+    """view.json exists → URL includes the auto-load query string."""
+
+    view_json = tmp_path / "view.json"
+    view_json.write_text('{"schema_version":"1.0"}')
+    _print_startup_banner(
+        tcp_host="127.0.0.1",
+        tcp_port=12345,
+        http_port=54321,
+        view_json_path=view_json,
+        log_path=None,
+    )
+    out = capfd.readouterr().err
+    assert "Viewer:   http://127.0.0.1:54321/?view=/view.json" in out
+
+
+def test_banner_includes_log_path_when_configured(capfd, tmp_path: Path):
+    log_path = tmp_path / "hub.log"
+    _print_startup_banner(
+        tcp_host="127.0.0.1",
+        tcp_port=12345,
+        http_port=None,
+        view_json_path=None,
+        log_path=log_path,
+    )
+    # Rich wraps long paths mid-string when the terminal width is narrow
+    # (as it is under pytest capture). Strip whitespace before asserting so
+    # the path-on-disk shows up as one contiguous substring.
+    out = "".join(capfd.readouterr().err.split())
+    assert "Logs:" in out
+    assert "".join(str(log_path).split()) in out


### PR DESCRIPTION
## Summary

Closes the #1 papercut from recent demos: `rb hub start` previously blocked the terminal with zero output, leaving users to dig the viewer URL out of `rb hub status` or `.rtl-buddy/hub.json`. Prints a short banner to stderr after the listeners bind, before the asyncio loop blocks:

```
rtl-buddy-hub running.
  Viewer:   http://127.0.0.1:59629/?view=/view.json
  TCP:      127.0.0.1:59628
  Logs:     /path/to/.rtl-buddy/hub.log
Press Ctrl-C to stop.
```

## Conditional lines

- **Viewer:** only with `--serve-viewer`. The `?view=/view.json` suffix only when `[mapping].view_json` resolves to an existing file (matches the `/view.json` 404 behaviour from #141, so the user doesn't click into a dead URL).
- **TCP:** always — peers can connect via this even without the viewer HTTP layer.
- **Logs:** only when `[hub].log_path` is configured (default is `.rtl-buddy/hub.log` so the line shows in the common case).
- **Press Ctrl-C:** documents that foregrounded blocking is by design (matches existing `--daemon` behaviour where we warn and stay in foreground).

## Why stderr

Diagnostic / informational output goes to stderr by convention (`ssh`, `git`, `npm`, `cargo` all do this). Keeps stdout clean for callers that pipe `rb hub` invocations — e.g. a hypothetical wrapper that watches `rb hub log` could still pipe cleanly. The existing `emit_console_text` helper already defaults to stderr.

## Test plan

- [x] `uv run pytest tests/test_hub_startup_banner.py` — 5 new tests, all pass (TCP-only, viewer-with-no-view-json, view_json-missing-file, view_json-present, log_path-set)
- [x] `uv run pytest tests/ -k hub` — 171 pass / 2 skipped (one unrelated `test_wave_hub_bridge` flake, passes in isolation; not introduced here)
- [x] `uv run ruff check && uv run ruff format --check` — clean
- [x] Live: `uv run rb hub start --serve-viewer` against the demo-tiny-npu project prints the expected 4-line banner (`Viewer:`, `TCP:`, `Logs:`, `Press Ctrl-C to stop.`); URL works in the browser.

## Out of scope

- Coloured output (the `emit_console_text` helper supports `style=` but plain text reads fine in non-TTY contexts like CI logs, and the demo doesn't need it).
- Including `--viewer-bundle` source (auto-discovered vs explicit). Could be added as a debug `--verbose` flag later but adds noise to the default banner.
- Updating `--daemon` to background after print. Separate concern from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)