### PR TITLE
feat(hub): --listen-port / --http-port flags + clean EADDRINUSE error

### DIFF
--- a/docs/concepts/hub.md
+++ b/docs/concepts/hub.md
@@ -46,7 +46,7 @@ uv run rb hub stop                    # graceful shutdown via SIGTERM
 
 | Command | Purpose |
 |---|---|
-| `rb hub start [--foreground/--daemon] [--serve-viewer] [--viewer-bundle PATH]` | Bind the TCP server (and optionally the viewer HTTP+WS layer), write `.rtl-buddy/hub.json`, run the asyncio loop. Exits cleanly on `SIGINT` / `SIGTERM` / `rb hub stop` and removes its discovery file. |
+| `rb hub start [--foreground/--daemon] [--serve-viewer] [--viewer-bundle PATH] [--listen-port N] [--http-port N]` | Bind the TCP server (and optionally the viewer HTTP+WS layer), write `.rtl-buddy/hub.json`, run the asyncio loop. `--listen-port` / `--http-port` override `[hub].listen_port` / `[hub].http_port` from `hub.toml` (default 0 = OS-assigned). When a pinned port is already in use, the command prints a one-line error and exits 1 without a traceback. Exits cleanly on `SIGINT` / `SIGTERM` / `rb hub stop` and removes its discovery file. |
 | `rb hub stop` | Send `SIGTERM` to the PID in `.rtl-buddy/hub.json`. |
 | `rb hub status` | Print the current discovery record + liveness. Reports stale records (PID gone) so users know to clear them. |
 | `rb hub log [--lines N] [--follow]` | Tail `.rtl-buddy/hub.log`. |

--- a/src/rtl_buddy/hub/cli.py
+++ b/src/rtl_buddy/hub/cli.py
@@ -96,6 +96,34 @@ def cmd_start(
             ),
         ),
     ] = None,
