### PR TITLE
feat(hub): broadcast peer_joined when a new peer registers

### DIFF
--- a/docs/concepts/hub.md
+++ b/docs/concepts/hub.md
@@ -114,6 +114,8 @@ Wire envelope is line-delimited JSON, one record per line, UTF-8. The full spec 
 
 State events (selection_changed, signal_selected, cursor_moved, …) are broadcast to every connected peer **except** the origin. Requests (`resolve_*`, `goto_declaration`, …) are routed to the peer whose origin owns the target coordinate system; if no peer is registered for that origin, the hub replies with `error{code: "not_connected"}`. The `view ↔ wave ↔ src` resolver lives in `rtl_buddy.hub.resolver` and consumes the `view.json` snapshot pointed at by `mapping.view_json`.
 
+Lifecycle events (`hello` / `welcome` / `peer_joined` / `bye`) keep each peer's view of the registry live without re-fetching: `welcome` carries the snapshot at handshake time, and `peer_joined` / `bye` are deltas the hub broadcasts when later peers connect or disconnect. The joining or leaving peer's origin is in the envelope's `origin` field (payload is empty). Consumers should react to all three to maintain a current peer list — relying on `welcome` alone leaves the list frozen at handshake time.
+
 ## Troubleshooting
 
 **`rb hub start` exits with "already running"** — `.rtl-buddy/hub.json` exists and its PID is live. If the prior daemon really is gone, the file is stale (clean shutdown didn't run); delete it and retry. `rb hub status` distinguishes the two cases.

--- a/src/rtl_buddy/hub/schema/hub-protocol-v1.json
+++ b/src/rtl_buddy/hub/schema/hub-protocol-v1.json
@@ -399,6 +399,21 @@
       }
     },
     {
+      "if": { "properties": { "type": { "const": "peer_joined" } }, "required": ["type"] },
+      "then": {
+        "properties": {
+          "kind": { "const": "event" },
+          "payload": {
+            "description": "Empty (or absent). Hub broadcasts peer_joined to already-registered peers when a new client finishes its hello handshake; the joining peer's origin lives in the envelope's `origin` field, mirroring `bye`'s shape so consumers can treat join + leave symmetrically.",
+            "oneOf": [
+              { "type": "null" },
+              { "type": "object", "additionalProperties": false }
+            ]
+          }
+        }
+      }
+    },
+    {
       "if": { "properties": { "type": { "const": "diagnostics_set" } }, "required": ["type"] },
       "then": {
         "properties": {

--- a/src/rtl_buddy/hub/server.py
+++ b/src/rtl_buddy/hub/server.py
@@ -394,6 +394,16 @@ class HubServer:
             version=conn.client_version,
             capabilities=list(conn.capabilities),
         )
+
+        # Tell already-registered peers that a new peer is online.
+        # The new peer learnt the current snapshot from `welcome`;
+        # this is the delta for the rest. ``suppress_origin=client``
+        # keeps the joining peer from receiving a peer_joined event
+        # about itself.
+        await self._broadcast(
+            self._peer_joined_envelope(origin=client),
+            suppress_origin=client,
+        )
         return True
 
     async def _dispatch_loop(self, conn: ClientConnection) -> None:
@@ -770,6 +780,24 @@ class HubServer:
             origin=origin,
             kind=Kind.EVENT,
             type="bye",
+            id=new_id(),
+            payload={},
+        )
+
+    def _peer_joined_envelope(self, *, origin: Origin) -> Envelope:
+        """Build a ``peer_joined`` event for the named origin.
+
+        Symmetric to :meth:`_bye_envelope` — the joining peer is in the
+        envelope's ``origin`` field, payload is empty. Consumers (the
+        SPA's useHub, the nvim plugin's hub.lua) treat this as the
+        join half of the lifecycle pair: ``welcome`` carries the
+        current snapshot, ``peer_joined`` is the delta for joiners
+        that arrive after.
+        """
+        return Envelope(
+            origin=origin,
+            kind=Kind.EVENT,
+            type="peer_joined",
             id=new_id(),
             payload={},
         )

--- a/tests/test_hub_protocol.py
+++ b/tests/test_hub_protocol.py
@@ -292,6 +292,7 @@ def test_vendored_schema_has_expected_types():
         "hello",
         "welcome",
         "bye",
+        "peer_joined",
         "error",
         "diagnostics_set",
     }

