### PR TITLE
feat(model): axi_bundles + axi_monitor_out optional fields in ModelConfig

### DIFF
--- a/src/rtl_buddy/config/model.py
+++ b/src/rtl_buddy/config/model.py
@@ -1,6 +1,7 @@
 import logging
 
 logger = logging.getLogger(__name__)
+import os
 import pprint
 
 from serde import serde, field
@@ -21,6 +22,14 @@ class ModelConfig:
       desc (str|None): Human-readable model description.
       filelist (list[str]): List of paths to files associated with the model.
       spec (str|None): Relative path from models.yaml to the block's specs.yaml.
+      axi_bundles (str|None): Relative path from models.yaml to the
+        block's ``axi-bundles.yaml`` manifest, when AXI profiling is
+        configured for this model. Consumed by ``rb axi-profile``.
+      axi_monitor_out (str|None): Relative path from models.yaml to
+        where ``rb axi-profile gen-monitor`` should write the generated
+        SystemVerilog monitor file. Typically points into the verif
+        testbench source tree so the file is picked up by the tb's
+        filelist (e.g. ``../verif/soc_top/gen/axi_perf_mon.sv``).
       path (str|None): Path to the model config file. Will usually be set by the loader.
     """
 
@@ -28,7 +37,40 @@ class ModelConfig:
     filelist: list[str]
     desc: str | None = None
     spec: str | None = None
+    axi_bundles: str | None = None
+    axi_monitor_out: str | None = None
     path: str | None = None
+
+    def _resolve_relative(self, rel: str) -> str:
+        """Resolve ``rel`` against the directory containing models.yaml.
+
+        Absolute paths pass through unchanged. Relative paths are
+        anchored at ``dirname(self.path)`` when ``self.path`` is set
+        (the loader normally sets it); otherwise the cwd is used.
+        """
+        if os.path.isabs(rel):
+            return rel
+        base = os.path.dirname(os.path.abspath(self.path)) if self.path else os.getcwd()
+        return os.path.normpath(os.path.join(base, rel))
+
+    def get_axi_bundles_path(self) -> str | None:
+        """Absolute path to the model's ``axi-bundles.yaml`` (or None).
+
+        Does not check that the file exists — callers should error
+        with a hint to run ``rb axi-profile discover`` when missing.
+        """
+        if self.axi_bundles is None:
+            return None
+        return self._resolve_relative(self.axi_bundles)
+
+    def get_axi_monitor_out_path(self) -> str | None:
+        """Absolute path where ``gen-monitor`` should write the SV file (or None).
+
+        Parent directory may not exist yet at load time.
+        """
+        if self.axi_monitor_out is None:
+            return None
+        return self._resolve_relative(self.axi_monitor_out)
 
     def get_model_name(self):
         """

--- a/tests/test_config_loaders.py
+++ b/tests/test_config_loaders.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 from serde.yaml import from_yaml
 
