### PR TITLE
feat(test): first-class SystemC + Verilator cosim testbench (closes #151)

### DIFF
--- a/src/rtl_buddy/config/root.py
+++ b/src/rtl_buddy/config/root.py
@@ -32,6 +32,7 @@ from .pnr_platform import PnrPlatformConfig, PnrPlatformConfigFile
 from .power import PowerToolConfig, PowerToolConfigFile
 from .cdc import CdcToolConfig, CdcToolConfigFile
 from .fpv import FpvToolConfig, FpvToolConfigFile
+from .systemc import SystemCConfig, SystemCConfigFile
 from ..errors import FatalRtlBuddyError
 from ..logging_utils import log_event
 
@@ -134,6 +135,7 @@ class RootConfigFile:
     synth_efforts: list[SynthEffortConfigFile] = field(
         rename="cfg-synth-efforts", default_factory=list
     )
+    systemc: SystemCConfigFile | None = field(rename="cfg-systemc", default=None)
 
 
 class RootConfig:
@@ -185,6 +187,7 @@ class RootConfig:
         self.cdc_tool_cfgs: dict = {}
         self.fpv_tool_cfgs: dict = {}
         self.synth_effort_cfgs: dict = {}
+        self.systemc_cfg: SystemCConfig | None = None
         self.platform_cfg = None
         self.reg_cfg = None  # initialise later when get_rtl_reg_cfg is called
 
@@ -279,6 +282,10 @@ class RootConfig:
             self.synth_effort_cfgs = {
                 cfg.name: SynthEffortConfig(cfg) for cfg in data.synth_efforts
             }
+
+            # SystemC config (optional, single block)
+            if data.systemc is not None:
+                self.systemc_cfg = data.systemc.initialise()
 
             # Initialise regression config
             self.cfg_rtl_reg = data.cfg_rtl_reg
@@ -601,6 +608,17 @@ class RootConfig:
                 f"synthesis effort '{name}' not found in cfg-synth-efforts"
             )
         return cfg
+
+    def get_systemc_cfg(self) -> SystemCConfig | None:
+        """
+        Get the SystemC root configuration, if cfg-systemc is present.
+
+        Returns:
+          cfg (SystemCConfig | None): SystemC config, or None when cfg-systemc
+            is absent. Callers (e.g. SystemCSim) decide whether absence is
+            fatal — a project with no SystemC testbenches does not require it.
+        """
+        return self.systemc_cfg
 
     def get_project_rootdir(self):
         """

--- a/src/rtl_buddy/config/systemc.py
+++ b/src/rtl_buddy/config/systemc.py
@@ -21,13 +21,25 @@ are always auto-emitted; users never need to repeat those.
 Resolution order for `home`: config value (with ~ and $VAR expansion) →
 $SYSTEMC_HOME env var → None. SystemCSim is responsible for failing fast
 when a SystemC testbench is requested but home cannot be resolved.
+
+An unresolved `${VAR}` (env var not set) is treated as if `home` was
+unset, so the env-var fallback still runs and the existing
+`systemc.home_unresolved` error fires instead of Verilator failing later
+with a confusing "include not found at ${SYSTEMC_HOME}/include".
 """
 
 import os
 import pprint
+import re
 from dataclasses import dataclass, field
 
 from serde import serde
+
+
+# Matches `${VAR}` and `$VAR` (identifier form). If `os.path.expandvars`
+# leaves either of these in the output, the env var was unset — POSIX
+# expandvars semantics return the literal rather than raising.
+_UNRESOLVED_VAR_RE = re.compile(r"\$\{[^}]+\}|\$[A-Za-z_][A-Za-z0-9_]*")
 
 
 @dataclass
@@ -42,11 +54,19 @@ class SystemCConfig:
     def get_home(self) -> str | None:
         """Configured SystemC install root, with ~ and $VAR expanded.
 
-        Falls back to $SYSTEMC_HOME when not set in config. Returns None if
-        neither is available; SystemCSim raises a fatal error in that case.
+        Falls back to $SYSTEMC_HOME when not set in config, or when the
+        config value contained a $VAR that did not resolve (env var unset).
+        Returns None if neither is available; SystemCSim raises a fatal
+        error in that case.
         """
         if self.home is not None:
-            return os.path.expanduser(os.path.expandvars(self.home))
+            expanded = os.path.expanduser(os.path.expandvars(self.home))
+            if not _UNRESOLVED_VAR_RE.search(expanded):
+                return expanded
+            # The configured value referenced an unset env var. Treat as
+            # if `home` was unset and let the env-var fallback / None path
+            # handle it, so SystemCSim's home_unresolved error fires
+            # instead of Verilator failing later on a literal "${...}" path.
         env_home = os.environ.get("SYSTEMC_HOME")
         return env_home if env_home else None
 

--- a/src/rtl_buddy/config/systemc.py
+++ b/src/rtl_buddy/config/systemc.py
@@ -9,6 +9,14 @@ Schema (in root_config.yaml):
     cfg-systemc:
       home: "${WORKSPACE}/systemc-install"   # optional; $SYSTEMC_HOME fallback
       cxx:  "/opt/homebrew/bin/g++-15"       # optional
+      cflags: ["-std=c++17"]                  # optional; project-wide -CFLAGS
+      ldflags: []                             # optional; project-wide -LDFLAGS
+
+`cflags` / `ldflags` here are project-wide defaults. Per-testbench
+`systemc.cflags` / `systemc.ldflags` in tests.yaml are appended (not
+replaced) so testbench-specific tokens layer on top of the project
+default. The SystemC include and library paths derived from `home`
+are always auto-emitted; users never need to repeat those.
 
 Resolution order for `home`: config value (with ~ and $VAR expansion) →
 $SYSTEMC_HOME env var → None. SystemCSim is responsible for failing fast
