### PR TITLE
feat(hub): resolver src_to_view + augment source_focused → selection_changed

### DIFF
--- a/docs/concepts/hub.md
+++ b/docs/concepts/hub.md
@@ -116,6 +116,8 @@ State events (selection_changed, signal_selected, cursor_moved, …) are broadca
 
 Lifecycle events (`hello` / `welcome` / `peer_joined` / `bye`) keep each peer's view of the registry live without re-fetching: `welcome` carries the snapshot at handshake time, and `peer_joined` / `bye` are deltas the hub broadcasts when later peers connect or disconnect. The joining or leaving peer's origin is in the envelope's `origin` field (payload is empty). Consumers should react to all three to maintain a current peer list — relying on `welcome` alone leaves the list frozen at handshake time.
 
+The hub also **augments `source_focused`**: when a `src` peer (e.g. nvim's `:RtlBuddyShow`) broadcasts `{file, line, col}`, the resolver looks up the instance(s) whose `source` range in `view.json` contains the point and the hub emits a derived `selection_changed { instance_path: [...] }` with `origin: "cli"`. The schematic SPA already handles `selection_changed` — pan/highlight the matching instance — so this bridge makes editor cursor movement light up the schematic without a SPA-side protocol change. Multiple matches (nested instances) come back smallest-range first; consumers picking element `[0]` get the most-specific instance. Line-only matching is used for multi-line ranges (cursor at column 1 still finds an instantiation whose keyword sits further right); single-line ranges still use columns so two instantiations on the same line resolve distinctly.
+
 ## Troubleshooting
 
 **`rb hub start` exits with "already running"** — `.rtl-buddy/hub.json` exists and its PID is live. If the prior daemon really is gone, the file is stale (clean shutdown didn't run); delete it and retry. `rb hub status` distinguishes the two cases.

--- a/src/rtl_buddy/hub/resolver.py
+++ b/src/rtl_buddy/hub/resolver.py
@@ -57,21 +57,65 @@ class ResolverError(Exception):
 
 @dataclass(frozen=True, slots=True)
 class SourceAnchor:
-    """A ``view.json`` ``location`` value — translated to wire shape.
+    """A ``view.json`` ``source`` value — translated to wire shape.
 
     The wire protocol's ``open_source`` / ``source_focused`` payloads
-    are ``{file, line, col}``; ``view.json`` uses ``start_line`` /
-    ``start_column`` (with end positions too). This dataclass holds
-    the canonical wire shape so the server doesn't have to translate
-    on every request.
+    are ``{file, line, col}`` — single point. ``view.json``'s
+    ``source_block`` is a range with ``start_line`` / ``start_column``
+    + optional ``end_line`` / ``end_column``. This dataclass keeps both
+    so :meth:`as_payload` returns the wire shape (start point) while
+    :meth:`contains` enables range queries for ``src_to_view``.
     """
 
     file: str
     line: int
     col: int
+    end_line: int | None = None
+    end_col: int | None = None
 
     def as_payload(self) -> dict[str, object]:
         return {"file": self.file, "line": self.line, "col": self.col}
+
+    def contains(self, *, line: int, col: int | None = None) -> bool:
+        """Return True when ``(line, col)`` falls inside the source
+        range, with a deliberate UX choice: line-only matching for
+        multi-line ranges.
+
+        Strict column checks at the start/end lines would reject the
+        common "cursor at column 1 on the instantiation line" case —
+        editors often park the cursor at indentation while the actual
+        instance keyword is much further right. A line-inside-range
+        match keeps ``src_to_view`` useful for `:RtlBuddyShow` without
+        forcing the user to land on the exact column.
+
+        For single-line ranges (``end_line == start_line``), columns
+        are still consulted to disambiguate adjacent instances on the
+        same line (rare but does happen with generate blocks).
+        """
+        if self.end_line is None:
+            # Point anchor (no range) — match exact line only.
+            return line == self.line
+        if not (self.line <= line <= self.end_line):
+            return False
+        # Multi-line range: line membership is enough. The
+        # smallest-range tiebreak in :meth:`Resolver.src_to_view`
+        # already favours the most-specific instance.
+        if self.end_line != self.line:
+            return True
+        # Single-line range: column boundaries matter (otherwise two
+        # instantiations on one line would both match every cursor on
+        # that line).
+        if col is None or self.end_col is None:
+            return True
+        return self.col <= col <= self.end_col
+
+    def range_size(self) -> int:
+        """Total covered lines, used to break ties when multiple
+        anchors contain the same point — the smaller range is the
+        more-specific match (a nested instance over its parent)."""
+        if self.end_line is None:
+            return 1
+        return max(1, self.end_line - self.line + 1)
 
 
 @dataclass(frozen=True, slots=True)
@@ -117,32 +161,64 @@ class ViewModel:
                 f"(expected {SUPPORTED_VIEW_SCHEMA_MAJOR})"
             )
 
-        top = raw.get("design", {}).get("top")
+        # Canonical schema lives in rtl-buddy-view/docs/view-json-v1.md
+        # and emits `top` flat at the root. Hand-rolled fixtures from
+        # before that doc was written use the older `design.top` shape,
+        # so we accept both rather than break legacy tests / projects.
+        top = raw.get("top")
+        if not (isinstance(top, str) and top):
+            top = (
+                raw.get("design", {}).get("top")
+                if isinstance(raw.get("design"), dict)
+                else None
+            )
         if not isinstance(top, str) or not top:
-            raise ResolverError("view.json missing design.top")
+            raise ResolverError("view.json missing top (or design.top)")
 
+        # Same dual-schema acceptance for nodes: canonical uses `id` +
+        # `source`; legacy fixtures use `instance_path` + `location`.
         nodes_by_path: dict[str, Node] = {}
         for entry in raw.get("nodes", []):
-            ip = entry.get("instance_path")
+            ip = entry.get("id")
+            if not (isinstance(ip, str) and ip):
+                ip = entry.get("instance_path")
             if not isinstance(ip, str) or not ip:
                 continue
-            loc = _location_to_anchor(entry.get("location"))
+            loc = _location_to_anchor(entry.get("source") or entry.get("location"))
             ports: list[tuple[str, str]] = []
-            for pc in entry.get("port_connections", []):
-                if not isinstance(pc, dict):
-                    continue
-                pn = pc.get("port_name")
-                ne = pc.get("net_expr_text")
-                if isinstance(pn, str) and isinstance(ne, str):
-                    ports.append((pn, ne))
+            # Canonical schema uses `ports` with `{name, expr}`; legacy
+            # fixtures use `port_connections` with `{port_name, net_expr_text}`.
+            ports_raw = entry.get("ports")
+            if isinstance(ports_raw, list):
+                for p in ports_raw:
+                    if not isinstance(p, dict):
+                        continue
+                    pn = p.get("name")
+                    ne = p.get("expr")
+                    if isinstance(pn, str) and isinstance(ne, str):
+                        ports.append((pn, ne))
+            else:
+                for pc in entry.get("port_connections", []):
+                    if not isinstance(pc, dict):
+                        continue
+                    pn = pc.get("port_name")
+                    ne = pc.get("net_expr_text")
+                    if isinstance(pn, str) and isinstance(ne, str):
+                        ports.append((pn, ne))
             nodes_by_path[ip] = Node(
                 instance_path=ip, location=loc, port_connections=tuple(ports)
             )
 
+        # Edges: canonical uses `{from, to}`; legacy uses `{parent, child}`.
         edges: dict[str, list[str]] = {}
         for e in raw.get("edges", []):
-            parent = e.get("parent")
-            child = e.get("child")
+            if not isinstance(e, dict):
+                continue
+            parent = e.get("from")
+            child = e.get("to")
+            if not (isinstance(parent, str) and isinstance(child, str)):
+                parent = e.get("parent")
+                child = e.get("child")
             if not (isinstance(parent, str) and isinstance(child, str)):
                 continue
             edges.setdefault(parent, []).append(child)
@@ -157,18 +233,34 @@ class ViewModel:
 
 
 def _location_to_anchor(raw: object) -> SourceAnchor | None:
+    """Translate a view.json ``source_block`` (or legacy ``location``)
+    into a :class:`SourceAnchor`.
+
+    Accepts both the canonical schema from rtl-buddy-view's
+    ``view-json-v1.md`` (``start_line`` + ``start_column`` + optional
+    ``end_line`` / ``end_column``) and the historical ``line`` / ``col``
+    shorthand used by hand-rolled test fixtures.
+    """
     if not isinstance(raw, dict):
         return None
     file = raw.get("file")
     line = raw.get("start_line", raw.get("line"))
     col = raw.get("start_column", raw.get("col"))
+    end_line = raw.get("end_line")
+    end_col = raw.get("end_column")
     if (
         not isinstance(file, str)
         or not isinstance(line, int)
         or not isinstance(col, int)
     ):
         return None
-    return SourceAnchor(file=file, line=line, col=col)
+    return SourceAnchor(
+        file=file,
+        line=line,
+        col=col,
+        end_line=end_line if isinstance(end_line, int) else None,
+        end_col=end_col if isinstance(end_col, int) else None,
+    )
 
 
 class Resolver:
@@ -299,6 +391,55 @@ class Resolver:
         if node is None:
             return None
         return node.location
+
+    # ------------------------------------------------------------------
+    # src → view  (`:RtlBuddyShow` from nvim → schematic selection)
+    # ------------------------------------------------------------------
+
+    def src_to_view(
+        self, *, file: str, line: int, col: int | None = None
+    ) -> tuple[str, ...]:
+        """Return instance paths whose source range contains the point.
+
+        Used to translate the editor's ``source_focused {file, line, col}``
+        event into a ``selection_changed`` the schematic SPA can act on.
+        Path matching is on absolute, normalised form (``Path.resolve``)
+        so a relative path in ``view.json`` matches an absolute path
+        from the editor — and vice versa.
+
+        Multiple matches can occur because a child instance's range is
+        nested in its parent's; results are ordered smallest range first
+        so the caller can pick the most-specific match (typically the
+        instance being clicked, not the surrounding module).
+        """
+        model = self._load_if_possible()
+        if model is None:
+            return ()
+
+        target = self._normalise_path(file)
+        if target is None:
+            return ()
+
+        matches: list[tuple[int, str]] = []
+        for ip, node in model.nodes_by_path.items():
+            anchor = node.location
+            if anchor is None:
+                continue
+            if self._normalise_path(anchor.file) != target:
+                continue
+            if not anchor.contains(line=line, col=col):
+                continue
+            matches.append((anchor.range_size(), ip))
+
+        matches.sort()
+        return tuple(ip for _size, ip in matches)
+
+    @staticmethod
+    def _normalise_path(p: str) -> str | None:
+        try:
+            return str(Path(p).resolve())
+        except (OSError, RuntimeError):
+            return None
 
     # ------------------------------------------------------------------
     # signal → drivers (the spec's resolve_signal_to_view)

--- a/src/rtl_buddy/hub/server.py
+++ b/src/rtl_buddy/hub/server.py
@@ -449,10 +449,80 @@ class HubServer:
         if env.type in STATE_EVENT_TYPES:
             self._update_state(env)
             await self._broadcast(env, suppress_origin=env.origin)
+            if env.type == "source_focused":
+                await self._augment_source_focused(env)
             return
 
         # Unknown event types are silently dropped per §11.
         log_event(logger, logging.DEBUG, "hub.event.dropped_unknown", type=env.type)
+
+    async def _augment_source_focused(self, env: Envelope) -> None:
+        """Derive a ``selection_changed`` from ``source_focused`` and
+        broadcast it.
+
+        Without this, the SPA receives ``source_focused {file, line, col}``
+        and silently drops it (its switch statement has no case). The
+        schematic SPA already handles ``selection_changed`` — pan/highlight
+        the matching instance — so resolving file/line/col → instance_path
+        on the hub side lets ``:RtlBuddyShow`` from nvim light up the
+        schematic with no SPA-side protocol changes.
+
+        Multiple matches can occur (nested instances); the resolver returns
+        them smallest-range-first, and we forward the full list so the SPA
+        picks the most-specific (per its existing ``Array.isArray ? [0] : ip``
+        logic in ``useHub.applyEnvelope``).
+        """
+        if self.resolver is None:
+            return
+        payload = env.payload or {}
+        file = payload.get("file")
+        line = payload.get("line")
+        col = payload.get("col")
+        if not (isinstance(file, str) and isinstance(line, int)):
+            return
+        try:
+            matches = self.resolver.src_to_view(
+                file=file,
+                line=line,
+                col=col if isinstance(col, int) else None,
+            )
+        except Exception:  # noqa: BLE001 — resolver errors mustn't abort the loop
+            log_event(
+                logger,
+                logging.WARNING,
+                "hub.augment.src_to_view_failed",
+                file=file,
+                line=line,
+            )
+            return
+        if not matches:
+            log_event(
+                logger,
+                logging.DEBUG,
+                "hub.augment.src_to_view_empty",
+                file=file,
+                line=line,
+            )
+            return
+
+        instance_path: object = matches[0] if len(matches) == 1 else list(matches)
+        derived = Envelope(
+            origin=Origin.CLI,
+            kind=Kind.EVENT,
+            type="selection_changed",
+            id=new_id(),
+            payload={"instance_path": instance_path},
+        )
+        self._update_state(derived)
+        await self._broadcast(derived, suppress_origin=None)
+        log_event(
+            logger,
+            logging.INFO,
+            "hub.augment.src_to_view_resolved",
+            file=file,
+            line=line,
+            instance_path=instance_path,
+        )
 
     def _update_state(self, env: Envelope) -> None:
         try:

--- a/tests/test_hub_resolver.py
+++ b/tests/test_hub_resolver.py
@@ -119,7 +119,9 @@ def test_from_dict_parses_minimal_payload(tmp_path: Path):
 
     u_ff = model.nodes_by_path["counter.u_ff"]
     assert u_ff.port_connections == (("clk", "clk"), ("q", "q"))
-    assert u_ff.location == SourceAnchor(file="/abs/rtl/counter.sv", line=10, col=16)
+    assert u_ff.location == SourceAnchor(
+        file="/abs/rtl/counter.sv", line=10, col=16, end_line=10, end_col=39
+    )
 
 
 def test_from_dict_rejects_unsupported_schema_major():
@@ -244,7 +246,9 @@ def test_view_to_src_returns_anchor(tmp_path: Path):
         view_json_path=_write_view_json(tmp_path), tb_prefix="tb.dut."
     )
     anchor = resolver.view_to_src("counter.u_ff")
-    assert anchor == SourceAnchor(file="/abs/rtl/counter.sv", line=10, col=16)
+    assert anchor == SourceAnchor(
+        file="/abs/rtl/counter.sv", line=10, col=16, end_line=10, end_col=39
+    )
 
 
 def test_view_to_src_missing_path_returns_none(tmp_path: Path):
@@ -257,6 +261,139 @@ def test_view_to_src_missing_path_returns_none(tmp_path: Path):
 def test_view_to_src_returns_none_without_view_json(tmp_path: Path):
     resolver = resolver_from_paths(view_json_path=None)
     assert resolver.view_to_src("counter.u_ff") is None
+
+
+# ---------------------------------------------------------------------------
+# canonical view-json-v1 schema (top + id + source) parsing
+# ---------------------------------------------------------------------------
+
+
+def _canonical_view_json() -> dict:
+    """Matches rtl-buddy-view's documented schema (view-json-v1.md):
+    flat ``top``, per-node ``id`` + ``source`` with start+end positions,
+    ``ports`` (not legacy ``port_connections``), ``{from, to}`` edges.
+    """
+    return {
+        "schema_version": "1.0",
+        "tool": {"name": "rtl-buddy-view", "version": "0.1.0"},
+        "top": "counter",
+        "nodes": [
+            {
+                "id": "counter",
+                "module": "counter",
+                "source": {
+                    "file": "/abs/rtl/counter.sv",
+                    "start_line": 5,
+                    "start_column": 1,
+                    "end_line": 50,
+                    "end_column": 10,
+                },
+                "ports": [],
+            },
+            {
+                "id": "counter.u_ff",
+                "module": "counter_ff",
+                "source": {
+                    "file": "/abs/rtl/counter.sv",
+                    "start_line": 20,
+                    "start_column": 16,
+                    "end_line": 25,
+                    "end_column": 4,
+                },
+                "ports": [
+                    {"name": "clk", "expr": "clk"},
+                    {"name": "q", "expr": "q"},
+                ],
+            },
+        ],
+        "edges": [{"from": "counter", "to": "counter.u_ff"}],
+    }
+
+
+def test_from_dict_parses_canonical_schema():
+    """The schema rtl-buddy-view actually emits — `top`, `id`, `source`,
+    `ports`, `{from, to}` edges. The legacy fixture covered the other
+    branch."""
+
+    model = ViewModel.from_dict(_canonical_view_json())
+    assert model.top == "counter"
+    assert set(model.nodes_by_path) == {"counter", "counter.u_ff"}
+    u_ff = model.nodes_by_path["counter.u_ff"]
+    assert u_ff.location == SourceAnchor(
+        file="/abs/rtl/counter.sv", line=20, col=16, end_line=25, end_col=4
+    )
+    assert u_ff.port_connections == (("clk", "clk"), ("q", "q"))
+    assert model.edges_parent_to_children["counter"] == ("counter.u_ff",)
+
+
+# ---------------------------------------------------------------------------
+# src → view  (cursor file/line/col → instance path)
+# ---------------------------------------------------------------------------
+
+
+def _write_canonical(tmp_path: Path) -> Path:
+    out = tmp_path / "view.json"
+    out.write_text(json.dumps(_canonical_view_json()))
+    return out
+
+
+def test_src_to_view_returns_containing_instance(tmp_path: Path):
+    resolver = resolver_from_paths(view_json_path=_write_canonical(tmp_path))
+    # Line 22 falls inside u_ff's [20, 25] range AND counter's [5, 50]
+    # range. Both qualify; the smaller (u_ff) wins on the size tiebreak.
+    matches = resolver.src_to_view(file="/abs/rtl/counter.sv", line=22)
+    assert matches == ("counter.u_ff", "counter")
+
+
+def test_src_to_view_returns_outer_instance_when_only_outer_matches(
+    tmp_path: Path,
+):
+    resolver = resolver_from_paths(view_json_path=_write_canonical(tmp_path))
+    # Line 7 is inside counter's [5, 50] but outside u_ff's [20, 25].
+    matches = resolver.src_to_view(file="/abs/rtl/counter.sv", line=7)
+    assert matches == ("counter",)
+
+
+def test_src_to_view_empty_when_line_outside_all_ranges(tmp_path: Path):
+    resolver = resolver_from_paths(view_json_path=_write_canonical(tmp_path))
+    # Line 999 is past every node's end_line.
+    assert resolver.src_to_view(file="/abs/rtl/counter.sv", line=999) == ()
+
+
+def test_src_to_view_empty_when_file_does_not_match(tmp_path: Path):
+    resolver = resolver_from_paths(view_json_path=_write_canonical(tmp_path))
+    assert resolver.src_to_view(file="/abs/rtl/other.sv", line=22) == ()
+
+
+def test_src_to_view_normalises_path(tmp_path: Path):
+    # The cursor's file is an absolute path; view.json's `source.file`
+    # was emitted as a relative path. Resolver normalises both via
+    # Path.resolve() so they compare equal.
+    rel = tmp_path / "rtl"
+    rel.mkdir()
+    (rel / "counter.sv").write_text("// content")
+    payload = _canonical_view_json()
+    payload["nodes"][1]["source"]["file"] = "rtl/counter.sv"
+
+    cwd_path = tmp_path / "view.json"
+    cwd_path.write_text(json.dumps(payload))
+
+    import os
+
+    prev = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        resolver = resolver_from_paths(view_json_path=cwd_path)
+        absolute = str(rel / "counter.sv")
+        matches = resolver.src_to_view(file=absolute, line=22)
+    finally:
+        os.chdir(prev)
+    assert "counter.u_ff" in matches
+
+
+def test_src_to_view_empty_without_view_json():
+    resolver = resolver_from_paths(view_json_path=None)
+    assert resolver.src_to_view(file="/abs/rtl/x.sv", line=1) == ()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_hub_server.py
+++ b/tests/test_hub_server.py
@@ -242,6 +242,178 @@ async def test_state_event_broadcast_skips_origin(server: HubServer):
         await src.close()
 
 
+async def test_source_focused_derives_selection_changed_via_resolver(
+    tmp_path,
+):
+    """When a `src` peer sends source_focused and the resolver has a
+    view.json that contains an instance whose source range covers the
+    point, the hub augments by broadcasting a derived selection_changed
+    with origin=cli. The SPA already handles selection_changed — this
+    bridge is what makes `:RtlBuddyShow` light up the schematic without
+    a SPA-side protocol change.
+    """
+
+    import json
+    from rtl_buddy.hub.config import HubMappingConfig
+    from rtl_buddy.hub.resolver import Resolver
+
+    view_json = tmp_path / "view.json"
+    view_json.write_text(
+        json.dumps(
+            {
+                "schema_version": "1.0",
+                "top": "counter",
+                "nodes": [
+                    {
+                        "id": "counter",
+                        "source": {
+                            "file": "/abs/rtl/counter.sv",
+                            "start_line": 5,
+                            "start_column": 1,
+                            "end_line": 50,
+                            "end_column": 10,
+                        },
+                    },
+                    {
+                        "id": "counter.u_ff",
+                        "source": {
+                            "file": "/abs/rtl/counter.sv",
+                            "start_line": 20,
+                            "start_column": 16,
+                            "end_line": 25,
+                            "end_column": 4,
+                        },
+                    },
+                ],
+                "edges": [{"from": "counter", "to": "counter.u_ff"}],
+            }
+        )
+    )
+
+    resolver = Resolver(view_json_path=view_json, mapping=HubMappingConfig())
+    s = HubServer(
+        host="127.0.0.1", port=0, server_version="0.0.0+test", resolver=resolver
+    )
+    await s.start()
+    task = asyncio.create_task(s.serve_forever())
+    try:
+        view = await MockClient.connect(s.host, s.port)
+        src = await MockClient.connect(s.host, s.port)
+        try:
+            await view.hello(Origin.VIEW)
+            await src.hello(Origin.SRC)
+
+            evt = Envelope(
+                origin=Origin.SRC,
+                kind=Kind.EVENT,
+                type="source_focused",
+                id=new_id(),
+                payload={"file": "/abs/rtl/counter.sv", "line": 22, "col": 1},
+            )
+            await src.send(evt)
+
+            # View receives both the raw source_focused and the
+            # derived selection_changed. Order: source_focused first
+            # (broadcast in the STATE_EVENT_TYPES path), then the
+            # augmentation. Use recv_until to skip past peer_joined.
+            raw = await view.recv_until("source_focused")
+            assert raw.payload == {
+                "file": "/abs/rtl/counter.sv",
+                "line": 22,
+                "col": 1,
+            }
+
+            derived = await view.recv_until("selection_changed")
+            assert derived.origin is Origin.CLI
+            # u_ff's [20, 25] range encloses line 22 and is smaller
+            # than counter's [5, 50]; smallest-range-first ordering
+            # means the resolver returns u_ff first.
+            assert derived.payload == {"instance_path": ["counter.u_ff", "counter"]}
+        finally:
+            await view.close()
+            await src.close()
+    finally:
+        await s.shutdown()
+        task.cancel()
+        try:
+            await task
+        except (asyncio.CancelledError, Exception):
+            pass
+
+
+async def test_source_focused_with_no_match_does_not_broadcast_selection(
+    tmp_path,
+):
+    """If the resolver returns no matches, the augmentation is silent —
+    the raw source_focused is still broadcast (downstream may have its
+    own use for it), but no spurious selection_changed is emitted.
+    """
+
+    import json
+    from rtl_buddy.hub.config import HubMappingConfig
+    from rtl_buddy.hub.resolver import Resolver
+
+    view_json = tmp_path / "view.json"
+    view_json.write_text(
+        json.dumps(
+            {
+                "schema_version": "1.0",
+                "top": "counter",
+                "nodes": [
+                    {
+                        "id": "counter",
+                        "source": {
+                            "file": "/abs/rtl/counter.sv",
+                            "start_line": 5,
+                            "start_column": 1,
+                            "end_line": 10,
+                            "end_column": 10,
+                        },
+                    }
+                ],
+                "edges": [],
+            }
+        )
+    )
+
+    resolver = Resolver(view_json_path=view_json, mapping=HubMappingConfig())
+    s = HubServer(
+        host="127.0.0.1", port=0, server_version="0.0.0+test", resolver=resolver
+    )
+    await s.start()
+    task = asyncio.create_task(s.serve_forever())
+    try:
+        view = await MockClient.connect(s.host, s.port)
+        src = await MockClient.connect(s.host, s.port)
+        try:
+            await view.hello(Origin.VIEW)
+            await src.hello(Origin.SRC)
+
+            evt = Envelope(
+                origin=Origin.SRC,
+                kind=Kind.EVENT,
+                type="source_focused",
+                id=new_id(),
+                payload={"file": "/abs/rtl/other.sv", "line": 1, "col": 1},
+            )
+            await src.send(evt)
+
+            raw = await view.recv_until("source_focused")
+            assert raw.id == evt.id
+            # No derived selection_changed should follow.
+            await view.expect_no_message()
+        finally:
+            await view.close()
+            await src.close()
+    finally:
+        await s.shutdown()
+        task.cancel()
+        try:
+            await task
+        except (asyncio.CancelledError, Exception):
+            pass
+
+
 async def test_peer_joined_broadcast_to_existing_peers(server: HubServer):
     """When a new peer hellos, every already-registered peer receives a
     ``peer_joined`` event carrying the joining peer's origin. The


### PR DESCRIPTION
## Summary

Closes the long-standing **`:RtlBuddyShow` has no effect** gap. The user types `:RtlBuddyShow` in nvim, the hub receives `source_focused {file, line, col}`, and… nothing happens in the schematic. Two underlying causes addressed in one PR because they're inseparable: the resolver couldn't parse real view.json at all, AND the hub didn't translate source_focused into anything the SPA can act on.

## Root causes

**1. Resolver couldn't parse real view.json**

`rtl-buddy-view`'s [view-json-v1 schema](https://github.com/rtl-buddy/rtl-buddy-view/blob/main/docs/view-json-v1.md) emits:

| Field | rtl-buddy-view emits | Resolver was reading |
|---|---|---|
| Top module | `top` (flat) | `design.top` |
| Node ID | `id` | `instance_path` |
| Source location | `source` (with `start_line`/`end_line`/`end_column`) | `location` (with `line`/`col` only) |
| Ports | `ports[].{name, expr}` | `port_connections[].{port_name, net_expr_text}` |
| Edges | `{from, to}` | `{parent, child}` |

The resolver had hand-rolled test fixtures matching its (wrong) expectations, so unit tests were green while production silently no-op'd: `view_json_invalid: missing design.top` on every real load. This PR makes `ViewModel.from_dict` accept both schemas — canonical wins when present, legacy is the fallback so existing fixtures still pass.

**2. Hub didn't bridge source_focused → SPA selection**

nvim's `:RtlBuddyShow` broadcasts `source_focused`. The SPA's `useHub.applyEnvelope` has no case for it (falls through to the silent default). Now the hub itself does the translation in `_handle_event`: after the normal broadcast, call `Resolver.src_to_view(file, line, col)` and emit a derived `selection_changed { instance_path: [...] }` with `origin: "cli"`. The SPA already handles `selection_changed` and pans/selects the matching instance — zero protocol changes needed on the SPA side.

## Changes

- **`src/rtl_buddy/hub/resolver.py`**
  - `SourceAnchor` gains `end_line` / `end_col` plus `.contains(line, col)` and `.range_size()` helpers
  - `_location_to_anchor` reads both schemas
  - `ViewModel.from_dict` reads both schemas
  - New `Resolver.src_to_view(*, file, line, col)` — returns instance paths whose source range contains the point, smallest-range first
  - Path normalisation (`Path.resolve()`) so a relative `source.file` in view.json matches an absolute path from the editor
- **`src/rtl_buddy/hub/server.py`**
  - New `_augment_source_focused` called after the normal broadcast for `type == source_focused`
  - Broadcasts a derived `selection_changed` with `origin: "cli"` and `instance_path` = single string for one match, list for multiple
  - Resolver errors are caught and logged; never aborts the dispatch loop
- **`docs/concepts/hub.md`** — describes the augmentation behaviour
- **`tests/test_hub_resolver.py`** — new `_canonical_view_json` fixture matching the real schema, six new tests for `src_to_view` (happy path, outer-only match, no-match, file mismatch, path normalisation, no-view-json)
- **`tests/test_hub_server.py`** — two new integration tests asserting the augmentation fires (and is silent when the resolver returns no matches)

## Live verification

Against the running demo-tiny-npu hub, sent `source_focused {file: ip_demo_tiny_npu.sv, line: 379, col: 3}`:

```
[wave] got: origin=cli type=selection_changed payload={'instance_path': ['ip_demo_tiny_npu.u_dma_rd_cmd_cdc', 'ip_demo_tiny_npu']}
```

Smallest-range first → SPA picks index 0 (`u_dma_rd_cmd_cdc`, the `ip_cdc_handshake` instantiation), which is exactly the instance the user is clicking on.

## Test plan

- [x] `uv run pytest tests/test_hub_resolver.py` — 32 pass (legacy + canonical + new src_to_view cases)
- [x] `uv run pytest tests/test_hub_server.py` — 24 pass (existing + two new augmentation cases)
- [x] `uv run pytest tests/ -k hub` — 185 pass / 2 skipped (one unrelated wave-bridge teardown flake, passes in isolation)
- [x] `uv run ruff check && uv run ruff format --check` — clean
- [x] Live: source_focused → derived selection_changed observed on the wire

## Column-matching UX choice

Strict column checks would reject the common "cursor at column 1 on the instantiation line" case — editors park the cursor at indentation while the actual `ip_cdc_handshake` keyword sits much further right (column 56 in the live example). So the `contains` method uses line-only matching for multi-line ranges and falls back to column checks only for single-line ranges (where two instantiations on the same line might otherwise both match every cursor position). The smallest-range-first tiebreak handles the nested-instances case for free.

## Out of scope

- A SPA-side `case 'source_focused'` handler for additional behaviour (e.g. a sidebar breadcrumb showing the source file). The current PR's derived `selection_changed` is the user-visible effect; a richer SPA handler is a follow-up.
- `signal_selected` → derived `selection_changed` (the docs hinted at this for wave clicks → schematic; separate concern, same machinery once we wire the wave-side resolver).

🤖 Generated with [Claude Code](https://claude.com/claude-code)