+from rtl_buddy.config.model import ModelConfig, ModelConfigLoader
 from rtl_buddy.config.reg import RegConfig
 from rtl_buddy.config.rtl import RtlBuilderConfig
 from rtl_buddy.config.root import (
@@ -380,3 +381,122 @@ def test_discover_rtl_builder_names_raises_without_root_config(tmp_path, monkeyp
     # If we picked up a real root_config.yaml from above tmp_path, accept that
     # too — just confirm the contract holds.
     assert isinstance(names, list)
+
+
+# ---------------------------------------------------------------------------
+# ModelConfig — axi_bundles + axi_monitor_out
+# ---------------------------------------------------------------------------
+
+
+def test_model_config_axi_fields_default_none():
+    """Bare ModelConfig has no AXI fields set (back-compat)."""
+    model = ModelConfig(name="soc", filelist=["src/soc.sv"])
+    assert model.axi_bundles is None
+    assert model.axi_monitor_out is None
+    assert model.get_axi_bundles_path() is None
+    assert model.get_axi_monitor_out_path() is None
+
+
+def test_model_config_axi_bundles_resolves_relative_to_models_yaml(tmp_path):
+    """axi_bundles relative path resolves against the models.yaml directory."""
+    models_yaml = tmp_path / "design" / "soc" / "models.yaml"
+    models_yaml.parent.mkdir(parents=True)
+
+    model = ModelConfig(
+        name="soc",
+        filelist=["src/soc.sv"],
+        axi_bundles="src/axi-bundles.yaml",
+        path=str(models_yaml),
+    )
+    resolved = model.get_axi_bundles_path()
+    assert resolved == str(tmp_path / "design" / "soc" / "src" / "axi-bundles.yaml")
+
+
+def test_model_config_axi_monitor_out_resolves_relative(tmp_path):
+    """axi_monitor_out relative path resolves against the models.yaml directory.
+
+    Typical usage: monitor SV lives in the verif testbench tree, sibling
+    to the design tree.
+    """
+    models_yaml = tmp_path / "design" / "soc" / "models.yaml"
+    models_yaml.parent.mkdir(parents=True)
+
+    model = ModelConfig(
+        name="soc",
+        filelist=["src/soc.sv"],
+        axi_monitor_out="../../verif/soc_top/gen/axi_perf_mon.sv",
+        path=str(models_yaml),
+    )
+    resolved = model.get_axi_monitor_out_path()
+    assert resolved == str(tmp_path / "verif" / "soc_top" / "gen" / "axi_perf_mon.sv")
+
+
+def test_model_config_axi_paths_pass_absolute_through(tmp_path):
+    abs_bundles = tmp_path / "elsewhere" / "axi-bundles.yaml"
+    abs_monitor = tmp_path / "verif" / "axi_perf_mon.sv"
+    model = ModelConfig(
+        name="soc",
+        filelist=["src/soc.sv"],
+        axi_bundles=str(abs_bundles),
+        axi_monitor_out=str(abs_monitor),
+        path=str(tmp_path / "design" / "models.yaml"),
+    )
+    assert model.get_axi_bundles_path() == str(abs_bundles)
+    assert model.get_axi_monitor_out_path() == str(abs_monitor)
+
+
+def test_model_config_axi_paths_resolved_against_cwd_when_path_unset(
+    tmp_path, monkeypatch
+):
+    """When the loader hasn't set path yet, fall back to cwd.
+
+    In normal use the loader sets path; this just locks the fallback
+    so a bare ModelConfig in tests doesn't blow up on relative paths.
+    """
+    monkeypatch.chdir(tmp_path)
+    model = ModelConfig(
+        name="soc",
+        filelist=["src/soc.sv"],
+        axi_bundles="axi-bundles.yaml",
+    )
+    assert model.get_axi_bundles_path() == str(tmp_path / "axi-bundles.yaml")
+
+
+def test_model_config_loader_round_trips_axi_fields(tmp_path):
+    """models.yaml with the new fields round-trips through the loader.
+
+    The loader sets ``path`` so the helpers resolve relative paths
+    correctly without further wiring.
+    """
+    models_yaml = tmp_path / "design" / "models.yaml"
+    models_yaml.parent.mkdir()
+    models_yaml.write_text(
+        "rtl-buddy-filetype: model_config\n"
+        "models:\n"
+        "  - name: soc\n"
+        "    filelist:\n"
+        "      - src/soc.sv\n"
+        "    axi_bundles: src/soc/axi-bundles.yaml\n"
+        "    axi_monitor_out: ../verif/soc_top/gen/axi_perf_mon.sv\n"
+        "  - name: cpu\n"
+        "    filelist:\n"
+        "      - src/cpu.sv\n"
+    )
+
+    loader = ModelConfigLoader(str(models_yaml))
+
+    soc = loader.get_model("soc")
+    assert soc.axi_bundles == "src/soc/axi-bundles.yaml"
+    assert soc.axi_monitor_out == "../verif/soc_top/gen/axi_perf_mon.sv"
+    assert soc.get_axi_bundles_path() == str(
+        tmp_path / "design" / "src" / "soc" / "axi-bundles.yaml"
+    )
+    assert soc.get_axi_monitor_out_path() == str(
+        tmp_path / "verif" / "soc_top" / "gen" / "axi_perf_mon.sv"
+    )
+
+    cpu = loader.get_model("cpu")
+    assert cpu.axi_bundles is None
+    assert cpu.axi_monitor_out is None
+    assert cpu.get_axi_bundles_path() is None
+    assert cpu.get_axi_monitor_out_path() is None


### PR DESCRIPTION
## Summary

Adds two optional fields to `ModelConfig` (models.yaml) to support the locked `rb axi-profile` usage model (see #157 design comment):

```yaml
models:
  - name: soc
    filelist: src/soc.f
    axi_bundles: src/soc/axi-bundles.yaml             # checked-in manifest path
    axi_monitor_out: ../verif/soc_top/gen/axi_perf_mon.sv  # gen-monitor target
```

Plus two helper methods that return absolute paths, resolving relatives against the directory containing `models.yaml` (same convention `filelist` already uses).

Both fields are optional. Absent → the respective `rb axi-profile` subcommand will error out with a clear hint in the follow-up PR; no behaviour change yet.

Closes #161 | Part of #157

## Test plan
- [x] `uv run pytest tests/test_config_loaders.py` — 35/35 pass (6 new)
- [x] `uv run ruff check` clean
- [x] `uv run ruff format --check` clean
- [ ] CI lint + test workflows pass on the PR

## Follow-ups (stacked)
- #162 — restructure `rb axi-profile` into a subcommand group + `run <test>` codepath (will branch off this)
- #163 — `gen-monitor` subcommand wiring (stacks on top of #162)

🤖 Generated with [Claude Code](https://claude.com/claude-code)