--- a/tests/test_hub_server.py
+++ b/tests/test_hub_server.py
@@ -74,6 +74,20 @@ class MockClient:
             raise EOFError("connection closed without a message")
         return decode(line)
 
+    async def recv_until(self, type_: str, *, timeout: float = 1.0) -> Envelope:
+        """Read envelopes until one with ``type == type_`` arrives.
+
+        Used by multi-peer tests to skip past the ``peer_joined``
+        broadcasts each later-arriving peer triggers — the hub fires
+        one peer_joined per existing peer when a new peer hellos, so a
+        test that connects three peers and then expects a single
+        ``selection_changed`` has to filter past the peer_joined noise.
+        """
+        while True:
+            env = await self.recv(timeout=timeout)
+            if env.type == type_:
+                return env
+
     async def expect_no_message(self, *, within: float = 0.1) -> None:
         try:
             line = await asyncio.wait_for(self.reader.readline(), timeout=within)
@@ -206,18 +220,57 @@ async def test_state_event_broadcast_skips_origin(server: HubServer):
         )
         await view.send(evt)
 
-        # wave + src must receive it; view must not echo back.
-        got_wave = await wave.recv()
-        got_src = await src.recv()
+        # wave + src must receive it; view must not echo back. Use
+        # recv_until to skip past the peer_joined broadcasts each later
+        # peer triggered (view saw peer_joined(wave), peer_joined(src);
+        # wave saw peer_joined(src)) and assert on selection_changed.
+        got_wave = await wave.recv_until("selection_changed")
+        got_src = await src.recv_until("selection_changed")
         assert got_wave.id == evt.id
         assert got_src.id == evt.id
         assert got_wave.payload == {"instance_path": "top.u_fifo"}
 
+        # Drain the two peer_joined events view received during setup
+        # before asserting it didn't get an echoed selection_changed.
+        for _ in range(2):
+            joined = await view.recv()
+            assert joined.type == "peer_joined"
         await view.expect_no_message()
     finally:
         await view.close()
         await wave.close()
         await src.close()
+
+
+async def test_peer_joined_broadcast_to_existing_peers(server: HubServer):
+    """When a new peer hellos, every already-registered peer receives a
+    ``peer_joined`` event carrying the joining peer's origin. The
+    joining peer itself does not (suppress_origin=client in the hub's
+    hello handler).
+
+    Symmetric to ``bye`` so consumers can maintain a live peer list
+    without re-fetching ``registered_clients`` every time.
+    """
+    view = await MockClient.connect(server.host, server.port)
+    wave = await MockClient.connect(server.host, server.port)
+    try:
+        # view hellos first: registry is empty, no one to notify.
+        await view.hello(Origin.VIEW)
+
+        # wave hellos second: view must get peer_joined(wave); wave
+        # itself must not get a peer_joined about itself.
+        await wave.hello(Origin.WAVE)
+
+        joined = await view.recv()
+        assert joined.type == "peer_joined"
+        assert joined.kind is Kind.EVENT
+        assert joined.origin is Origin.WAVE
+        assert joined.payload == {}
+
+        await wave.expect_no_message()
+    finally:
+        await view.close()
+        await wave.close()
 
 
 async def test_state_is_recorded_after_event(server: HubServer):
@@ -296,10 +349,16 @@ async def test_diagnostics_set_broadcasts_and_caches(server: HubServer):
         evt = _diag_evt(Origin.CLI, "rtl-buddy-cdc", items)
         await publisher.send(evt)
 
-        got = await subscriber.recv()
-        assert got.type == "diagnostics_set"
+        # Skip the peer_joined(subscriber) the publisher already
+        # received when subscriber connected; assert the actual
+        # broadcast we care about lands at the subscriber.
+        got = await subscriber.recv_until("diagnostics_set")
         assert got.payload["source"] == "rtl-buddy-cdc"
         assert got.payload["items"] == items
