### PR TITLE
docs(readme): refresh Features list for CDC, FPV, PnR, power, hub, hier, spec, wave, cocotb

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 [![License](https://img.shields.io/badge/license-BSD--3--Clause-blue)](LICENSE)
 [![Docs](https://img.shields.io/badge/docs-rtl--buddy.github.io-blue)](https://rtl-buddy.github.io/rtl_buddy/)
 
-`rtl_buddy` is a Python CLI for running Verilog and SystemVerilog RTL tests, randomized regressions, filelist generation, Verilator/VCS simulator workflows, Yosys synthesis flows, coverage, and adjacent verification automation. It is designed to work well for both humans and AI agents.
+`rtl_buddy` is a Python CLI for Verilog and SystemVerilog RTL design and verification workflows: simulator-driven tests and randomized regressions, filelist generation, synthesis, place-and-route, power analysis, CDC lint, formal property verification, waveform viewing, hierarchy rendering, spec traceability, and adjacent automation. It is designed to work well for both humans and AI agents.
 
-It is built to sit on top of the tools your project already uses, while giving you a cleaner, more repeatable interface for day-to-day verification work. The primary supported simulation flows are Verilator and VCS-based compile, simulation, test, regression, as well as Yosys-based synthesis. Basic Verible command integration exists, while broader first-class Verible and PeakRDL workflows are on the roadmap.
+It is built to sit on top of the tools your project already uses, while giving you a cleaner, more repeatable interface for day-to-day RTL work. Current first-class flows cover Verilator/VCS simulation (with optional cocotb), Yosys synthesis (with optional yosys-slang frontend), OpenROAD-based place-and-route and power analysis, [rtl-buddy-cdc](https://github.com/rtl-buddy/rtl-buddy-cdc) CDC lint, SymbiYosys formal verification, and Surfer-based waveform viewing with live editor annotation. Basic Verible command integration exists; broader first-class Verible and PeakRDL workflows are on the roadmap.
 
 Typical commands look like:
 
@@ -16,6 +16,10 @@ uv run rb test basic
 uv run rb test smoke --repeat 20
 uv run rb regression
 uv run rb regression --coverage-merge
+uv run rb synth -c synth/sandbox/synth.yaml
+uv run rb cdc -c cdc/sandbox/cdc.yaml
+uv run rb fpv -c fpv/sandbox/fpv.yaml
+uv run rb wave basic
 ```
 
 ## Why `rtl_buddy`
@@ -30,12 +34,21 @@ uv run rb regression --coverage-merge
 
 ## Features
 
-- **Test and regression commands**: run one test, many tests, or whole suites with a consistent CLI
+- **Test and regression commands**: run one test, many tests, or whole suites with a consistent CLI across Verilator and VCS
 - **Randomized testing support**: create new seeds, repeat runs, and replay previous randomized iterations
 - **Structured config model**: describe suites, regressions, platforms, builders, and models in readable YAML
 - **Filelist generation**: build simulator-ready filelists from `models.yaml`
-- **Synthesis flows**: run Yosys synthesis from `synth.yaml`, including optional Liberty-mapped runs and synthesis regressions
+- **Synthesis flows** (`rb synth`): run Yosys synthesis from `synth.yaml`, including optional Liberty-mapped runs, synthesis regressions, configurable effort levels, and an optional yosys-slang frontend; OpenROAD is also available as an alternative backend
+- **Place-and-route** (`rb pnr`): OpenROAD-driven flow that consumes the post-synth netlist and produces routed DEF, post-route netlist + SDC, and timing/DRC reports
+- **Power analysis** (`rb power`, `rb power-regression`): OpenROAD `report_power` over post-synth or post-PnR netlists, with static, synthetic, or SAIF/VCD activity sources (`rb saif` converts FST/VCD traces to SAIF v2.0)
+- **CDC lint** (`rb cdc`, `rb cdc-regression`): first-class integration with [rtl-buddy-cdc](https://github.com/rtl-buddy/rtl-buddy-cdc)
+- **Formal property verification** (`rb fpv`, `rb fpv-regression`): SymbiYosys-driven proofs with reproducible solver pinning; `rb wave-fpv` opens the counterexample VCD for a failed run
+- **Waveform viewing** (`rb wave`): opens [Surfer](https://surfer-project.org/) with live signal-value annotation in your editor via the WCP protocol
+- **Hierarchy rendering** (`rb hier`): module hierarchy diagrams via [rtl-buddy-view](https://github.com/rtl-buddy/rtl-buddy-view)
+- **Coordination hub** (`rb hub`): TCP + HTTP/WebSocket broker that mediates between the rtl-buddy-view SPA, Surfer (via `rb wave`), and editor adapters; optional macOS LaunchAgent install
+- **Spec traceability** (`rb spec`): trace `specs.yaml` items to design models (`check-design`) and tests (`check-coverage`)
 - **Coverage workflows**: collect, merge, summarize, and export Verilator coverage
+- **cocotb support**: Verilator + VPI cocotb tests integrated into the standard test/regression flow
 - **Hookable execution flow**: plug in your own sweep generation, test preprocessing, and postprocessing scripts
 - **Verible integration**: invoke lint, syntax, formatting, and preprocessing commands through the same project config
 - **Rich outputs for humans**: displays pretty formatted for easy reading
@@ -64,7 +77,7 @@ Prerequisites:
 - Python 3.11+
 - `uv`
 
-Beyond Python and `uv`, every other dependency is feature-dependent: which external tools you need depends on which `rb` commands you use. For example, `rb test` needs a simulator (Verilator / VCS), `rb synth` needs the [rtl-buddy/yosys fork](https://github.com/rtl-buddy/yosys), `rb wave` needs the [rtl-buddy/surfer fork](https://github.com/rtl-buddy/surfer).
+Beyond Python and `uv`, every other dependency is feature-dependent: which external tools you need depends on which `rb` commands you use. For example, `rb test` needs a simulator (Verilator / VCS), `rb synth` needs the [rtl-buddy/yosys fork](https://github.com/rtl-buddy/yosys), `rb pnr` and `rb power` need OpenROAD, `rb cdc` needs [rtl-buddy-cdc](https://github.com/rtl-buddy/rtl-buddy-cdc), `rb fpv` needs [SymbiYosys](https://github.com/YosysHQ/sby) plus an SMT solver, `rb hier` needs [rtl-buddy-view](https://github.com/rtl-buddy/rtl-buddy-view), and `rb wave` needs the [rtl-buddy/surfer fork](https://github.com/rtl-buddy/surfer).
 
 See the [installation page](https://rtl-buddy.github.io/rtl_buddy/latest/install/) for the full feature-to-dependency matrix, including integration types (Integrated tool vs Pluggable vs Pluggable — curated) and install commands.
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 [![License](https://img.shields.io/badge/license-BSD--3--Clause-blue)](LICENSE)
 [![Docs](https://img.shields.io/badge/docs-rtl--buddy.github.io-blue)](https://rtl-buddy.github.io/rtl_buddy/)
 
-`rtl_buddy` is a Python CLI for Verilog and SystemVerilog RTL design and verification workflows: simulator-driven tests and randomized regressions, filelist generation, synthesis, place-and-route, power analysis, CDC lint, formal property verification, waveform viewing, hierarchy rendering, spec traceability, and adjacent automation. It is designed to work well for both humans and AI agents.
+`rtl_buddy` is a Python CLI for Verilog and SystemVerilog RTL design and verification workflows: simulator-driven tests and randomized regressions, filelist generation, synthesis, place-and-route, power analysis, CDC lint, formal property verification, waveform viewing, hierarchy rendering, AXI interconnect profiling, spec traceability, and adjacent automation. It is designed to work well for both humans and AI agents.
 
-It is built to sit on top of the tools your project already uses, while giving you a cleaner, more repeatable interface for day-to-day RTL work. Current first-class flows cover Verilator/VCS simulation (with optional cocotb), Yosys synthesis (with optional yosys-slang frontend), OpenROAD-based place-and-route and power analysis, [rtl-buddy-cdc](https://github.com/rtl-buddy/rtl-buddy-cdc) CDC lint, SymbiYosys formal verification, and Surfer-based waveform viewing with live editor annotation. Basic Verible command integration exists; broader first-class Verible and PeakRDL workflows are on the roadmap.
+It is built to sit on top of the tools your project already uses, while giving you a cleaner, more repeatable interface for day-to-day RTL work. Current first-class flows cover Verilator/VCS simulation (with optional cocotb), Yosys synthesis (with optional yosys-slang frontend), OpenROAD-based place-and-route and power analysis, [rtl-buddy-cdc](https://github.com/rtl-buddy/rtl-buddy-cdc) CDC lint, SymbiYosys formal verification, and Surfer-based waveform viewing with live editor annotation. Verible command integration covers lint, syntax, format, preprocessor, and `verible.filelist` generation; broader first-class Verible and PeakRDL workflows are on the roadmap.
 
 Typical commands look like:
 
@@ -20,6 +20,8 @@ uv run rb synth -c synth/sandbox/synth.yaml
 uv run rb cdc -c cdc/sandbox/cdc.yaml
 uv run rb fpv -c fpv/sandbox/fpv.yaml
 uv run rb wave basic
+uv run rb axi-profile run basic
+uv run rb tool-check
 ```
 
 ## Why `rtl_buddy`
@@ -44,13 +46,15 @@ uv run rb wave basic
 - **CDC lint** (`rb cdc`, `rb cdc-regression`): first-class integration with [rtl-buddy-cdc](https://github.com/rtl-buddy/rtl-buddy-cdc)
 - **Formal property verification** (`rb fpv`, `rb fpv-regression`): SymbiYosys-driven proofs with reproducible solver pinning; `rb wave-fpv` opens the counterexample VCD for a failed run
 - **Waveform viewing** (`rb wave`): opens [Surfer](https://surfer-project.org/) with live signal-value annotation in your editor via the WCP protocol
-- **Hierarchy rendering** (`rb hier`): module hierarchy diagrams via [rtl-buddy-view](https://github.com/rtl-buddy/rtl-buddy-view)
-- **Coordination hub** (`rb hub`): TCP + HTTP/WebSocket broker that mediates between the rtl-buddy-view SPA, Surfer (via `rb wave`), and editor adapters; optional macOS LaunchAgent install
+- **Hierarchy rendering** (`rb hier`): module hierarchy diagrams via [rtl-buddy-view](https://github.com/rtl-buddy/rtl-buddy-view), with optional CDC and RDC clock-domain annotations
+- **AXI interconnect profiling** (`rb axi-profile`): discover AXI bundles from RTL, emit a bind-style SV monitor, ingest a test's FST into per-test `axi-perf.json` + per-transaction Parquet, and launch a packaged marimo notebook for interactive analysis
+- **Coordination hub** (`rb hub`): TCP + HTTP/WebSocket broker that mediates between the rtl-buddy-view SPA, Surfer (via `rb wave`), and editor adapters; supports runtime model switching, AXI-perf overlays, and CDC diagnostics; optional macOS LaunchAgent install
 - **Spec traceability** (`rb spec`): trace `specs.yaml` items to design models (`check-design`) and tests (`check-coverage`)
+- **Tool dependency check** (`rb tool-check`): declarative manifest of external tool dependencies — reports which `rb` subcommands are ready and which are blocked on missing or out-of-version tools
 - **Coverage workflows**: collect, merge, summarize, and export Verilator coverage
 - **cocotb support**: Verilator + VPI cocotb tests integrated into the standard test/regression flow
 - **Hookable execution flow**: plug in your own sweep generation, test preprocessing, and postprocessing scripts
-- **Verible integration**: invoke lint, syntax, formatting, and preprocessing commands through the same project config
+- **Verible integration** (`rb verible`): invoke lint, syntax, formatting, and preprocessor commands through the same project config, plus generate `verible.filelist` from `models.yaml` for `verible-verilog-ls`
 - **Rich outputs for humans**: displays pretty formatted for easy reading
 - **Structured logging for machines**: emits JSONL logs for interpretation by CI systems, automation, and coding agents
 - **Cross-project reuse**: keep one tool interface while adapting it to different RTL repo layouts and builder setups


### PR DESCRIPTION
## Summary

README hadn't been refreshed since the v0.x era and was missing roughly a year of feature work. This brings it in line with `main` as of the PR's tip.

Touches the opening paragraphs, the typical-commands snippet, the Features list, and the external-tool sentence under Installation. No CLI behavior changes, no doc-site changes in this PR — only `README.md`.

## What's now mentioned that wasn't before

| Area | Commands / surface |
|---|---|
| Simulation breadth | `rb test` / `rb regression` across **Verilator and VCS** |
| cocotb | Verilator + VPI cocotb tests integrated into the standard test/regression flow |
| Synthesis additions | yosys-slang frontend, configurable effort levels, OpenROAD as alternative backend |
| Place-and-route | `rb pnr` (OpenROAD) |
| Power analysis | `rb power`, `rb power-regression`, `rb saif` (OpenROAD `report_power`) |
| CDC lint | `rb cdc`, `rb cdc-regression` (via [rtl-buddy-cdc](https://github.com/rtl-buddy/rtl-buddy-cdc)) |
| Formal verification | `rb fpv`, `rb fpv-regression`, `rb wave-fpv` (SymbiYosys, solver pinning) |
| Waveform viewing | `rb wave` (Surfer + WCP, live editor annotation) |
| Hierarchy rendering | `rb hier` (via [rtl-buddy-view](https://github.com/rtl-buddy/rtl-buddy-view)) with optional `--cdc-annotations` / `--rdc-annotations` |
| AXI profiling | `rb axi-profile run / discover / gen-monitor / notebook` (per-test FST → `axi-perf.json` + per-txn Parquet, packaged marimo notebook) |
| Coordination hub | `rb hub` (TCP + HTTP/WebSocket broker) with runtime model switching, AXI-perf overlays, CDC diagnostics; optional macOS LaunchAgent install |
| Spec traceability | `rb spec list / check-design / check-coverage` |
| Verible | `rb verible filelist` (generates `verible.filelist` from `models.yaml`) alongside existing lint / syntax / format / preprocessor |
| Tool readiness | `rb tool-check` (declarative manifest of external tool deps + per-subcommand readiness) |

The Verible / PeakRDL roadmap line is preserved — broader first-class Verible and PeakRDL workflows are still on the roadmap.

## Out of scope (intentional)

- No `docs/concepts/` pages added for `axi-profile`, `tool-check`, `cdc`, `hier`, or `spec`. Those should land in their own follow-ups; this PR is README-only so it can be reviewed against the CLI surface in isolation.
- No `docs/reference/cli.md` regeneration needed — no CLI surface changed in this PR (`scripts/gen_cli_reference.py --check` would no-op).

## Test plan

- [ ] Render the README on the PR page and skim for layout regressions — the Features bullets are longer; check that wrapping still feels OK on GitHub.
- [ ] Confirm every `rb <subcommand>` mentioned matches an entry registered in `src/rtl_buddy/rtl_buddy.py` (top-level + Typer sub-apps).
- [ ] Sanity-check the external-tool links (`rtl-buddy-cdc`, `rtl-buddy-view`, `rtl-buddy/yosys`, `rtl-buddy/surfer`, `YosysHQ/sby`, OpenROAD via the install doc).
- [ ] No CI changes expected — neither `docs/` nor any CLI surface changed, so `scripts/check_docs_frontmatter.py --check` and `scripts/gen_cli_reference.py --check` are both no-ops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)