@@ -17,7 +25,7 @@ when a SystemC testbench is requested but home cannot be resolved.
 
 import os
 import pprint
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from serde import serde
 
@@ -28,6 +36,8 @@ class SystemCConfig:
 
     home: str | None
     cxx: str | None
+    cflags: list[str] = field(default_factory=list)
+    ldflags: list[str] = field(default_factory=list)
 
     def get_home(self) -> str | None:
         """Configured SystemC install root, with ~ and $VAR expanded.
@@ -51,6 +61,14 @@ class SystemCConfig:
     def get_cxx(self) -> str | None:
         return self.cxx
 
+    def get_cflags(self) -> list[str]:
+        """Project-wide -CFLAGS tokens (testbench-level cflags append on top)."""
+        return list(self.cflags)
+
+    def get_ldflags(self) -> list[str]:
+        """Project-wide -LDFLAGS tokens (testbench-level ldflags append on top)."""
+        return list(self.ldflags)
+
     def __str__(self):
         return pprint.pformat(self)
 
@@ -61,6 +79,13 @@ class SystemCConfigFile:
 
     home: str | None = None
     cxx: str | None = None
+    cflags: list[str] | None = None
+    ldflags: list[str] | None = None
 
     def initialise(self) -> SystemCConfig:
-        return SystemCConfig(home=self.home, cxx=self.cxx)
+        return SystemCConfig(
+            home=self.home,
+            cxx=self.cxx,
+            cflags=list(self.cflags) if self.cflags else [],
+            ldflags=list(self.ldflags) if self.ldflags else [],
+        )

--- a/src/rtl_buddy/config/systemc.py
+++ b/src/rtl_buddy/config/systemc.py
@@ -1,0 +1,66 @@
+"""SystemC root-config support.
+
+A single optional block on root_config.yaml that pins where the project's
+SystemC install lives (headers + libsystemc.{a,dylib,so}) and, optionally,
+the C++ compiler to use so the cosim binary's ABI matches libsystemc.
+
+Schema (in root_config.yaml):
+
+    cfg-systemc:
+      home: "${WORKSPACE}/systemc-install"   # optional; $SYSTEMC_HOME fallback
+      cxx:  "/opt/homebrew/bin/g++-15"       # optional
+
+Resolution order for `home`: config value (with ~ and $VAR expansion) →
+$SYSTEMC_HOME env var → None. SystemCSim is responsible for failing fast
+when a SystemC testbench is requested but home cannot be resolved.
+"""
+
+import os
+import pprint
+from dataclasses import dataclass
+
+from serde import serde
+
+
+@dataclass
+class SystemCConfig:
+    """Resolved SystemC config consumed by SystemCSim."""
+
+    home: str | None
+    cxx: str | None
+
+    def get_home(self) -> str | None:
+        """Configured SystemC install root, with ~ and $VAR expanded.
+
+        Falls back to $SYSTEMC_HOME when not set in config. Returns None if
+        neither is available; SystemCSim raises a fatal error in that case.
+        """
+        if self.home is not None:
+            return os.path.expanduser(os.path.expandvars(self.home))
+        env_home = os.environ.get("SYSTEMC_HOME")
+        return env_home if env_home else None
+
+    def get_include_dir(self) -> str | None:
+        home = self.get_home()
+        return os.path.join(home, "include") if home else None
+
+    def get_lib_dir(self) -> str | None:
+        home = self.get_home()
+        return os.path.join(home, "lib") if home else None
+
+    def get_cxx(self) -> str | None:
+        return self.cxx
+
+    def __str__(self):
+        return pprint.pformat(self)
+
+
+@serde
+class SystemCConfigFile:
+    """YAML-backed cfg-systemc block."""
+
+    home: str | None = None
+    cxx: str | None = None
+
+    def initialise(self) -> SystemCConfig:
+        return SystemCConfig(home=self.home, cxx=self.cxx)

--- a/src/rtl_buddy/config/test.py
+++ b/src/rtl_buddy/config/test.py
@@ -1,5 +1,6 @@
 import logging
 from dataclasses import dataclass
+from typing import Literal
 from serde import serde, field
 from .model import ModelConfig, ModelConfigLoader
 from .uvm import UVMConfig
@@ -31,6 +32,31 @@ class CocotbTestbenchConfig:
 
 
 @serde
+class SystemCTestbenchConfig:
+    """
+    SystemC-specific configuration nested under a testbench.
+
+    Presence signals that Verilator should emit the DUT as an sc_module and
+    link it against a user-provided sc_main(). Mirrors CocotbTestbenchConfig.
+
+    Attributes:
+      sc_main (str): C++ source file containing sc_main(), relative to suite dir.
+      sc_extra (list[str]): Additional C++ translation units to compile and link.
+      cflags (list[str]): Tokens appended to -CFLAGS at verilator invocation.
+      ldflags (list[str]): Tokens appended to -LDFLAGS at verilator invocation.
+      pin_style (str | None): One of "uint" | "bv" | "biguint" — maps to
+        --pins-sc-uint / --pins-sc-biguint / (no flag for "bv"). None leaves
+        Verilator's default emission (uint32_t for ≤32-bit, sc_bv for wider).
+    """
+
+    sc_main: str
+    sc_extra: list[str] = field(default_factory=list)
+    cflags: list[str] = field(default_factory=list)
+    ldflags: list[str] = field(default_factory=list)
+    pin_style: Literal["uint", "bv", "biguint"] | None = None
+
+
+@serde
 class TestbenchConfig:
     """
     Configuration for a single testbench within a test suite.
@@ -38,23 +64,37 @@ class TestbenchConfig:
     Attributes:
       name (str): Unique testbench identifier.
       filelist (list[str]): List of paths to files involved in running the testbench.
-      toplevel (str | None): Top-level DUT module name. Required for cocotb testbenches.
+      toplevel (str | None): Top-level DUT module name. Required for cocotb and SystemC testbenches.
       cocotb (CocotbTestbenchConfig | None): cocotb config; presence signals cocotb mode.