+    listen_port: Annotated[
+        int | None,
+        typer.Option(
+            "--listen-port",
+            help=(
+                "TCP port for adapter peers (nvim, rb wave). Overrides "
+                "[hub].listen_port from hub.toml. 0 = OS-assigned. Pin to a "
+                "specific number so peers' discovery records stay stable "
+                "across restarts."
+            ),
+            min=0,
+            max=65535,
+        ),
+    ] = None,
+    http_port: Annotated[
+        int | None,
+        typer.Option(
+            "--http-port",
+            help=(
+                "HTTP/WS port for the browser-side SPA. Overrides "
+                "[hub].http_port from hub.toml. 0 = OS-assigned. Pin to a "
+                "specific number so the SPA URL stays the same across "
+                "restarts. Only used with --serve-viewer."
+            ),
+            min=0,
+            max=65535,
+        ),
+    ] = None,
 ) -> None:
     """Bind, write ``hub.json``, run the server loop.
 
@@ -121,6 +149,23 @@ def cmd_start(
 
     project_root = _resolve_project_root()
     cfg = _resolve_config(project_root)
+
+    # CLI flags override hub.toml — the user typed them on this invocation
+    # and we should trust that over the on-disk default. Frozen config so
+    # we rebuild via dataclasses.replace.
+    if listen_port is not None or http_port is not None:
+        import dataclasses
+
+        cfg = dataclasses.replace(
+            cfg,
+            hub=dataclasses.replace(
+                cfg.hub,
+                listen_port=listen_port
+                if listen_port is not None
+                else cfg.hub.listen_port,
+                http_port=http_port if http_port is not None else cfg.hub.http_port,
+            ),
+        )
 
     existing = discovery.read_record(project_root)
     if existing is not None and discovery._pid_is_live(existing.pid):  # noqa: SLF001

--- a/src/rtl_buddy/hub/loop.py
+++ b/src/rtl_buddy/hub/loop.py
@@ -12,6 +12,7 @@ obviously-correct boot sequence.
 from __future__ import annotations
 
 import asyncio
+import errno
 import logging
 import os
 import signal
@@ -29,6 +30,31 @@ from .viewer_http import ViewerServer
 
 
 logger = logging.getLogger(__name__)
+
+
+class _PortInUseError(Exception):
+    """Bind failed because the port is held by another process.
+
+    Carried from ``_run`` up to ``serve`` where it's translated into a
+    clean ``rb hub start`` error message + exit code 1 (no traceback).
+    """
+
+    def __init__(self, role: str, port: int) -> None:
+        self.role = role
+        self.port = port
+        super().__init__(f"{role} port {port} already in use")
+
+
+async def _start_listener(coro, *, role: str, port: int):
+    """Run a listener-bind coroutine, translating EADDRINUSE into a
+    clean :class:`_PortInUseError` so the CLI doesn't print a raw
+    websockets/asyncio traceback when a user pins a busy port."""
+    try:
+        return await coro
+    except OSError as exc:
+        if exc.errno == errno.EADDRINUSE:
+            raise _PortInUseError(role=role, port=port) from exc
+        raise
 
 
 def _server_version() -> str:
@@ -110,7 +136,9 @@ async def _run(
         server_version=_server_version(),
         resolver=resolver,
     )
-    host, port = await server.start()
+    host, port = await _start_listener(
+        server.start(), role="TCP", port=config.hub.listen_port
+    )
 
     viewer: ViewerServer | None = None
     http_port: int | None = None
@@ -132,7 +160,9 @@ async def _run(
             viewer_bundle=resolved_bundle,
             view_json_path=view_json_path,
         )
-        _vhost, vport = await viewer.start()
+        _vhost, vport = await _start_listener(
+            viewer.start(), role="HTTP", port=config.hub.http_port
+        )
         http_port = vport
         log_event(
             logger,
@@ -220,14 +250,41 @@ def serve(
 ) -> int:
     """Run the hub event loop until exit. Returns the process exit code."""
 
-    return asyncio.run(
-        _run(
-            project_root,
-            config,
-            serve_viewer=serve_viewer,
-            viewer_bundle=viewer_bundle,
+    try:
+        return asyncio.run(
+            _run(
+                project_root,
+                config,
+                serve_viewer=serve_viewer,
+                viewer_bundle=viewer_bundle,
+            )
         )
-    )
+    except _PortInUseError as exc:
+        # Clean one-line error in place of a 20-line websockets traceback.
+        # The user pinned a port that's already held; tell them which port
+        # and where to change it, then exit 1 without a stack trace.
+        #
+        # Rich parses `[hub]` as a style tag and eats the brackets. Use
+        # `\[` to escape the opening bracket so the literal hub.toml
+        # section name renders.
+        which_toml = (
+            r"\[hub].http_port" if exc.role == "HTTP" else r"\[hub].listen_port"
+        )
+        which_flag = "--http-port" if exc.role == "HTTP" else "--listen-port"
+        emit_console_text(
+            f"rb hub start: {exc.role} port {exc.port} already in use. "
+            f"Pick another port in {which_toml} (hub.toml) or "
+            f"{which_flag} N, or stop the process holding it.",
+            style="red",
+        )
+        log_event(
+            logger,
+            logging.ERROR,
+            "hub.bind.port_in_use",
+            role=exc.role,
+            port=exc.port,
+        )
+        return 1
 
 
 __all__ = ["serve"]

--- a/tests/test_hub_port_in_use.py
+++ b/tests/test_hub_port_in_use.py
@@ -1,0 +1,85 @@
+"""Tests for the EADDRINUSE clean-error path in ``rb hub start``.
+
+Pinning a port (via CLI flag or hub.toml) is common; landing on a port
+that's already held by another process should produce a one-line
+"port X already in use" message, not a websockets/asyncio traceback.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import socket
+from pathlib import Path
+
+import pytest
+
+from rtl_buddy.hub.config import HubConfig, HubMappingConfig, HubServerConfig
+from rtl_buddy.hub.loop import _PortInUseError, _start_listener, serve
+
+
+@contextlib.contextmanager
+def _hold_port(port: int):
+    """Bind a TCP listener on (127.0.0.1, port) so any other bind on
+    the same port hits EADDRINUSE. Yields the port back."""
+    s = socket.socket()
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 0)
+    s.bind(("127.0.0.1", port))
+    s.listen()
+    try:
+        yield s.getsockname()[1]
+    finally:
+        s.close()
+
+
+@pytest.mark.asyncio
+async def test_start_listener_translates_eaddrinuse_to_port_in_use():
+    """Direct exercise of the helper that wraps server/viewer .start()."""
+
+    with _hold_port(0) as taken:
+
+        async def bind_again():
+            srv = await asyncio.start_server(
+                lambda r, w: None, host="127.0.0.1", port=taken
+            )
+            return srv
+
+        with pytest.raises(_PortInUseError) as info:
+            await _start_listener(bind_again(), role="TCP", port=taken)
+        assert info.value.role == "TCP"
+        assert info.value.port == taken
+
+
+@pytest.mark.asyncio
+async def test_start_listener_passes_other_oserror_through():
+    """Non-EADDRINUSE OSErrors should propagate unchanged; we only
+    translate the specific bind-conflict case."""
+
+    async def boom():
+        raise OSError(13, "permission denied")
+
+    with pytest.raises(OSError) as info:
+        await _start_listener(boom(), role="TCP", port=42)
+    assert info.value.errno == 13
+
+
+def test_serve_returns_1_and_emits_clean_message_on_eaddrinuse(tmp_path: Path, capfd):
+    """End-to-end: ``serve()`` with a pinned listen_port that's already
+    held returns exit code 1 and prints a one-line message — no
+    traceback. Mirrors what ``rb hub start --listen-port N`` does at
+    the CLI surface."""
+
+    with _hold_port(0) as taken:
+        cfg = HubConfig(
+            hub=HubServerConfig(listen_port=taken, http_port=0),
+            mapping=HubMappingConfig(),
+        )
+        rc = serve(tmp_path, cfg, serve_viewer=False)
+
+    assert rc == 1
+    out = "".join(capfd.readouterr().err.split())
+    # Either ordering of "TCP port" + the port number is fine; we just
+    # need the user-visible substring and no Traceback.
+    assert "TCPport" in out or f"TCPport{taken}" in out
+    assert "alreadyinuse" in out
+    assert "Traceback" not in out


