### PR TITLE
feat(hub): support hello.takeover so a new view tab can evict an old one

### DIFF
--- a/src/rtl_buddy/hub/schema/hub-protocol-v1.json
+++ b/src/rtl_buddy/hub/schema/hub-protocol-v1.json
@@ -357,7 +357,8 @@
             "properties": {
               "client": { "enum": ["view", "wave", "src", "cli"] },
               "version": { "type": "string", "minLength": 1, "description": "Semver of the client implementation." },
-              "capabilities": { "type": "array", "items": { "type": "string", "minLength": 1 }, "uniqueItems": true }
+              "capabilities": { "type": "array", "items": { "type": "string", "minLength": 1 }, "uniqueItems": true },
+              "takeover": { "type": "boolean", "description": "When true, instructs the hub to disconnect any existing registration for the same client slot before accepting this hello. Used by browser tabs that find an older tab already attached: the new tab requests takeover, the old tab gets bye-broadcast and its socket closed. Optional; default false." }
             }
           }
         }
@@ -463,8 +464,8 @@
             "additionalProperties": false,
             "properties": {
               "code": {
-                "enum": ["unresolvable", "not_connected", "bad_request", "protocol_mismatch"],
-                "description": "`timeout` is a client-side-only code and is never sent on the wire."
+                "enum": ["unresolvable", "not_connected", "bad_request", "protocol_mismatch", "superseded"],
+                "description": "`timeout` is a client-side-only code and is never sent on the wire. `superseded` is sent by the hub to a client whose origin slot was just taken over by a newer hello (see hello.payload.takeover)."
               },
               "message": { "type": "string", "minLength": 1 },
               "context": { "type": "object", "description": "Arbitrary structured context for the error; e.g. the offending input." }

--- a/src/rtl_buddy/hub/server.py
+++ b/src/rtl_buddy/hub/server.py
@@ -344,17 +344,52 @@ class HubServer:
             return False
 
         client = Origin(env.payload["client"])
+        takeover = bool(env.payload.get("takeover", False))
         if client in self._registry:
-            await self._safe_send(
-                conn,
-                make_error(
-                    origin=Origin.CLI,
-                    code="not_connected",
-                    message=f"{client.value} client already registered",
-                    in_reply_to=env.id,
-                ),
+            if not takeover:
+                await self._safe_send(
+                    conn,
+                    make_error(
+                        origin=Origin.CLI,
+                        code="not_connected",
+                        message=f"{client.value} client already registered",
+                        in_reply_to=env.id,
+                    ),
+                )
+                return False
+            # Takeover path: the incoming hello asked to replace any
+            # existing registration for this client slot (e.g. a fresh
+            # browser tab supersedes a stale one). Bye-broadcast the
+            # outgoing peer to everyone else so listeners refresh
+            # their peer indicators, close its socket, and drop it
+            # from the registry before the new connection registers.
+            existing = self._registry.pop(client)
+            self.state.registered_clients = set(self._registry.keys())
+            log_event(
+                logger,
+                logging.INFO,
+                "hub.client.superseded",
+                origin=client.value,
+                old_peer=existing.peer,
+                new_peer=conn.peer,
             )
-            return False
+            await self._broadcast(
+                self._bye_envelope(origin=client), suppress_origin=None
+            )
+            try:
+                await self._safe_send(
+                    existing,
+                    make_error(
+                        origin=Origin.CLI,
+                        code="superseded",
+                        message=(
+                            f"{client.value} client replaced by a newer registration"
+                        ),
+                    ),
+                )
+            except Exception:
+                pass
+            existing.close()
 
         conn.origin = client
         conn.capabilities = tuple(env.payload.get("capabilities", []))

--- a/tests/test_hub_server.py
+++ b/tests/test_hub_server.py
@@ -97,18 +97,26 @@ class MockClient:
             pytest.fail(f"expected no message but got: {line!r}")
 
     async def hello(
-        self, origin: Origin, *, version: str = "0.1.0", caps: list[str] | None = None
+        self,
+        origin: Origin,
+        *,
+        version: str = "0.1.0",
+        caps: list[str] | None = None,
+        takeover: bool = False,
     ) -> Envelope:
+        payload: dict = {
+            "client": origin.value,
+            "version": version,
+            "capabilities": caps or [],
+        }
+        if takeover:
+            payload["takeover"] = True
         hello = Envelope(
             origin=origin,
             kind=Kind.REQUEST,
             type="hello",
             id=new_id(),
-            payload={
-                "client": origin.value,
-                "version": version,
-                "capabilities": caps or [],
-            },
+            payload=payload,
         )
         await self.send(hello)
         return await self.recv()
@@ -184,6 +192,62 @@ async def test_duplicate_origin_refused(server: HubServer):
     finally:
         await a.close()
         await b.close()
+
+
+async def test_takeover_kicks_existing_registration(server: HubServer):
+    """A second client may take over an in-use origin slot by
+    setting ``payload.takeover=true`` on its hello. The old
+    registration is replaced: its socket gets an ``error`` envelope
+    with code ``superseded`` and is closed; remaining peers receive
+    a ``bye`` for the displaced origin; the new client gets the
+    usual welcome.
+    """
+    src = await MockClient.connect(server.host, server.port)
+    old_view = await MockClient.connect(server.host, server.port)
+    new_view = await MockClient.connect(server.host, server.port)
+    try:
+        # Register a sibling so we can observe the bye broadcast.
+        await src.hello(Origin.SRC)
+        await old_view.hello(Origin.VIEW)
+        # Drain the peer_joined event src received when view joined.
+        await src.recv_until("peer_joined")
+
+        welcome = await new_view.hello(Origin.VIEW, takeover=True)
+        assert welcome.type == "welcome", (
+            f"takeover hello should be welcomed, got {welcome}"
+        )
+
+        # Old view receives the superseded error.
+        kick = await old_view.recv()
+        assert kick.type == "error"
+        assert kick.payload["code"] == "superseded"
+        # And its socket closes shortly after — readline returns
+        # ``b""`` once the peer FIN'd.
+        trailing = await asyncio.wait_for(old_view.reader.readline(), timeout=1.0)
+        assert trailing == b"", f"expected EOF, got {trailing!r}"
+
+        # Sibling sees bye(view) and then peer_joined(view) for the
+        # new registration.
+        bye = await src.recv_until("bye")
+        assert bye.origin is Origin.VIEW
+    finally:
+        await src.close()
+        await old_view.close()
+        await new_view.close()
+
+
+async def test_takeover_without_existing_registration_is_a_normal_hello(
+    server: HubServer,
+):
+    """``takeover=true`` is harmless when the slot is empty —
+    behaves like a regular hello, no spurious bye broadcast.
+    """
+    client = await MockClient.connect(server.host, server.port)
+    try:
+        welcome = await client.hello(Origin.VIEW, takeover=True)
+        assert welcome.type == "welcome"
+    finally:
+        await client.close()
 
 
 async def test_bad_request_on_malformed_handshake(server: HubServer):


### PR DESCRIPTION
## Summary

Adds an opt-in takeover branch to the hub's hello handler so a fresh SPA tab can gracefully replace a stale one instead of getting stuck in reconnect loops.

When the second tab's hello carries \`payload.takeover=true\`, the hub:

1. Pops the existing registration from the slot.
2. Broadcasts \`bye(origin=view)\` to the remaining peers so their peer indicators refresh.
3. Sends the displaced client an \`error\` envelope with the new \`superseded\` code.
4. Closes the displaced socket.
5. Welcomes the new client normally.

Without \`takeover\`, behaviour is unchanged — \`not_connected\` error, no slot mutation — so the polite single-tab path still works.

## Wire-side changes (schemas/hub-protocol-v1.json)

- \`hello.payload.takeover\` boolean, optional, default false.
- \`error.code\` enum gains \`superseded\`.

## Tests

- \`test_takeover_kicks_existing_registration\` — sibling sees the bye, displaced view sees \`superseded\` + EOF, new view gets welcome.
- \`test_takeover_without_existing_registration_is_a_normal_hello\` — slot-empty no-op path so the flag is safe to set unconditionally.
- Existing \`test_duplicate_origin_refused\` unchanged (covers the no-takeover path).
- All 614 tests pass.

## Cross-repo

Pairs with [rtl-buddy-view#…](https://github.com/rtl-buddy/rtl-buddy-view/pulls?q=takeover) which adds the SPA-side retry-with-takeover handshake + the "Superseded — another tab took over [Take back]" banner. Either side can ship first since the SPA only sets the flag on retry; old hubs reject the new field as additional-property and the SPA falls through to its existing reconnect loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)