+      systemc (SystemCTestbenchConfig | None): SystemC config; presence signals SystemC cosim mode.
     """
 
     name: str
     filelist: list[str]
     toplevel: str | None = None
     cocotb: CocotbTestbenchConfig | None = None
+    systemc: SystemCTestbenchConfig | None = None
 
     def __post_init__(self):
+        if self.cocotb is not None and self.systemc is not None:
+            raise FatalRtlBuddyError(
+                f"testbench '{self.name}': cocotb: and systemc: are mutually exclusive "
+                "(different host kernels cannot share one Verilator build)"
+            )
         if self.cocotb is not None and self.toplevel is None:
             raise FatalRtlBuddyError(
                 f"testbench '{self.name}': toplevel is required when cocotb: is present"
             )
+        if self.systemc is not None and self.toplevel is None:
+            raise FatalRtlBuddyError(
+                f"testbench '{self.name}': toplevel is required when systemc: is present"
+            )
 
     def is_cocotb(self) -> bool:
         return self.cocotb is not None
+
+    def is_systemc(self) -> bool:
+        return self.systemc is not None
 
     def get_name(self):
         """

--- a/src/rtl_buddy/logging_utils.py
+++ b/src/rtl_buddy/logging_utils.py
@@ -412,6 +412,10 @@ def _human_message(event: str, fields: Mapping[str, Any]) -> str:
             return f"project path is not a directory: {fields.get('path')}"
         case "cocotb.results_missing":
             return f"cocotb results file not found for {target} at {fields.get('path')} — sim may have crashed before writing results"
+        case "systemc.cfg_missing":
+            return f"SystemC testbench '{target}' requires cfg-systemc block in root_config.yaml"
+        case "systemc.home_unresolved":
+            return f"SystemC testbench '{target}' could not resolve home (set cfg-systemc.home or $SYSTEMC_HOME)"
         case "builder.mode_missing":
             return f'builder "{fields.get("builder")}": mode "{fields.get("mode")}" not in config (stage={fields.get("stage")})'
         case "builder.stage_missing":

--- a/src/rtl_buddy/runner/test_runner.py
+++ b/src/rtl_buddy/runner/test_runner.py
@@ -10,6 +10,7 @@ logger = logging.getLogger(__name__)
 
 from ..tools.vlog_sim import VlogSim
 from ..tools.cocotb_sim import CocotbSim
+from ..tools.systemc_sim import SystemCSim
 from ..seed_mode import SeedMode
 from .test_results import *
 from ..errors import FilelistError
@@ -65,7 +66,13 @@ class TestRunner:
         if "sim_to_stdout" in self.test_runner_mode:
             sim_mode["sim_to_stdout"] = self.test_runner_mode["sim_to_stdout"]
 