+        # Publisher received peer_joined(subscriber) at setup time —
+        # drain it before asserting it got no echoed diagnostics_set.
+        joined = await publisher.recv()
+        assert joined.type == "peer_joined"
         await publisher.expect_no_message()  # origin gets suppressed
 
         await asyncio.sleep(0.05)
@@ -463,7 +522,14 @@ async def test_response_routed_back_to_requester(server: HubServer):
             payload={"variables": ["tb.dut.x"]},
         )
         await view.send(req)
-        forwarded = await wave.recv()
+        # wave received peer_joined(wave) for itself? no — suppress_origin
+        # skips that. But wave still has the peer_joined(view) it got at
+        # its own welcome time? Actually view registered first so when
+        # wave connected, view got peer_joined(wave) but wave got no
+        # peer_joined (no earlier peers). So wave.recv() here would be
+        # the forwarded request directly. Use recv_until anyway for
+        # robustness against future broadcasts that might interleave.
+        forwarded = await wave.recv_until("wave_add_variables")
         assert forwarded.id == req.id
 
         resp = Envelope(
@@ -475,7 +541,9 @@ async def test_response_routed_back_to_requester(server: HubServer):
         )
         await wave.send(resp)
 
-        got = await view.recv()
+        # view's queue has peer_joined(wave) from when wave connected.
+        # Skip it and assert on the response.
+        got = await view.recv_until("wave_add_variables")
         assert got.id == req.id
         assert got.kind is Kind.RESPONSE
         assert got.payload == {"ids": [17]}


### PR DESCRIPTION
## Summary

Closes the symmetric gap to `bye` — when a new peer hellos, the hub now broadcasts a `peer_joined` event to all already-registered peers. Without this, the SPA popover (and any other live peer-list consumer) is stuck with whatever `registered_clients` it received in its own `welcome`: open the browser first, start nvim later, the popover never paints `src` green.

This PR is the hub-side half; companion is **rtl-buddy-view#54** (already amended with the `peer_joined` schema branch + SPA handler, both byte-identical to this PR's vendored schema).

## Changes

- **`src/rtl_buddy/hub/server.py`** — new `_peer_joined_envelope` helper symmetric to `_bye_envelope`. Broadcast at the end of the hello handler (after welcome + diagnostics replay) with `suppress_origin=client` so the joining peer doesn't get a peer_joined about itself.
- **`src/rtl_buddy/hub/schema/hub-protocol-v1.json`** — add a `peer_joined` branch alongside the existing `bye` branch, same null-or-empty-object payload shape. Synced byte-for-byte with rtl-buddy-view's schema (the drift detector covers regressions in either direction).
- **`docs/concepts/hub.md`** — explain the lifecycle delta pair: `welcome` is the snapshot, `peer_joined` + `bye` are the deltas.

## Tests

- New `test_peer_joined_broadcast_to_existing_peers` (`tests/test_hub_server.py`): two peers, second hello → first receives `peer_joined` with `origin=joiner`, second receives nothing.
- `MockClient.recv_until(type_)` helper for multi-peer tests that previously did a bare `recv()` and now need to skip past peer_joined broadcasts.
- Existing tests updated: `test_state_event_broadcast_skips_origin`, `test_diagnostics_set_broadcasts_and_caches`, `test_response_routed_back_to_requester` now drain the peer_joined events they newly receive before asserting on the message they care about.
- `test_vendored_schema_has_expected_types` updated to include `peer_joined`.

## Verification

- [x] `uv run pytest tests/ -k hub` — 173 pass / 2 skipped (one unrelated wave-bridge flake, passes in isolation)
- [x] `uv run ruff check && uv run ruff format --check` — clean
- [x] `uv run python scripts/check_docs_frontmatter.py --check` — clean (hub.md still has the frontmatter)

## Out of scope

- A `peers_changed` event with the full registered_clients list as a snapshot — would be useful for late-coming peers to reconcile if they missed a peer_joined/bye sequence, but right now the snapshot lives in `welcome` and that's only sent once per connection. Track separately if a need arises.
- Hub-side aggregation of `peer_joined` storms (rare since peers don't churn). Today each hello fires exactly one broadcast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)