### PR DESCRIPTION
## Summary

Three changes to `rb hub start` for users who want to pin ports (so the browser URL stays the same across restarts) and who currently get a 20-line Python traceback when the pinned port is busy.

- **New CLI flags `--listen-port N` and `--http-port N`** (`src/rtl_buddy/hub/cli.py`) override `[hub].listen_port` / `[hub].http_port` from `hub.toml`. Default `0` = OS-assigned (unchanged behaviour). typer validates `[0, 65535]`.
- **Clean error on EADDRINUSE** (`src/rtl_buddy/hub/loop.py`) — both `server.start()` (TCP) and `viewer.start()` (HTTP/WS) are wrapped in `_start_listener` which translates `OSError(EADDRINUSE)` into a typed `_PortInUseError`. `serve()` catches it, prints a one-line message via `emit_console_text`, returns exit code 1, no traceback.

  ```
  rb hub start: HTTP port 18765 already in use. Pick another port in
  [hub].http_port (hub.toml) or --http-port N, or stop the process holding it.
  ```

  (Rich's `[…]` markup parsing eats `[hub]` by default; escaped with `\[hub]` so the literal section name renders.)
- **Docs updated** (`docs/concepts/hub.md`) — CLI table mentions both flags and the clean-error behaviour.

## Test plan

- [x] `uv run pytest tests/test_hub_port_in_use.py -v` — 3/3 pass (helper translates EADDRINUSE; non-EADDRINUSE OSError propagates; end-to-end serve() exits 1 with the clean message and no Traceback)
- [x] `uv run pytest tests/ -k hub` — 175 pass / 2 skipped (one unrelated wave-bridge flake, passes in isolation)
- [x] `uv run ruff check && uv run ruff format --check` — clean
- [x] Live: `rb hub start --serve-viewer --http-port 18765` pins port (banner shows `Viewer: http://127.0.0.1:18765/?view=/view.json`), `hub.json` records `http_port: 18765`
- [x] Live conflict: pre-bind port 19878, run `rb hub start --serve-viewer --http-port 19878` → one-line "port 19878 already in use" message, exit 1, no traceback

## Out of scope

- Falling back from a pinned port to an OS-assigned one when the pin is busy — that would silently change behaviour; explicit pinning means "this port or fail."
- Pinning the WS path (`/ws`) — the path is fixed by protocol.
- Daemon-mode background detach (still a separate concern; `--daemon` warns and stays in foreground).

🤖 Generated with [Claude Code](https://claude.com/claude-code)