### PR TITLE
Clarify agent command scope and log locations

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -58,6 +58,14 @@ In machine mode:
 
 This makes it reliable to parse outcomes from `rtl_buddy.log` without screen-scraping.
 
+## Working directory rules
+
+Use the command from the directory that matches its scope:
+
+- Run single-suite commands such as `test`, `randtest`, `wave`, and `fpv` from the suite directory that contains the relevant `tests.yaml` or `fpv.yaml`.
+- Run project-wide commands such as `regression`, `synth-regression`, `cdc-regression`, `fpv-regression`, `spec ...`, and `docs ...` from the project root unless you are intentionally narrowing scope.
+- Multi-suite commands change into each suite as they execute, so their `rtl_buddy.log` and `artefacts/` outputs are written per suite, not only in the repo-root directory where you launched the command.
+
 ## Log file locations
 
 | File | Description |
@@ -73,7 +81,7 @@ This makes it reliable to parse outcomes from `rtl_buddy.log` without screen-scr
 | `test.err` | Symlink to the most recent test's stderr |
 | `test.randseed` | Symlink to the most recent test's seed |
 
-All files are written relative to the suite directory where `rtl_buddy` is invoked.
+For single-suite commands, these files are written relative to the suite directory where you ran `rtl_buddy`. For multi-suite commands such as `regression`, each suite gets its own `rtl_buddy.log`, `artefacts/`, and latest-run symlinks inside that suite directory even though the command was launched from the project root.
 
 ## Machine mode log format
 


### PR DESCRIPTION
## Summary

- add a working-directory rules section to `docs/agents.md`
- clarify that multi-suite commands write `rtl_buddy.log` and `artefacts/` per suite rather than only at the repo root
- tighten the log-location guidance so agent workflows can find outputs reliably

## Why

The current agent docs explain machine mode well, but they leave a fuzzy edge around where commands should be run and where logs appear for multi-suite workflows. That ambiguity is small for humans and surprisingly annoying for automation, especially when a regression was launched from the project root but the actionable logs live under each suite.

## Validation

- reviewed against `.claude/skills/audit-docs/SKILL.md`
- connector-only docs change; no runtime checks performed in this environment

Signed off by: RTL Buddy Automated Checker