-        sim_class = CocotbSim if self.test_cfg.get_testbench().is_cocotb() else VlogSim
+        tb = self.test_cfg.get_testbench()
+        if tb.is_cocotb():
+            sim_class = CocotbSim
+        elif tb.is_systemc():
+            sim_class = SystemCSim
+        else:
+            sim_class = VlogSim
         return sim_class(
             name=self.name + "/vlog_sim",
             root_cfg=self.root_cfg,

--- a/src/rtl_buddy/tools/systemc_sim.py
+++ b/src/rtl_buddy/tools/systemc_sim.py
@@ -101,12 +101,25 @@ class SystemCSim(VlogSim):
 
     def _get_extra_compile_flags(self) -> list:
         sc_cfg = self.testbench.systemc
+        root_sc_cfg = self._systemc_cfg()
         home = self._systemc_home()
         include_dir = str(Path(home) / "include")
         lib_dir = str(Path(home) / "lib")
 
-        cflag_tokens = [f"-I{include_dir}", *sc_cfg.cflags]
-        ldflag_tokens = [f"-L{lib_dir}", "-lsystemc", *sc_cfg.ldflags]
+        # SystemC include + libsystemc are always auto-emitted; root-level
+        # cflags/ldflags are project-wide defaults; per-testbench tokens
+        # append on top so testbench-specific defines layer above the default.
+        cflag_tokens = [
+            f"-I{include_dir}",
+            *root_sc_cfg.get_cflags(),
+            *sc_cfg.cflags,
+        ]
+        ldflag_tokens = [
+            f"-L{lib_dir}",
+            "-lsystemc",
+            *root_sc_cfg.get_ldflags(),
+            *sc_cfg.ldflags,
+        ]
 
         flags = [
             "--sc",

--- a/src/rtl_buddy/tools/systemc_sim.py
+++ b/src/rtl_buddy/tools/systemc_sim.py
@@ -1,0 +1,185 @@
+# rtl-buddy
+# vim: set sw=2:ts=2:et:
+#
+# Copyright 2024 rtl_buddy contributors
+#
+"""SystemC + Verilator cosim runner.
+
+Extends VlogSim with Verilator's --sc cosim build path:
+  - drops --binary (use --exe + --build like cocotb)
+  - adds --sc + sc_main/sc_extra positional sources
+  - resolves SYSTEMC_HOME from cfg-systemc (or $SYSTEMC_HOME fallback)
+  - injects -CFLAGS / -LDFLAGS to find headers and libsystemc.{a,dylib,so}
+  - pins CXX at compile time when cfg-systemc.cxx is set (ABI parity with
+    libsystemc.a)
+
+Runtime contract: the Verilator-generated binary's main() is the user's
+sc_main(). Verilator::commandArgs(argc, argv) reads +KEY=VAL plusargs from
+argv, so the existing VlogSim plusarg forwarding works unchanged.
+"""
+
+import logging
+import os
+import sys
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+from .vlog_sim import VlogSim
+from ..errors import FatalRtlBuddyError
+from ..logging_utils import log_event
+
+
+_PIN_STYLE_FLAGS = {
+    "uint": "--pins-sc-uint",
+    "biguint": "--pins-sc-biguint",
+    # "bv" → no flag; Verilator's default emits sc_bv for >32-bit ports
+    "bv": None,
+}
+
+
+class SystemCSim(VlogSim):
+    """SystemC cosim — Verilator --sc + user sc_main()."""
+
+    def _systemc_cfg(self):
+        """Return the resolved cfg-systemc block or fail with a clear error.
+
+        cfg-systemc is optional at the root_config level (projects with no
+        SystemC tests do not need it), so absence is fatal only when reached
+        from a SystemC testbench.
+        """
+        cfg = self.root_cfg.get_systemc_cfg()
+        if cfg is None:
+            log_event(
+                logger,
+                logging.ERROR,
+                "systemc.cfg_missing",
+                test=self.test_name,
+            )
+            raise FatalRtlBuddyError(
+                f"testbench '{self.testbench.name}' requires SystemC, "
+                "but root_config.yaml has no cfg-systemc block"
+            )
+        return cfg
+
+    def _systemc_home(self) -> str:
+        cfg = self._systemc_cfg()
+        home = cfg.get_home()
+        if home is None:
+            log_event(
+                logger,
+                logging.ERROR,
+                "systemc.home_unresolved",
+                test=self.test_name,
+            )
+            raise FatalRtlBuddyError(
+                f"testbench '{self.testbench.name}' requires SystemC, but neither "
+                "cfg-systemc.home nor $SYSTEMC_HOME is set"
+            )
+        return home
+
+    def _resolve_suite_path(self, rel_path: str) -> str:
+        """Resolve a testbench-relative path against the suite directory."""
+        if os.path.isabs(rel_path):
+            return rel_path
+        return str(Path(self.suite_work_dir) / rel_path)
+
+    def _pin_style_flag(self) -> str | None:
+        style = self.testbench.systemc.pin_style
+        if style is None:
+            return None
+        if style not in _PIN_STYLE_FLAGS:
+            raise FatalRtlBuddyError(
+                f"testbench '{self.testbench.name}': systemc.pin_style "
+                f"'{style}' invalid; expected one of {sorted(_PIN_STYLE_FLAGS)}"
+            )
+        return _PIN_STYLE_FLAGS[style]
+
+    def _filter_builder_opts(self, opts: list) -> list:
+        # SystemC uses --exe + --build; the builder's --binary would conflict.
+        return [o for o in opts if o != "--binary"]
+
+    def _get_extra_compile_flags(self) -> list:
+        sc_cfg = self.testbench.systemc
+        home = self._systemc_home()
+        include_dir = str(Path(home) / "include")
+        lib_dir = str(Path(home) / "lib")
+
+        cflag_tokens = [f"-I{include_dir}", *sc_cfg.cflags]
+        ldflag_tokens = [f"-L{lib_dir}", "-lsystemc", *sc_cfg.ldflags]
+
+        flags = [
+            "--sc",
+            "--exe",
+            "--build",
+            "-j",
+            "0",
+            "--top-module",
+            self.testbench.toplevel,
+        ]
+
+        pin_flag = self._pin_style_flag()
+        if pin_flag is not None:
+            flags.append(pin_flag)
+
+        flags.append(self._resolve_suite_path(sc_cfg.sc_main))
+        for extra in sc_cfg.sc_extra:
+            flags.append(self._resolve_suite_path(extra))
+
+        flags += ["-CFLAGS", " ".join(cflag_tokens)]
+        flags += ["-LDFLAGS", " ".join(ldflag_tokens)]
+
+        log_event(
+            logger,
+            logging.DEBUG,
+            "systemc.compile_flags",
+            test=self.test_name,
+            toplevel=self.testbench.toplevel,
+            sc_main=sc_cfg.sc_main,
+            sc_extra=sc_cfg.sc_extra,
+            pin_style=sc_cfg.pin_style,
+            home=home,
+        )
+        return flags
+
+    def _get_extra_compile_env(self) -> dict:
+        cfg = self._systemc_cfg()
+        home = self._systemc_home()
+        env: dict[str, str] = {
+            "SYSTEMC_HOME": home,
+            "SYSTEMC_INCLUDE": str(Path(home) / "include"),
+            "SYSTEMC_LIBDIR": str(Path(home) / "lib"),
+        }
+        cxx = cfg.get_cxx()
+        if cxx is not None:
+            env["CXX"] = cxx
+        return env
+
+    def _get_extra_sim_env(self, run_id=None) -> dict:
+        """Add SystemC libdir to the dynamic-linker search path.
+
+        No-op for static libsystemc.a (the binary is self-contained), but
+        required when libsystemc is built as a shared object — checking the
+        link form here would be brittle, so we always add the path.
+        """
+        home = self._systemc_home()
+        lib_dir = str(Path(home) / "lib")
+
+        env: dict[str, str] = {}
+        if sys.platform == "darwin":
+            existing = os.environ.get("DYLD_FALLBACK_LIBRARY_PATH", "")
+            parts = [lib_dir] + ([existing] if existing else [])
+            env["DYLD_FALLBACK_LIBRARY_PATH"] = ":".join(parts)
+        else:
+            existing = os.environ.get("LD_LIBRARY_PATH", "")
+            parts = [lib_dir] + ([existing] if existing else [])
+            env["LD_LIBRARY_PATH"] = ":".join(parts)
+        log_event(
+            logger,
+            logging.DEBUG,
+            "systemc.sim_env",
+            test=self.test_name,
+            run_id=run_id,
+            lib_dir=lib_dir,
+        )
+        return env

--- a/src/rtl_buddy/tools/vlog_sim.py
+++ b/src/rtl_buddy/tools/vlog_sim.py
@@ -151,6 +151,15 @@ class VlogSim:
     def _get_extra_compile_flags(self) -> list:
         return []
 
+    def _get_extra_compile_env(self) -> dict:
+        """Hook for subclasses to inject env vars into the compile subprocess.
+
+        Base VlogSim has no extra env. SystemCSim overrides to pin CXX and
+        export SYSTEMC_HOME / SYSTEMC_INCLUDE / SYSTEMC_LIBDIR so Verilator's
+        --build step picks them up when invoking the generated Makefile.
+        """
+        return {}
+
     def _get_extra_sim_env(self, run_id=None) -> dict:
         return {}
 
@@ -322,10 +331,16 @@ class VlogSim:
             builder=rtl_builder_cfg.get_name(),
         )
         s_time = time.time()
+        extra_compile_env = self._get_extra_compile_env()
+        compile_env = {**os.environ, **extra_compile_env} if extra_compile_env else None
         with task_status(f"Compiling {self.test_name}", spinner="dots12"):
             try:
                 result = run_managed_process(
-                    run_cmd, capture_output=True, text=True, cwd=compile_work_dir
+                    run_cmd,
+                    capture_output=True,
+                    text=True,
+                    cwd=compile_work_dir,
+                    env=compile_env,
                 )
             except FileNotFoundError:
                 log_event(

--- a/tests/test_config_loaders.py
+++ b/tests/test_config_loaders.py
@@ -17,7 +17,7 @@ from rtl_buddy.config.root import (
 from rtl_buddy.config.suite import SuiteConfig
 
 # Alias imports so pytest does not try to collect them as test classes.
-from rtl_buddy.config.test import CocotbTestbenchConfig
+from rtl_buddy.config.test import CocotbTestbenchConfig, SystemCTestbenchConfig
 from rtl_buddy.config.test import TestConfig as TC
 from rtl_buddy.config.test import TestbenchConfig as TB
 from rtl_buddy.errors import FatalRtlBuddyError
@@ -117,6 +117,52 @@ def test_testbench_is_cocotb_flag():
         cocotb=CocotbTestbenchConfig(module="tb_mod"),
     )
     assert cocotb.is_cocotb() is True
+
+
+# ---------------------------------------------------------------------------
+# SystemCTestbenchConfig
+# ---------------------------------------------------------------------------
+
+
+def test_systemc_testbench_requires_toplevel():
+    with pytest.raises(FatalRtlBuddyError, match="toplevel is required"):
+        TB(
+            name="tb",
+            filelist=["a.sv"],
+            systemc=SystemCTestbenchConfig(sc_main="sc_main.cpp"),
+        )
+
+
+def test_systemc_and_cocotb_are_mutually_exclusive():
+    with pytest.raises(FatalRtlBuddyError, match="mutually exclusive"):
+        TB(
+            name="tb",
+            filelist=["a.sv"],
+            toplevel="dut",
+            cocotb=CocotbTestbenchConfig(module="tb_mod"),
+            systemc=SystemCTestbenchConfig(sc_main="sc_main.cpp"),
+        )
+
+
+def test_testbench_is_systemc_flag():
+    plain = TB(name="tb", filelist=["a.sv"])
+    assert plain.is_systemc() is False
+    sc = TB(
+        name="tb",
+        filelist=["a.sv"],
+        toplevel="dut",
+        systemc=SystemCTestbenchConfig(sc_main="sc_main.cpp"),
+    )
+    assert sc.is_systemc() is True
+    assert sc.is_cocotb() is False
+
+
+def test_systemc_default_fields_are_empty():
+    sc = SystemCTestbenchConfig(sc_main="sc_main.cpp")
+    assert sc.sc_extra == []
+    assert sc.cflags == []
+    assert sc.ldflags == []
+    assert sc.pin_style is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_systemc_sim.py
+++ b/tests/test_systemc_sim.py
@@ -174,6 +174,58 @@ def test_compile_flags_embed_cflags_and_ldflags(tmp_path):
     assert "-lpthread" in ldflags_value
 
 
+def test_root_cflags_apply_as_project_default(tmp_path):
+    """Project-wide cflags from cfg-systemc apply even when the testbench
+    omits its own cflags."""
+    sc = SystemCTestbenchConfig(sc_main="sc_main.cpp")
+    sim = _make_sim(
+        tmp_path,
+        sc,
+        systemc_cfg=SystemCConfig(
+            home="/opt/sc",
+            cxx=None,
+            cflags=["-std=c++17"],
+            ldflags=["-lz"],
+        ),
+    )
+    flags = sim._get_extra_compile_flags()
+    assert "-std=c++17" in flags[flags.index("-CFLAGS") + 1]
+    assert "-lz" in flags[flags.index("-LDFLAGS") + 1]
+
+
+def test_testbench_cflags_append_to_root_cflags(tmp_path):
+    """Per-testbench cflags layer above the root-level default, not replace it."""
+    sc = SystemCTestbenchConfig(
+        sc_main="sc_main.cpp",
+        cflags=["-DTB_LOCAL=1"],
+        ldflags=["-lpthread"],
+    )
+    sim = _make_sim(
+        tmp_path,
+        sc,
+        systemc_cfg=SystemCConfig(
+            home="/opt/sc",
+            cxx=None,
+            cflags=["-std=c++17"],
+            ldflags=["-lz"],
+        ),
+    )
+    flags = sim._get_extra_compile_flags()
+    cflags_value = flags[flags.index("-CFLAGS") + 1]
+    ldflags_value = flags[flags.index("-LDFLAGS") + 1]
+
+    # Both layers present.
+    assert "-std=c++17" in cflags_value
+    assert "-DTB_LOCAL=1" in cflags_value
+    assert "-lz" in ldflags_value
+    assert "-lpthread" in ldflags_value
+
+    # Root tokens appear before testbench tokens, so testbench can override
+    # via "last wins" semantics on flags like -O2 / -DFOO.
+    assert cflags_value.index("-std=c++17") < cflags_value.index("-DTB_LOCAL=1")
+    assert ldflags_value.index("-lz") < ldflags_value.index("-lpthread")
+
+
 def test_pin_style_uint_adds_pins_sc_uint(tmp_path):
     sc = SystemCTestbenchConfig(sc_main="sc_main.cpp", pin_style="uint")
     sim = _make_sim(tmp_path, sc, systemc_cfg=SystemCConfig(home="/opt/sc", cxx=None))

--- a/tests/test_systemc_sim.py
+++ b/tests/test_systemc_sim.py
@@ -322,3 +322,34 @@ def test_home_expands_variables_and_user(tmp_path, monkeypatch):
     )
     env = sim._get_extra_compile_env()
     assert env["SYSTEMC_HOME"] == "/expanded/systemc"
+
+
+def test_home_with_unresolved_var_falls_through_to_env(tmp_path, monkeypatch):
+    """If the configured ${VAR} doesn't resolve, the env-var fallback still runs.
+
+    Without this, os.path.expandvars would leave the literal "${VAR}" and
+    SystemCSim would pass that to Verilator as a path, producing a confusing
+    "include not found at ${SYSTEMC_HOME}/include" instead of the clean
+    home_unresolved error.
+    """
+    monkeypatch.delenv("MY_CUSTOM_ROOT", raising=False)
+    monkeypatch.setenv("SYSTEMC_HOME", "/fallback/sc")
+    sc = SystemCTestbenchConfig(sc_main="sc_main.cpp")
+    sim = _make_sim(
+        tmp_path, sc, systemc_cfg=SystemCConfig(home="${MY_CUSTOM_ROOT}", cxx=None)
+    )
+    env = sim._get_extra_compile_env()
+    assert env["SYSTEMC_HOME"] == "/fallback/sc"
+
+
+def test_home_with_unresolved_var_and_no_fallback_raises(tmp_path, monkeypatch):
+    """Unresolved ${VAR} + unset SYSTEMC_HOME → clean home_unresolved error,
+    not a literal "${VAR}" propagated as a path."""
+    monkeypatch.delenv("MY_CUSTOM_ROOT", raising=False)
+    monkeypatch.delenv("SYSTEMC_HOME", raising=False)
+    sc = SystemCTestbenchConfig(sc_main="sc_main.cpp")
+    sim = _make_sim(
+        tmp_path, sc, systemc_cfg=SystemCConfig(home="${MY_CUSTOM_ROOT}", cxx=None)
+    )
+    with pytest.raises(FatalRtlBuddyError, match="SYSTEMC_HOME"):
+        sim._get_extra_compile_flags()

--- a/tests/test_systemc_sim.py
+++ b/tests/test_systemc_sim.py
@@ -1,0 +1,272 @@
+"""Unit tests for SystemCSim — verilator --sc cosim runner."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from rtl_buddy.config.systemc import SystemCConfig
+from rtl_buddy.config.test import SystemCTestbenchConfig
+from rtl_buddy.errors import FatalRtlBuddyError
+from rtl_buddy.tools.systemc_sim import SystemCSim
+
+
+class _DummyBuilderCfg:
+    def get_exe(self):
+        return "verilator"
+
+    def get_simv(self):
+        return "simv"
+
+    def get_seed(self):
+        return 1
+
+    def get_name(self):
+        return "verilator"
+
+    def get_simulator_family(self):
+        return "verilator"
+
+    def get_compile_time_opts(self, _m):
+        return ["--binary", "-sv", "-o", "simv"]
+
+    def get_run_time_opts(self, _m, seed=None):
+        return []
+
+
+class _DummyRootCfg:
+    def __init__(self, systemc_cfg: SystemCConfig | None):
+        self._systemc_cfg = systemc_cfg
+
+    def get_rtl_builder_cfg(self):
+        return _DummyBuilderCfg()
+
+    def get_use_lcov(self, _):
+        return False
+
+    def get_systemc_cfg(self):
+        return self._systemc_cfg
+
+
+class _DummyTestbench:
+    def __init__(self, sc_cfg: SystemCTestbenchConfig, toplevel="my_dut"):
+        self.name = "tb_sc"
+        self.toplevel = toplevel
+        self.systemc = sc_cfg
+        self.cocotb = None
+
+    def get_filelist(self):
+        return []
+
+    def is_cocotb(self):
+        return False
+
+    def is_systemc(self):
+        return True
+
+
+class _DummyTestCfg:
+    pd = None
+    uvm = None
+
+    def __init__(self, sc_cfg, toplevel="my_dut"):
+        self._tb = _DummyTestbench(sc_cfg, toplevel=toplevel)
+
+    def get_name(self):
+        return "test_sc"
+
+    def get_model(self):
+        from types import SimpleNamespace
+
+        return SimpleNamespace(
+            get_model_path=lambda: "/dev/null", get_filelist=lambda: []
+        )
+
+    def get_testbench(self):
+        return self._tb
+
+    def get_plusargs(self):
+        return None
+
+    def get_plusdefines(self):
+        return {}
+
+    def get_timeout(self):
+        return 60, False
+
+    def get_preproc_path(self):
+        return None
+
+
+def _make_sim(tmp_path, sc_cfg, *, systemc_cfg=None):
+    return SystemCSim(
+        name="rtl_buddy/systemc_sim",
+        root_cfg=_DummyRootCfg(systemc_cfg),
+        test_cfg=_DummyTestCfg(sc_cfg),
+        rtl_builder_mode="sim",
+        sim_mode={"sim_to_stdout": True},
+        suite_dir=str(tmp_path),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Compile-flag emission
+# ---------------------------------------------------------------------------
+
+
+def test_filter_builder_opts_drops_binary(tmp_path):
+    sc = SystemCTestbenchConfig(sc_main="sc_main.cpp")
+    sim = _make_sim(tmp_path, sc, systemc_cfg=SystemCConfig(home="/opt/sc", cxx=None))
+    assert sim._filter_builder_opts(["--binary", "-sv", "-o", "simv"]) == [
+        "-sv",
+        "-o",
+        "simv",
+    ]
+
+
+def test_compile_flags_include_sc_exe_build_and_top(tmp_path):
+    sc = SystemCTestbenchConfig(sc_main="sc_main.cpp")
+    sim = _make_sim(tmp_path, sc, systemc_cfg=SystemCConfig(home="/opt/sc", cxx=None))
+    flags = sim._get_extra_compile_flags()
+    assert "--sc" in flags
+    assert "--exe" in flags
+    assert "--build" in flags
+    assert flags[flags.index("--top-module") + 1] == "my_dut"
+
+
+def test_compile_flags_resolve_sc_main_against_suite(tmp_path):
+    sc = SystemCTestbenchConfig(sc_main="harness/sc_main.cpp")
+    sim = _make_sim(tmp_path, sc, systemc_cfg=SystemCConfig(home="/opt/sc", cxx=None))
+    flags = sim._get_extra_compile_flags()
+    expected = str(Path(tmp_path) / "harness" / "sc_main.cpp")
+    assert expected in flags
+
+
+def test_compile_flags_include_sc_extra_resolved(tmp_path):
+    sc = SystemCTestbenchConfig(
+        sc_main="sc_main.cpp", sc_extra=["models/bus.cpp", "models/scoreboard.cpp"]
+    )
+    sim = _make_sim(tmp_path, sc, systemc_cfg=SystemCConfig(home="/opt/sc", cxx=None))
+    flags = sim._get_extra_compile_flags()
+    assert str(Path(tmp_path) / "models" / "bus.cpp") in flags
+    assert str(Path(tmp_path) / "models" / "scoreboard.cpp") in flags
+
+
+def test_compile_flags_embed_cflags_and_ldflags(tmp_path):
+    sc = SystemCTestbenchConfig(
+        sc_main="sc_main.cpp",
+        cflags=["-std=c++17", "-DFOO=1"],
+        ldflags=["-lpthread"],
+    )
+    sim = _make_sim(tmp_path, sc, systemc_cfg=SystemCConfig(home="/opt/sc", cxx=None))
+    flags = sim._get_extra_compile_flags()
+
+    cflags_value = flags[flags.index("-CFLAGS") + 1]
+    assert "-I/opt/sc/include" in cflags_value
+    assert "-std=c++17" in cflags_value
+    assert "-DFOO=1" in cflags_value
+
+    ldflags_value = flags[flags.index("-LDFLAGS") + 1]
+    assert "-L/opt/sc/lib" in ldflags_value
+    assert "-lsystemc" in ldflags_value
+    assert "-lpthread" in ldflags_value
+
+
+def test_pin_style_uint_adds_pins_sc_uint(tmp_path):
+    sc = SystemCTestbenchConfig(sc_main="sc_main.cpp", pin_style="uint")
+    sim = _make_sim(tmp_path, sc, systemc_cfg=SystemCConfig(home="/opt/sc", cxx=None))
+    assert "--pins-sc-uint" in sim._get_extra_compile_flags()
+
+
+def test_pin_style_biguint_adds_pins_sc_biguint(tmp_path):
+    sc = SystemCTestbenchConfig(sc_main="sc_main.cpp", pin_style="biguint")
+    sim = _make_sim(tmp_path, sc, systemc_cfg=SystemCConfig(home="/opt/sc", cxx=None))
+    assert "--pins-sc-biguint" in sim._get_extra_compile_flags()
+
+
+def test_pin_style_bv_adds_no_pin_flag(tmp_path):
+    sc = SystemCTestbenchConfig(sc_main="sc_main.cpp", pin_style="bv")
+    sim = _make_sim(tmp_path, sc, systemc_cfg=SystemCConfig(home="/opt/sc", cxx=None))
+    flags = sim._get_extra_compile_flags()
+    assert not any(f.startswith("--pins-sc-") for f in flags)
+
+
+# ---------------------------------------------------------------------------
+# Env handling
+# ---------------------------------------------------------------------------
+
+
+def test_compile_env_exports_systemc_paths(tmp_path):
+    sc = SystemCTestbenchConfig(sc_main="sc_main.cpp")
+    sim = _make_sim(tmp_path, sc, systemc_cfg=SystemCConfig(home="/opt/sc", cxx=None))
+    env = sim._get_extra_compile_env()
+    assert env["SYSTEMC_HOME"] == "/opt/sc"
+    assert env["SYSTEMC_INCLUDE"] == "/opt/sc/include"
+    assert env["SYSTEMC_LIBDIR"] == "/opt/sc/lib"
+    assert "CXX" not in env
+
+
+def test_compile_env_pins_cxx_when_configured(tmp_path):
+    sc = SystemCTestbenchConfig(sc_main="sc_main.cpp")
+    sim = _make_sim(
+        tmp_path,
+        sc,
+        systemc_cfg=SystemCConfig(home="/opt/sc", cxx="/usr/local/bin/g++-15"),
+    )
+    env = sim._get_extra_compile_env()
+    assert env["CXX"] == "/usr/local/bin/g++-15"
+
+
+def test_sim_env_adds_libdir_to_dynamic_loader_path(tmp_path, monkeypatch):
+    sc = SystemCTestbenchConfig(sc_main="sc_main.cpp")
+    sim = _make_sim(tmp_path, sc, systemc_cfg=SystemCConfig(home="/opt/sc", cxx=None))
+    monkeypatch.delenv("DYLD_FALLBACK_LIBRARY_PATH", raising=False)
+    monkeypatch.delenv("LD_LIBRARY_PATH", raising=False)
+
+    env = sim._get_extra_sim_env()
+    key = (
+        "DYLD_FALLBACK_LIBRARY_PATH"
+        if os.uname().sysname == "Darwin"
+        else "LD_LIBRARY_PATH"
+    )
+    assert env[key].startswith("/opt/sc/lib")
+
+
+# ---------------------------------------------------------------------------
+# Fail-fast paths
+# ---------------------------------------------------------------------------
+
+
+def test_missing_cfg_systemc_raises(tmp_path):
+    sc = SystemCTestbenchConfig(sc_main="sc_main.cpp")
+    sim = _make_sim(tmp_path, sc, systemc_cfg=None)
+    with pytest.raises(FatalRtlBuddyError, match="cfg-systemc"):
+        sim._get_extra_compile_flags()
+
+
+def test_missing_home_raises(tmp_path, monkeypatch):
+    monkeypatch.delenv("SYSTEMC_HOME", raising=False)
+    sc = SystemCTestbenchConfig(sc_main="sc_main.cpp")
+    sim = _make_sim(tmp_path, sc, systemc_cfg=SystemCConfig(home=None, cxx=None))
+    with pytest.raises(FatalRtlBuddyError, match="SYSTEMC_HOME"):
+        sim._get_extra_compile_flags()
+
+
+def test_home_falls_back_to_env(tmp_path, monkeypatch):
+    monkeypatch.setenv("SYSTEMC_HOME", "/from/env/systemc")
+    sc = SystemCTestbenchConfig(sc_main="sc_main.cpp")
+    sim = _make_sim(tmp_path, sc, systemc_cfg=SystemCConfig(home=None, cxx=None))
+    env = sim._get_extra_compile_env()
+    assert env["SYSTEMC_HOME"] == "/from/env/systemc"
+
+
+def test_home_expands_variables_and_user(tmp_path, monkeypatch):
+    monkeypatch.setenv("MY_SC_ROOT", "/expanded/systemc")
+    sc = SystemCTestbenchConfig(sc_main="sc_main.cpp")
+    sim = _make_sim(
+        tmp_path, sc, systemc_cfg=SystemCConfig(home="${MY_SC_ROOT}", cxx=None)
+    )
+    env = sim._get_extra_compile_env()
+    assert env["SYSTEMC_HOME"] == "/expanded/systemc"

--- a/tests/test_vlog_sim_paths.py
+++ b/tests/test_vlog_sim_paths.py
@@ -185,9 +185,10 @@ def test_vlog_sim_compile_uses_explicit_filelist_path_and_suite_cwd(
     captured = {}
     sim = _make_sim(tmp_path, monkeypatch)
 
-    def _fake_run(cmd, capture_output, text, cwd):
+    def _fake_run(cmd, capture_output, text, cwd, env=None):
         captured["cmd"] = list(cmd)
         captured["cwd"] = cwd
+        captured["env"] = env
         return ManagedProcessResult(returncode=0, stdout="", stderr="")
 
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary

- Adds a `systemc:` nested block on `TestbenchConfig` (mirrors the existing cocotb convention exactly — presence-of-nested-block, sibling `SystemCSim` extending `VlogSim`, no `kind:` discriminator).
- Adds `cfg-systemc: {home, cxx}` to `root_config.yaml` for SYSTEMC_HOME / CXX resolution, with `$SYSTEMC_HOME` env fallback and \$VAR / ~ expansion.
- `SystemCSim` drops `--binary`, emits `--sc --exe --build --top-module`, resolves sc_main/sc_extra against the suite dir, embeds `-CFLAGS -I\$home/include` + `-LDFLAGS -L\$home/lib -lsystemc`, pins CXX + SYSTEMC_* env at compile, adds libdir to dynamic-linker path at run.
- Forwards plusargs as argv (Verilator's `commandArgs(argc, argv)` reads them in `sc_main`) — same `+TEST=basic` contract as today.
- Fail-fast paths: `cocotb:` + `systemc:` mutually exclusive (different host kernels can't share one Verilator build); `toplevel` required when `systemc:` present; missing `cfg-systemc` or unresolved `home` raises with a clear event.

Closes #151. See the convention-parity-with-cocotb discussion on the issue for why the original `kind:` proposal was dropped.

## Schema example

\`\`\`yaml
# tests.yaml
testbenches:
  - name: tb_alu_sc
    toplevel: demo_tiny_alu
    filelist: ["../../design/demo_tiny_alu/demo_tiny_alu.sv"]
    systemc:
      sc_main: sc_main.cpp
      cflags: ["-std=c++17"]

# root_config.yaml
cfg-systemc:
  home: "\${WORKSPACE}/systemc-install"
  cxx: "/opt/homebrew/bin/g++-15"
\`\`\`

## Test plan

- [x] Unit tests for `SystemCTestbenchConfig` (validation, mutual exclusion with cocotb, defaults).
- [x] Unit tests for `SystemCSim` — compile flag emission, env, pin-style mapping, fail-fast paths, env-var expansion (15 tests in `tests/test_systemc_sim.py`).
- [x] Existing `_fake_run` mock in `test_vlog_sim_paths.py` updated for new `env=` kwarg on `run_managed_process`.
- [x] Full pytest suite: 607 passed (1 pre-existing schema-drift check unrelated to this change).
- [x] `ruff check` clean; `ruff format` applied.
- [x] End-to-end validation in `rtl-buddy-project-template`'s `dev/local-rtl-buddy` worktree — `rb test basic_sc` PASS (8/8 directed ALU opcode vectors). SV (`basic`) and cocotb (`cocotb_random`) suites unaffected.

## Follow-ups (out of scope)

- Coverage merging from C++ gcov (VL-coverage of the RTL works as-is).
- TLM-2.0 socket helpers / pre-baked initiator stubs — left to user code.
- Mixed cocotb + SystemC in one testbench — kernel coexistence problem, see issue thread.
- Downstream rtl-buddy-project-template demo (`verif/demo_tiny_alu_sc/`) and pinned dependency bump — separate PR once this releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)