### PR TITLE
feat(fpv): per-engine status aggregation from sby logfile (#133)

### DIFF
--- a/docs/concepts/fpv.md
+++ b/docs/concepts/fpv.md
@@ -148,8 +148,11 @@ A summary table prints after each run:
 ```
 
 - **Mode / Depth / Engines** — what was actually run, surfaced for quick triage.
+- **Engine Results** — per-engine verdict mix parsed from `<workdir>/logfile.txt`'s `summary: engine_<N> (...) returned <verdict>` lines. Renders compactly: `1/1 pass (smtbmc yices)` for single-engine runs, `2/2 pass` when all of multiple engines agree, `1/2 pass (smtbmc yices won)` when only some succeed. Shows `-` when sby died before producing a logfile.
 - **Runtime** — wall-clock seconds for the sby invocation.
 - **Description** — `property proved (...)` on pass; on fail, the path to the counterexample VCD when available.
+
+> **Per-property granularity is not surfaced.** Sby has no structured per-assertion output today — `fpv.xml` is JUnit-style per-task only and the prose log doesn't tag individual assertions. Per-engine status is the finest grain `rb fpv` exposes; per-property aggregation would need a yosys-frontend change to dump assertion identifiers + per-COI status.
 
 ## Artefacts
 

--- a/src/rtl_buddy/rtl_buddy.py
+++ b/src/rtl_buddy/rtl_buddy.py
@@ -2342,11 +2342,14 @@ class RtlBuddy:
     # --- FPV subcommands ----------------------------------------------------
 
     def _render_fpv_summary(self, title, fpv_results, *, metadata=None):
+        from .tools.fpv_log_parse import summarize_engines
+
         rows = []
         for r in fpv_results:
             res = r["results"].results
             engines = res.get("engines") or []
             runtime = res.get("runtime_s")
+            per_engine = res.get("per_engine") or []
             row = {
                 "fpv_name": r["fpv_name"],
                 "result": res["result"],
@@ -2354,6 +2357,7 @@ class RtlBuddy:
                 "mode": str(res.get("mode", "-")),
                 "depth": str(res.get("depth", "-")),
                 "engines": ", ".join(engines) if engines else "-",
+                "engine_results": summarize_engines(per_engine) if per_engine else "-",
                 "runtime": f"{runtime:.1f}s" if runtime is not None else "-",
             }
             rows.append(row)
@@ -2365,6 +2369,7 @@ class RtlBuddy:
             ("mode", "Mode"),
             ("depth", "Depth"),
             ("engines", "Engines"),
+            ("engine_results", "Engine Results"),
             ("runtime", "Runtime"),
         ]
         render_summary(

--- a/src/rtl_buddy/runner/fpv_results.py
+++ b/src/rtl_buddy/runner/fpv_results.py
@@ -30,6 +30,7 @@ class FpvPassResults(FpvResults):
         depth: int,
         engines: list[str] | None = None,
         runtime_s: float | None = None,
+        per_engine: list[dict] | None = None,
     ):
         desc = f"property proved ({mode}, depth {depth})"
         super().__init__(
@@ -41,6 +42,10 @@ class FpvPassResults(FpvResults):
         self.results["engines"] = list(engines) if engines is not None else []
         if runtime_s is not None:
             self.results["runtime_s"] = runtime_s
+        # per_engine carries the parsed `summary: engine_<N> ...`
+        # lines from sby's logfile.txt: list of dicts with idx, spec,
+        # verdict, trace_count. Empty when no logfile was produced.
+        self.results["per_engine"] = list(per_engine) if per_engine is not None else []
 
 
 class FpvFailResults(FpvResults):
@@ -53,6 +58,7 @@ class FpvFailResults(FpvResults):
         engines: list[str] | None = None,
         runtime_s: float | None = None,
         desc: str | None = None,
+        per_engine: list[dict] | None = None,
     ):
         msg = desc or f"property disproved ({mode}, depth {depth})"
         super().__init__(
@@ -64,6 +70,7 @@ class FpvFailResults(FpvResults):
         self.results["engines"] = list(engines) if engines is not None else []
         if runtime_s is not None:
             self.results["runtime_s"] = runtime_s
+        self.results["per_engine"] = list(per_engine) if per_engine is not None else []
 
 
 class FpvSkipResults(FpvResults):

--- a/src/rtl_buddy/tools/fpv_log_parse.py
+++ b/src/rtl_buddy/tools/fpv_log_parse.py
@@ -1,0 +1,123 @@
+"""Per-engine status extraction from SymbiYosys ``logfile.txt``.
+
+Sby's ``status`` file gives the overall verdict; the per-engine
+breakdown lives only in the prose ``logfile.txt``. The relevant lines
+share a stable ``summary:`` prefix:
+
+    SBY ... summary: engine_0 (smtbmc yices) returned pass
+    SBY ... summary: engine_0 did not produce any traces
+    SBY ... summary: engine_1 (smtbmc z3) returned pass
+    SBY ... summary: Elapsed clock time [H:MM:SS (secs)]: 0:00:00 (0)
+
+We parse those into a per-engine list so the ``rb fpv`` results table
+can show which engines ran and which won.
+
+Per-property granularity is not extractable — sby has no
+structured per-assertion output today (see #133).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+
+_ENGINE_VERDICT_RE = re.compile(
+    r"summary:\s+engine_(?P<idx>\d+)\s+\((?P<spec>[^)]*)\)\s+returned\s+(?P<verdict>\S+)"
+)
+_ENGINE_TRACE_RE = re.compile(
+    r"summary:\s+engine_(?P<idx>\d+)\s+"
+    r"(?P<msg>did not produce any traces|produced (?P<count>\d+) traces?)"
+)
+_ELAPSED_RE = re.compile(
+    r"summary:\s+Elapsed clock time \[H:MM:SS \(secs\)\]:\s+\S+\s+\((?P<secs>\d+)\)"
+)
+
+
+@dataclass
+class EnginePartial:
+    """One engine's parsed view of the logfile. Verdict is None until
+    the corresponding ``returned X`` line is seen."""
+
+    idx: int
+    spec: str | None = None
+    verdict: str | None = None
+    trace_count: int | None = None  # None = unknown, 0 = explicit "did not produce"
+
+    def to_dict(self) -> dict:
+        return {
+            "idx": self.idx,
+            "spec": self.spec,
+            "verdict": self.verdict,
+            "trace_count": self.trace_count,
+        }
+
+
+def parse_engine_summary(log_text: str) -> list[dict]:
+    """Return a list of engine dicts sorted by index, parsed from
+    ``logfile.txt`` text. Empty list when no engine summary lines are
+    present (failed setup, sby exited before any engine ran).
+    """
+    engines: dict[int, EnginePartial] = {}
+    for line in log_text.splitlines():
+        m = _ENGINE_VERDICT_RE.search(line)
+        if m:
+            idx = int(m["idx"])
+            entry = engines.setdefault(idx, EnginePartial(idx=idx))
+            entry.spec = m["spec"].strip()
+            entry.verdict = m["verdict"]
+            continue
+        m = _ENGINE_TRACE_RE.search(line)
+        if m:
+            idx = int(m["idx"])
+            entry = engines.setdefault(idx, EnginePartial(idx=idx))
+            if m["msg"].startswith("did not"):
+                entry.trace_count = 0
+            elif m["count"]:
+                entry.trace_count = int(m["count"])
+    return [engines[i].to_dict() for i in sorted(engines)]
+
+
+def parse_elapsed_seconds(log_text: str) -> int | None:
+    """Return the elapsed clock time in seconds from the logfile, or
+    ``None`` when the summary line is missing."""
+    m = _ELAPSED_RE.search(log_text)
+    return int(m["secs"]) if m else None
+
+
+def read_workdir_log(workdir: str) -> str | None:
+    """Convenience: read ``<workdir>/logfile.txt`` if present."""
+    path = Path(workdir) / "logfile.txt"
+    if not path.is_file():
+        return None
+    return path.read_text()
+
+
+def summarize_engines(per_engine: list[dict]) -> str:
+    """Compact one-line render of a per-engine list for the results
+    table. Examples:
+
+        []                             -> "no engine data"
+        [pass]                         -> "1/1 pass (smtbmc yices)"
+        [pass, pass]                   -> "2/2 pass"
+        [pass, fail]                   -> "1/2 pass (smtbmc yices won)"
+        [fail, fail]                   -> "0/2 pass"
+    """
+    if not per_engine:
+        return "no engine data"
+    total = len(per_engine)
+    winners = [e for e in per_engine if e.get("verdict") == "pass"]
+    passed = len(winners)
+    if total == 1:
+        e = per_engine[0]
+        spec = e.get("spec") or "engine"
+        return f"1/1 {e.get('verdict') or '?'} ({spec})"
+    if passed == total:
+        return f"{passed}/{total} pass"
+    if passed > 0:
+        # When only some engines pass, name one of the winners so the
+        # user knows which spec to keep.
+        spec = winners[0].get("spec") or "?"
+        return f"{passed}/{total} pass ({spec} won)"
+    return f"0/{total} pass"

--- a/src/rtl_buddy/tools/sby_fpv.py
+++ b/src/rtl_buddy/tools/sby_fpv.py
@@ -262,6 +262,7 @@ class SbyFpv:
             runtime_s = time.monotonic() - start
 
         status = self._read_status(workdir)
+        per_engine = self._read_per_engine(workdir)
 
         # Sby exit code conventions:
         #   0 -> PASS, 1 -> FAIL, 2 -> UNKNOWN/timeout, other -> ERROR.
@@ -274,6 +275,7 @@ class SbyFpv:
                 depth=cfg.get_depth(),
                 engines=cfg.get_engines(),
                 runtime_s=round(runtime_s, 2),
+                per_engine=per_engine,
             )
 
         if status == "FAIL":
@@ -284,6 +286,7 @@ class SbyFpv:
                 engines=cfg.get_engines(),
                 runtime_s=round(runtime_s, 2),
                 desc=self._counterexample_desc(workdir),
+                per_engine=per_engine,
             )
 
         desc_status = status or f"sby exit code {proc.returncode}"
@@ -294,6 +297,7 @@ class SbyFpv:
             engines=cfg.get_engines(),
             runtime_s=round(runtime_s, 2),
             desc=f"sby reported {desc_status} (see {log_path})",
+            per_engine=per_engine,
         )
 
     # --- result helpers -----------------------------------------------------
@@ -313,6 +317,21 @@ class SbyFpv:
         # Status lines look like "PASS" or "PASS (engine_0)" — keep the
         # first whitespace-delimited token.
         return text.split()[0] if text else None
+
+    @staticmethod
+    def _read_per_engine(workdir: str) -> list[dict]:
+        """Parse per-engine status from ``<workdir>/logfile.txt``.
+
+        Returns an empty list when the logfile is missing (sby died
+        before producing one) — callers treat that as "no engine data
+        available" and surface the overall verdict only.
+        """
+        from .fpv_log_parse import parse_engine_summary, read_workdir_log
+
+        log_text = read_workdir_log(workdir)
+        if log_text is None:
+            return []
+        return parse_engine_summary(log_text)
 
     @staticmethod
     def _counterexample_desc(workdir: str) -> str:

--- a/tests/test_fpv.py
+++ b/tests/test_fpv.py
@@ -824,3 +824,180 @@ def test_find_cex_vcd_ignores_non_engine_dirs(tmp_path):
     (workdir / "model").mkdir(parents=True)
 
     assert find_cex_vcd(str(tmp_path), "demo_safety") is None
+
+
+# ---------------------------------------------------------------------------
+# fpv_log_parse — per-engine summary extraction from sby logfile.txt
+# ---------------------------------------------------------------------------
+
+
+_REAL_LOG_PASS = dedent("""\
+    SBY 11:10:18 [wd] Removing directory 'wd'.
+    SBY 11:10:18 [wd] engine_0: smtbmc yices
+    SBY 11:10:18 [wd] engine_0: starting process "..."
+    SBY 11:10:18 [wd] engine_0: ##   0:00:00  Status: passed
+    SBY 11:10:18 [wd] engine_0: finished (returncode=0)
+    SBY 11:10:18 [wd] summary: Elapsed clock time [H:MM:SS (secs)]: 0:00:00 (0)
+    SBY 11:10:18 [wd] summary: Elapsed process time [H:MM:SS (secs)]: 0:00:00 (0)
+    SBY 11:10:18 [wd] summary: engine_0 (smtbmc yices) returned pass
+    SBY 11:10:18 [wd] summary: engine_0 did not produce any traces
+    SBY 11:10:18 [wd] DONE (PASS, rc=0)
+""")
+
+
+def test_parse_engine_summary_single_engine_pass():
+    from rtl_buddy.tools.fpv_log_parse import parse_engine_summary
+
+    engines = parse_engine_summary(_REAL_LOG_PASS)
+    assert engines == [
+        {"idx": 0, "spec": "smtbmc yices", "verdict": "pass", "trace_count": 0}
+    ]
+
+
+def test_parse_engine_summary_multi_engine_mixed():
+    log = dedent("""\
+        SBY summary: engine_0 (smtbmc yices) returned pass
+        SBY summary: engine_0 did not produce any traces
+        SBY summary: engine_1 (smtbmc z3) returned fail
+        SBY summary: engine_1 produced 1 trace
+        SBY summary: engine_2 (abc pdr) returned pass
+        SBY summary: engine_2 did not produce any traces
+    """)
+    from rtl_buddy.tools.fpv_log_parse import parse_engine_summary
+
+    engines = parse_engine_summary(log)
+    assert engines == [
+        {"idx": 0, "spec": "smtbmc yices", "verdict": "pass", "trace_count": 0},
+        {"idx": 1, "spec": "smtbmc z3", "verdict": "fail", "trace_count": 1},
+        {"idx": 2, "spec": "abc pdr", "verdict": "pass", "trace_count": 0},
+    ]
+
+
+def test_parse_engine_summary_unsorted_lines_sort_by_index():
+    log = dedent("""\
+        SBY summary: engine_2 (abc pdr) returned pass
+        SBY summary: engine_0 (smtbmc yices) returned pass
+        SBY summary: engine_1 (smtbmc z3) returned pass
+    """)
+    from rtl_buddy.tools.fpv_log_parse import parse_engine_summary
+
+    engines = parse_engine_summary(log)
+    assert [e["idx"] for e in engines] == [0, 1, 2]
+
+
+def test_parse_engine_summary_multiple_traces():
+    log = "SBY summary: engine_0 produced 3 traces\n"
+    from rtl_buddy.tools.fpv_log_parse import parse_engine_summary
+
+    engines = parse_engine_summary(log)
+    assert engines == [{"idx": 0, "spec": None, "verdict": None, "trace_count": 3}]
+
+
+def test_parse_engine_summary_empty_log_returns_empty():
+    from rtl_buddy.tools.fpv_log_parse import parse_engine_summary
+
+    assert parse_engine_summary("") == []
+    assert parse_engine_summary("no summary lines here\n") == []
+
+
+def test_parse_elapsed_seconds_extracts_secs():
+    from rtl_buddy.tools.fpv_log_parse import parse_elapsed_seconds
+
+    assert parse_elapsed_seconds(_REAL_LOG_PASS) == 0
+    assert (
+        parse_elapsed_seconds(
+            "SBY summary: Elapsed clock time [H:MM:SS (secs)]: 0:01:23 (83)\n"
+        )
+        == 83
+    )
+
+
+def test_parse_elapsed_seconds_missing_returns_none():
+    from rtl_buddy.tools.fpv_log_parse import parse_elapsed_seconds
+
+    assert parse_elapsed_seconds("no elapsed line\n") is None
+
+
+def test_read_workdir_log_missing_file_returns_none(tmp_path):
+    from rtl_buddy.tools.fpv_log_parse import read_workdir_log
+
+    assert read_workdir_log(str(tmp_path)) is None
+
+
+def test_read_workdir_log_returns_file_contents(tmp_path):
+    from rtl_buddy.tools.fpv_log_parse import read_workdir_log
+
+    (tmp_path / "logfile.txt").write_text("hello\n")
+    assert read_workdir_log(str(tmp_path)) == "hello\n"
+
+
+def test_summarize_engines_no_data():
+    from rtl_buddy.tools.fpv_log_parse import summarize_engines
+
+    assert summarize_engines([]) == "no engine data"
+
+
+def test_summarize_engines_single_engine_named():
+    from rtl_buddy.tools.fpv_log_parse import summarize_engines
+
+    assert (
+        summarize_engines(
+            [{"idx": 0, "spec": "smtbmc yices", "verdict": "pass", "trace_count": 0}]
+        )
+        == "1/1 pass (smtbmc yices)"
+    )
+
+
+def test_summarize_engines_all_pass_multi():
+    from rtl_buddy.tools.fpv_log_parse import summarize_engines
+
+    engines = [
+        {"idx": 0, "spec": "smtbmc yices", "verdict": "pass", "trace_count": 0},
+        {"idx": 1, "spec": "smtbmc z3", "verdict": "pass", "trace_count": 0},
+    ]
+    assert summarize_engines(engines) == "2/2 pass"
+
+
+def test_summarize_engines_partial_pass_names_winner():
+    from rtl_buddy.tools.fpv_log_parse import summarize_engines
+
+    engines = [
+        {"idx": 0, "spec": "smtbmc yices", "verdict": "pass", "trace_count": 0},
+        {"idx": 1, "spec": "smtbmc z3", "verdict": "fail", "trace_count": 1},
+    ]
+    assert summarize_engines(engines) == "1/2 pass (smtbmc yices won)"
+
+
+def test_summarize_engines_all_fail():
+    from rtl_buddy.tools.fpv_log_parse import summarize_engines
+
+    engines = [
+        {"idx": 0, "spec": "smtbmc yices", "verdict": "fail", "trace_count": 1},
+        {"idx": 1, "spec": "smtbmc z3", "verdict": "fail", "trace_count": 1},
+    ]
+    assert summarize_engines(engines) == "0/2 pass"
+
+
+# ---------------------------------------------------------------------------
+# SbyFpv._read_per_engine — integration with the workdir
+# ---------------------------------------------------------------------------
+
+
+def test_sby_fpv_read_per_engine_parses_real_log(tmp_path):
+    from rtl_buddy.tools.sby_fpv import SbyFpv
+
+    workdir = tmp_path / "sby_workdir"
+    workdir.mkdir()
+    (workdir / "logfile.txt").write_text(_REAL_LOG_PASS)
+    engines = SbyFpv._read_per_engine(str(workdir))
+    assert engines == [
+        {"idx": 0, "spec": "smtbmc yices", "verdict": "pass", "trace_count": 0}
+    ]
+
+
+def test_sby_fpv_read_per_engine_no_logfile_returns_empty(tmp_path):
+    from rtl_buddy.tools.sby_fpv import SbyFpv
+
+    workdir = tmp_path / "sby_workdir"
+    workdir.mkdir()
+    assert SbyFpv._read_per_engine(str(workdir)) == []


### PR DESCRIPTION
## Summary

- New `tools/fpv_log_parse.py` — pure parser for the per-engine `summary:` lines in `<workdir>/logfile.txt`.
- `SbyFpv` calls it after every run; `FpvPassResults` / `FpvFailResults` carry the parsed data on a new `per_engine` field.
- New "Engine Results" column in the `rb fpv` summary table renders the verdict mix compactly:
  - `1/1 pass (smtbmc yices)` — single engine
  - `2/2 pass` — multiple engines, all pass
  - `1/2 pass (smtbmc yices won)` — partial pass, name the winning spec
  - `0/2 pass` — all engines fail
  - `-` — no logfile (sby died before producing one)

Closes #133.

## Why the scope was rewritten

The original #133 body claimed sby emits per-property `status.json` — **that was wrong**. The structured output is `fpv.xml` (JUnit-style, per-task only with `tests="0"`) and `status` (single-line verdict). What sby *does* emit per-engine, in `<workdir>/logfile.txt`:

```
SBY ... summary: engine_0 (smtbmc yices) returned pass
SBY ... summary: engine_0 did not produce any traces
SBY ... summary: Elapsed clock time [H:MM:SS (secs)]: 0:00:00 (0)
SBY ... DONE (PASS, rc=0)
```

Per-engine is realisable; per-property would need a yosys-frontend change. Issue body rewritten to reflect that before implementation.

## Changes

- `src/rtl_buddy/tools/fpv_log_parse.py` (new, ~110 LOC) — `parse_engine_summary()`, `parse_elapsed_seconds()`, `read_workdir_log()`, `summarize_engines()`.
- `src/rtl_buddy/runner/fpv_results.py` — `per_engine` field on PASS/FAIL results.
- `src/rtl_buddy/tools/sby_fpv.py` — `_read_per_engine()` helper; populated on every return path.
- `src/rtl_buddy/rtl_buddy.py` — "Engine Results" column wired through `_render_fpv_summary`.
- `tests/test_fpv.py` — 16 new tests: parser shapes, sort-by-index, multi-engine mixed verdicts, missing-logfile, `summarize_engines` cases (single/all-pass/partial/all-fail), `SbyFpv._read_per_engine` integration.
- `docs/concepts/fpv.md` — new column documented; explicit callout that per-property is out of scope and why.

## Test plan

- [x] `uv run ruff check` — clean
- [x] `uv run ruff format --check` — clean
- [x] `uv run pytest tests/test_fpv.py` — 69 pass
- [x] `uv run pytest` — 614 pass + 3 skips + 1 pre-existing hub-bridge flake (passes in isolation; same flake as PRs #143/#144)
- [ ] End-to-end: run `rb fpv` on the template demo, confirm `1/1 pass (smtbmc yices)` renders. (Local validation requires dev-local worktree setup with this branch wired in; unit tests cover the rendering path.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)