### PR TITLE
feat(axi-profile): subcommand group + run <test> codepath

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -61,6 +61,7 @@ Usage: rtl-buddy [OPTIONS] COMMAND [ARGS]...
 │ cdc-regression     run CDC lint regression                                           │
 │ fpv                run formal property verification                                  │
 │ fpv-regression     run FPV regression                                                │
+│ axi-profile        profile AXI interconnect performance via rtl-buddy-axi-profiler   │
 │ hub                manage the rtl-buddy-hub daemon                                   │
 │ skill              manage the rtl_buddy agent skill                                  │
 │ docs               browse bundled documentation                                      │
@@ -208,6 +209,22 @@ Usage: rtl-buddy hier [OPTIONS] MODEL_NAME
 │ --tool                     TEXT  path to the rtl-buddy-view binary                   │
 │                                  [default: rtl-buddy-view]                           │
 │ --help                           Show this message and exit.                         │
+╰──────────────────────────────────────────────────────────────────────────────────────╯
+```
+
+## axi-profile
+
+```text
+Usage: rtl-buddy axi-profile [OPTIONS] COMMAND [ARGS]...                               
+                                                                                        
+ profile AXI interconnect performance via rtl-buddy-axi-profiler                        
+                                                                                        
+╭─ Options ────────────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                          │
+╰──────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────────────╮
+│ run       ingest a test's FST and emit per-test axi-perf.json                        │
+│ discover  parse RTL to (re)generate the model's axi-bundles.yaml manifest            │
 ╰──────────────────────────────────────────────────────────────────────────────────────╯
 ```
 

--- a/scripts/gen_cli_reference.py
+++ b/scripts/gen_cli_reference.py
@@ -17,6 +17,7 @@ SUBCOMMANDS = [
     "regression",
     "filelist",
     "hier",
+    "axi-profile",
     "verible",
     "wave",
     "wave-install-nvim",

--- a/src/rtl_buddy/config/model.py
+++ b/src/rtl_buddy/config/model.py
@@ -1,6 +1,7 @@
 import logging
 
 logger = logging.getLogger(__name__)
+import os
 import pprint
 
 from serde import serde, field
@@ -21,6 +22,14 @@ class ModelConfig:
       desc (str|None): Human-readable model description.
       filelist (list[str]): List of paths to files associated with the model.
       spec (str|None): Relative path from models.yaml to the block's specs.yaml.
+      axi_bundles (str|None): Relative path from models.yaml to the
+        block's ``axi-bundles.yaml`` manifest, when AXI profiling is
+        configured for this model. Consumed by ``rb axi-profile``.
+      axi_monitor_out (str|None): Relative path from models.yaml to
+        where ``rb axi-profile gen-monitor`` should write the generated
+        SystemVerilog monitor file. Typically points into the verif
+        testbench source tree so the file is picked up by the tb's
+        filelist (e.g. ``../verif/soc_top/gen/axi_perf_mon.sv``).
       path (str|None): Path to the model config file. Will usually be set by the loader.
     """
 
@@ -28,7 +37,40 @@ class ModelConfig:
     filelist: list[str]
     desc: str | None = None
     spec: str | None = None
+    axi_bundles: str | None = None
+    axi_monitor_out: str | None = None
     path: str | None = None
+
+    def _resolve_relative(self, rel: str) -> str:
+        """Resolve ``rel`` against the directory containing models.yaml.
+
+        Absolute paths pass through unchanged. Relative paths are
+        anchored at ``dirname(self.path)`` when ``self.path`` is set
+        (the loader normally sets it); otherwise the cwd is used.
+        """
+        if os.path.isabs(rel):
+            return rel
+        base = os.path.dirname(os.path.abspath(self.path)) if self.path else os.getcwd()
+        return os.path.normpath(os.path.join(base, rel))
+
+    def get_axi_bundles_path(self) -> str | None:
+        """Absolute path to the model's ``axi-bundles.yaml`` (or None).
+
+        Does not check that the file exists — callers should error
+        with a hint to run ``rb axi-profile discover`` when missing.
+        """
+        if self.axi_bundles is None:
+            return None
+        return self._resolve_relative(self.axi_bundles)
+
+    def get_axi_monitor_out_path(self) -> str | None:
+        """Absolute path where ``gen-monitor`` should write the SV file (or None).
+
+        Parent directory may not exist yet at load time.
+        """
+        if self.axi_monitor_out is None:
+            return None
+        return self._resolve_relative(self.axi_monitor_out)
 
     def get_model_name(self):
         """

--- a/src/rtl_buddy/rtl_buddy.py
+++ b/src/rtl_buddy/rtl_buddy.py
@@ -45,6 +45,10 @@ from .runner.synth_results import SynthSkipResults
 from .seed_mode import SeedMode
 from .hub.cli import app as hub_app
 from .skill_install import app as skill_app
+from .tools.axi_profile_rtl_buddy import (
+    RtlBuddyAxiProfileDiscover,
+    RtlBuddyAxiProfileRun,
+)
 from .tools.coverage import CoverageReporter
 from .tools.artifact_paths import test_artifact_dir
 from .tools.hier_rtl_buddy_view import RtlBuddyView
@@ -115,6 +119,10 @@ class RtlBuddy:
         self.spec_app = typer.Typer(
             help="spec traceability commands", no_args_is_help=True
         )
+        self.axi_profile_app = typer.Typer(
+            help=("profile AXI interconnect performance via rtl-buddy-axi-profiler"),
+            no_args_is_help=True,
+        )
         self.app.callback()(self.root_options)
         self.app.command("test", help="run a simple test")(self.do_cmd_test)
         self.app.command("randtest", help="repeat a test with multiple random seeds")(
@@ -128,6 +136,19 @@ class RtlBuddy:
         )
         self.app.command("hier", help="render module hierarchy via rtl-buddy-view")(
             self.do_cmd_hier
+        )
+        self.axi_profile_app.command(
+            "run",
+            help="ingest a test's FST and emit per-test axi-perf.json",
+        )(self.do_cmd_axi_profile_run)
+        self.axi_profile_app.command(
+            "discover",
+            help="parse RTL to (re)generate the model's axi-bundles.yaml manifest",
+        )(self.do_cmd_axi_profile_discover)
+        self.app.add_typer(
+            self.axi_profile_app,
+            name="axi-profile",
+            help=("profile AXI interconnect performance via rtl-buddy-axi-profiler"),
         )
         self.app.command("verible", help="run verible cmd")(self.do_verible)
         self.app.command("wave", help="open waveform viewer for a test")(
@@ -1179,6 +1200,126 @@ class RtlBuddy:
             executable=tool,
         )
         raise typer.Exit(view.run())
+
+    def do_cmd_axi_profile_discover(
+        self,
+        model_name: Annotated[str, typer.Argument(help="model from models.yaml")],
+        model_config: Annotated[
+            str, typer.Option("-c", "--model-config", help="models.yaml to use")
+        ] = "models.yaml",
+        output: Annotated[
+            str | None,
+            typer.Option(
+                "-o",
+                "--output",
+                help=(
+                    "output path for axi-bundles.yaml (default: the model's "
+                    "`axi_bundles:` from models.yaml when set, else "
+                    "artefacts/axi/<model>/axi-bundles.yaml)"
+                ),
+            ),
+        ] = None,
+        amend: Annotated[
+            str | None,
+            typer.Option(
+                "--amend",
+                help=(
+                    "existing axi-bundles.yaml to merge user edits from "
+                    "(deferred to a follow-up; warns if passed)"
+                ),
+            ),
+        ] = None,
+        tool: Annotated[
+            str,
+            typer.Option("--tool", help="path to the axi-profiler binary"),
+        ] = "axi-profiler",
+    ):
+        """
+        parse RTL to (re)generate the model's axi-bundles.yaml manifest
+        """
+        model_cfg = ModelConfigLoader(model_config).get_model(model_name)
+        log_event(
+            logger,
+            logging.INFO,
+            "command.axi_profile_discover",
+            command="axi-profile",
+            subcommand="discover",
+            model=model_name,
+            output=output,
+        )
+        profiler = RtlBuddyAxiProfileDiscover(
+            name=self.name + "/axi-profile/discover",
+            model_cfg=model_cfg,
+            suite_dir=os.getcwd(),
+            output=output,
+            amend=amend,
+            executable=tool,
+        )
+        raise typer.Exit(profiler.run())
+
+    def do_cmd_axi_profile_run(
+        self,
+        test_name: Annotated[str, typer.Argument(help="test from tests.yaml")],
+        test_config: Annotated[
+            str, typer.Option("-c", "--test-config", help="tests.yaml to use")
+        ] = "tests.yaml",
+        output: Annotated[
+            str | None,
+            typer.Option(
+                "-o",
+                "--output",
+                help=(
+                    "output path for axi-perf.json "
+                    "(default: artefacts/axi/<test>/axi-perf.json)"
+                ),
+            ),
+        ] = None,
+        tb_prefix: Annotated[
+            str | None,
+            typer.Option(
+                "--tb-prefix",
+                help=(
+                    "Override the testbench top scope name used as the "
+                    "hierarchical prefix in the FST. Default is the test's "
+                    "tb name from tests.yaml. Pass empty string to disable."
+                ),
+            ),
+        ] = None,
+        tool: Annotated[
+            str,
+            typer.Option("--tool", help="path to the axi-profiler binary"),
+        ] = "axi-profiler",
+    ):
+        """
+        ingest a test's FST and emit per-test axi-perf.json
+
+        Looks up `<test>` in tests.yaml, resolves the model, the
+        checked-in axi-bundles.yaml manifest (model.axi_bundles in
+        models.yaml), and the FST at artefacts/<test>/dump.fst, then
+        invokes axi-profiler run.
+        """
+        suite_cfg = SuiteConfig(test_config)
+        test_cfg = suite_cfg.get_tests(test_name)[0]
+        log_event(
+            logger,
+            logging.INFO,
+            "command.axi_profile_run",
+            command="axi-profile",
+            subcommand="run",
+            test=test_name,
+            model=test_cfg.get_model().name,
+            output=output,
+            tb_prefix=tb_prefix,
+        )
+        profiler = RtlBuddyAxiProfileRun(
+            name=self.name + "/axi-profile/run",
+            test_cfg=test_cfg,
+            suite_dir=os.path.dirname(os.path.abspath(test_config)),
+            output=output,
+            tb_prefix_override=tb_prefix,
+            executable=tool,
+        )
+        raise typer.Exit(profiler.run())
 
     def do_docs_list(self):
         pages = [page.to_list_item() for page in list_pages()]

--- a/src/rtl_buddy/tools/axi_profile_rtl_buddy.py
+++ b/src/rtl_buddy/tools/axi_profile_rtl_buddy.py
@@ -1,0 +1,319 @@
+"""rtl-buddy-axi-profiler tool wrappers.
+
+Drives the standalone ``axi-profiler`` CLI in subprocess-granularity
+mode: rtl_buddy is not coupled to the profiler's Python API, and a
+profiler release can be picked up via ``uv sync`` (or by re-installing
+the standalone binary) without code changes here.
+
+Two wrappers, one per ``rb axi-profile`` subcommand:
+
+* :class:`RtlBuddyAxiProfileDiscover` — ``rb axi-profile discover <model>``:
+  parses RTL via ``axi-profiler discover`` and writes
+  ``axi-bundles.yaml``. Output defaults to ``model.axi_bundles`` (the
+  checked-in manifest path) when set, falling back to
+  ``artefacts/axi/<model>/axi-bundles.yaml``.
+
+* :class:`RtlBuddyAxiProfileRun` — ``rb axi-profile run <test>``: ingests
+  a per-test FST and writes ``axi-perf.json``. Resolves the model
+  (from ``tests.yaml``), the checked-in manifest (from
+  ``models.yaml``'s ``axi_bundles``), the FST path
+  (``<suite_dir>/artefacts/<test>/dump.fst`` — same convention as
+  ``rb wave``), and the testbench top scope (from the test's
+  ``tb.name`` in ``tests.yaml``) without further user input. The
+  ``tb_prefix`` override lets the user replace the auto-extracted
+  value when the wrapping scope name diverges from the testbench
+  name (e.g. a custom Verilator wrapper).
+
+The ``gen-monitor`` subcommand wrapper lands separately (#163).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+from pathlib import Path
+
+from .vlog_filelist import VlogFilelist
+from ..config.model import ModelConfig
+from ..config.test import TestConfig
+from ..errors import FatalRtlBuddyError
+from ..logging_utils import log_event, task_status
+from ..process_utils import run_managed_process
+
+logger = logging.getLogger(__name__)
+
+
+def _require_axi_profiler(executable: str) -> None:
+    """Resolve ``executable`` to a runnable axi-profiler or raise."""
+    if os.sep in executable or (os.altsep and os.altsep in executable):
+        if not (os.path.isfile(executable) and os.access(executable, os.X_OK)):
+            raise FatalRtlBuddyError(
+                f"axi-profile: axi-profiler not found or not executable: {executable}"
+            )
+        return
+    if shutil.which(executable) is None:
+        raise FatalRtlBuddyError(
+            f"axi-profile: '{executable}' not found on PATH; "
+            f"install rtl-buddy-axi-profiler "
+            f"(e.g. `uv tool install rtl-buddy-axi-profiler`)."
+        )
+
+
+class RtlBuddyAxiProfileDiscover:
+    """Generates a filelist + invokes ``axi-profiler discover``.
+
+    Single-shot. Constructed per ``rb axi-profile discover`` invocation.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        model_cfg: ModelConfig,
+        *,
+        suite_dir: str,
+        output: str | None = None,
+        amend: str | None = None,
+        executable: str = "axi-profiler",
+    ):
+        self.name = name
+        self.model_cfg = model_cfg
+        self.output_override = output
+        self.amend = amend
+        self.executable = executable
+
+        artefact_root = Path(suite_dir) / "artefacts" / "axi" / model_cfg.name
+        artefact_root.mkdir(parents=True, exist_ok=True)
+        self.artefact_dir = str(artefact_root)
+
+    def _filelist_path(self) -> str:
+        return os.path.join(self.artefact_dir, "axi.f")
+
+    def _log_path(self) -> str:
+        return os.path.join(self.artefact_dir, "axi-profile-discover.log")
+
+    def _resolve_output_path(self) -> str:
+        if self.output_override:
+            return self.output_override
+        # Prefer the checked-in manifest path from models.yaml when set;
+        # otherwise drop the output under artefacts/ so discover stays
+        # usable for models that don't yet have the field configured.
+        configured = self.model_cfg.get_axi_bundles_path()
+        if configured:
+            os.makedirs(os.path.dirname(configured), exist_ok=True)
+            return configured
+        return os.path.join(self.artefact_dir, "axi-bundles.yaml")
+
+    def _write_filelist(self) -> str:
+        fl_path = self._filelist_path()
+        vlog_fl = VlogFilelist(
+            name=self.name + "/filelist",
+            model_cfg=self.model_cfg,
+            output_path=fl_path,
+        )
+        vlog_fl.write_output(
+            output_filepath=fl_path, unroll=True, strip=True, deduplicate=True
+        )
+        return fl_path
+
+    def _build_cmd(self, fl_path: str, out_path: str) -> list[str]:
+        cmd = [
+            self.executable,
+            "discover",
+            "--filelist",
+            fl_path,
+            "--top",
+            self.model_cfg.name,
+            "--output",
+            out_path,
+        ]
+        if self.amend:
+            cmd += ["--amend", self.amend]
+        return cmd
+
+    def run(self) -> int:
+        _require_axi_profiler(self.executable)
+
+        fl_path = self._write_filelist()
+        out_path = self._resolve_output_path()
+        cmd = self._build_cmd(fl_path, out_path)
+        log_event(
+            logger,
+            logging.INFO,
+            "axi_profile_discover.run",
+            model=self.model_cfg.name,
+            cmd=" ".join(cmd),
+            output=out_path,
+        )
+
+        log_path = self._log_path()
+        with task_status(f"axi-profile discover {self.model_cfg.name}"):
+            with open(log_path, "w") as log_f:
+                log_f.write("$ " + " ".join(cmd) + "\n")
+                log_f.flush()
+                proc = run_managed_process(cmd, stdout=None, stderr=log_f)
+
+        log_event(
+            logger,
+            logging.INFO,
+            "axi_profile_discover.done",
+            model=self.model_cfg.name,
+            output=out_path,
+            returncode=proc.returncode,
+        )
+        return proc.returncode
+
+
+class RtlBuddyAxiProfileRun:
+    """Per-test ingest + aggregate via ``axi-profiler run``.
+
+    Resolves model + manifest + FST + tb_prefix automatically from
+    ``tests.yaml`` / ``models.yaml`` / the standard artefact layout —
+    the user only types ``rb axi-profile run <test>``. Override hooks
+    exist for ``--output`` and ``--tb-prefix`` so unusual setups can
+    redirect without editing config files.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        test_cfg: TestConfig,
+        *,
+        suite_dir: str,
+        output: str | None = None,
+        tb_prefix_override: str | None = None,
+        executable: str = "axi-profiler",
+    ):
+        self.name = name
+        self.test_cfg = test_cfg
+        self.test_name = test_cfg.get_name()
+        self.model_cfg = test_cfg.get_model()
+        self.suite_dir = os.path.abspath(suite_dir)
+        self.output_override = output
+        self.tb_prefix_override = tb_prefix_override
+        self.executable = executable
+
+        artefact_root = Path(self.suite_dir) / "artefacts" / "axi" / self.test_name
+        artefact_root.mkdir(parents=True, exist_ok=True)
+        self.artefact_dir = str(artefact_root)
+
+    def _filelist_path(self) -> str:
+        return os.path.join(self.artefact_dir, "axi.f")
+
+    def _log_path(self) -> str:
+        return os.path.join(self.artefact_dir, "axi-profile-run.log")
+
+    def _default_output_path(self) -> str:
+        return os.path.join(self.artefact_dir, "axi-perf.json")
+
+    def _fst_path(self) -> str:
+        # Same convention as `rb wave`: artefacts/<test>/dump.fst.
+        return os.path.join(self.suite_dir, "artefacts", self.test_name, "dump.fst")
+
+    def _resolve_manifest_path(self) -> str:
+        manifest = self.model_cfg.get_axi_bundles_path()
+        if manifest is None:
+            raise FatalRtlBuddyError(
+                f"axi-profile run: model '{self.model_cfg.name}' has no "
+                "`axi_bundles:` in models.yaml. Add the field pointing at "
+                "the checked-in axi-bundles.yaml manifest, then run "
+                f"`rb axi-profile discover {self.model_cfg.name}` to "
+                "generate one if it doesn't exist."
+            )
+        if not os.path.isfile(manifest):
+            raise FatalRtlBuddyError(
+                f"axi-profile run: manifest not found at {manifest}. "
+                f"Run `rb axi-profile discover {self.model_cfg.name}` first."
+            )
+        return manifest
+
+    def _resolve_fst_path(self) -> str:
+        fst = self._fst_path()
+        if not os.path.isfile(fst):
+            raise FatalRtlBuddyError(
+                f"axi-profile run: FST not found at {fst}. "
+                f"Run `rb test {self.test_name}` first to produce it."
+            )
+        return fst
+
+    def _resolve_tb_prefix(self) -> str:
+        if self.tb_prefix_override is not None:
+            return self.tb_prefix_override
+        # Auto-extract: the testbench wraps the DUT, and Verilator names
+        # the top scope after the testbench module — which is what
+        # tests.yaml's `testbenches:` section names. Empty if the user
+        # explicitly opts out via --tb-prefix=''.
+        tb = self.test_cfg.get_testbench()
+        return tb.get_name() if tb is not None else ""
+
+    def _write_filelist(self) -> str:
+        fl_path = self._filelist_path()
+        vlog_fl = VlogFilelist(
+            name=self.name + "/filelist",
+            model_cfg=self.model_cfg,
+            output_path=fl_path,
+        )
+        vlog_fl.write_output(
+            output_filepath=fl_path, unroll=True, strip=True, deduplicate=True
+        )
+        return fl_path
+
+    def _build_cmd(
+        self, fl_path: str, manifest: str, fst: str, out_path: str, tb_prefix: str
+    ) -> list[str]:
+        cmd = [
+            self.executable,
+            "run",
+            "--filelist",
+            fl_path,
+            "--top",
+            self.model_cfg.name,
+            "--input",
+            fst,
+            "--manifest",
+            manifest,
+            "--output",
+            out_path,
+        ]
+        if tb_prefix:
+            cmd += ["--tb-prefix", tb_prefix]
+        return cmd
+
+    def run(self) -> int:
+        _require_axi_profiler(self.executable)
+
+        manifest = self._resolve_manifest_path()
+        fst = self._resolve_fst_path()
+        tb_prefix = self._resolve_tb_prefix()
+        out_path = self.output_override or self._default_output_path()
+
+        fl_path = self._write_filelist()
+        cmd = self._build_cmd(fl_path, manifest, fst, out_path, tb_prefix)
+
+        log_event(
+            logger,
+            logging.INFO,
+            "axi_profile_run.start",
+            test=self.test_name,
+            model=self.model_cfg.name,
+            cmd=" ".join(cmd),
+            output=out_path,
+            tb_prefix=tb_prefix,
+        )
+
+        log_path = self._log_path()
+        with task_status(f"axi-profile run {self.test_name}"):
+            with open(log_path, "w") as log_f:
+                log_f.write("$ " + " ".join(cmd) + "\n")
+                log_f.flush()
+                proc = run_managed_process(cmd, stdout=None, stderr=log_f)
+
+        log_event(
+            logger,
+            logging.INFO,
+            "axi_profile_run.done",
+            test=self.test_name,
+            output=out_path,
+            returncode=proc.returncode,
+        )
+        return proc.returncode

--- a/tests/test_axi_profile.py
+++ b/tests/test_axi_profile.py
@@ -1,0 +1,490 @@
+"""Tests for the ``rb axi-profile`` subcommand group + wrappers.
+
+Same fake-binary pattern as ``tests/test_hier.py``: the real
+``axi-profiler`` isn't on PATH in CI, so we stub it with a tiny
+shell script that records its argv. This pins the CLI shapes we
+promise the downstream:
+
+* ``axi-profiler discover --filelist ... --top ... --output ...``
+* ``axi-profiler run --filelist ... --top ... --input ... --manifest ... --output ... [--tb-prefix ...]``
+"""
+
+from __future__ import annotations
+
+import json
+import stat
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from rtl_buddy.config.model import ModelConfig
+from rtl_buddy.config.suite import SuiteConfig
+from rtl_buddy.errors import FatalRtlBuddyError
+from rtl_buddy.rtl_buddy import RtlBuddy
+from rtl_buddy.tools.axi_profile_rtl_buddy import (
+    RtlBuddyAxiProfileDiscover,
+    RtlBuddyAxiProfileRun,
+)
+
+
+def _make_fake_profiler(tmp_path: Path, *, exit_code: int = 0) -> tuple[Path, Path]:
+    """Drop a fake ``axi-profiler`` that records argv to a JSON sidecar."""
+    record = tmp_path / "axi-profiler-argv.json"
+    script = tmp_path / "axi-profiler"
+    script.write_text(
+        "#!/usr/bin/env bash\n"
+        f'python - "$@" <<PY\n'
+        "import json, sys\n"
+        f'open({json.dumps(str(record))}, "w").write(json.dumps(sys.argv[1:]))\n'
+        "PY\n"
+        f"exit {exit_code}\n"
+    )
+    script.chmod(script.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return script, record
+
+
+def _make_model(
+    tmp_path: Path,
+    *,
+    axi_bundles: str | None = None,
+    axi_monitor_out: str | None = None,
+) -> ModelConfig:
+    src = tmp_path / "src" / "soc.sv"
+    src.parent.mkdir(exist_ok=True)
+    src.write_text("module soc; endmodule\n")
+    return ModelConfig(
+        name="soc",
+        filelist=[str(src)],
+        axi_bundles=axi_bundles,
+        axi_monitor_out=axi_monitor_out,
+        path=str(tmp_path / "models.yaml"),
+    )
+
+
+def _runner() -> tuple[CliRunner, RtlBuddy]:
+    return CliRunner(), RtlBuddy(name="test_axi_profile")
+
+
+# ---------------------------------------------------------------------------
+# RtlBuddyAxiProfileDiscover (unit)
+# ---------------------------------------------------------------------------
+
+
+def test_discover_wrapper_builds_expected_argv(tmp_path: Path) -> None:
+    model = _make_model(tmp_path)
+    script, record = _make_fake_profiler(tmp_path)
+
+    profiler = RtlBuddyAxiProfileDiscover(
+        name="t",
+        model_cfg=model,
+        suite_dir=str(tmp_path),
+        executable=str(script),
+    )
+    assert profiler.run() == 0
+
+    argv = json.loads(record.read_text())
+    assert argv[0] == "discover"
+    fl_idx = argv.index("--filelist") + 1
+    assert argv[fl_idx].endswith("axi.f")
+    assert Path(argv[fl_idx]).is_file()
+    assert argv[argv.index("--top") + 1] == "soc"
+    assert argv[argv.index("--output") + 1].endswith("axi-bundles.yaml")
+
+
+def test_discover_default_output_falls_back_to_artefacts(tmp_path: Path) -> None:
+    """Without `axi_bundles:` set the default output lands under artefacts/."""
+    model = _make_model(tmp_path)
+    script, record = _make_fake_profiler(tmp_path)
+
+    profiler = RtlBuddyAxiProfileDiscover(
+        name="t",
+        model_cfg=model,
+        suite_dir=str(tmp_path),
+        executable=str(script),
+    )
+    assert profiler.run() == 0
+    argv = json.loads(record.read_text())
+    out = argv[argv.index("--output") + 1]
+    assert "artefacts/axi/soc/axi-bundles.yaml" in out
+
+
+def test_discover_default_output_uses_model_axi_bundles_when_set(
+    tmp_path: Path,
+) -> None:
+    """With `axi_bundles:` set, discover writes there by default."""
+    model = _make_model(tmp_path, axi_bundles="src/axi-bundles.yaml")
+    script, record = _make_fake_profiler(tmp_path)
+
+    profiler = RtlBuddyAxiProfileDiscover(
+        name="t",
+        model_cfg=model,
+        suite_dir=str(tmp_path),
+        executable=str(script),
+    )
+    assert profiler.run() == 0
+    argv = json.loads(record.read_text())
+    expected = str(tmp_path / "src" / "axi-bundles.yaml")
+    assert argv[argv.index("--output") + 1] == expected
+
+
+def test_discover_explicit_output_overrides_default(tmp_path: Path) -> None:
+    model = _make_model(tmp_path, axi_bundles="src/axi-bundles.yaml")
+    script, record = _make_fake_profiler(tmp_path)
+    custom_out = tmp_path / "elsewhere" / "my-axi.yaml"
+    custom_out.parent.mkdir()
+
+    profiler = RtlBuddyAxiProfileDiscover(
+        name="t",
+        model_cfg=model,
+        suite_dir=str(tmp_path),
+        output=str(custom_out),
+        executable=str(script),
+    )
+    assert profiler.run() == 0
+    argv = json.loads(record.read_text())
+    assert argv[argv.index("--output") + 1] == str(custom_out)
+
+
+def test_discover_forwards_amend_flag(tmp_path: Path) -> None:
+    model = _make_model(tmp_path)
+    script, record = _make_fake_profiler(tmp_path)
+    amend_path = tmp_path / "existing.yaml"
+    amend_path.write_text("schema_version: '1.0'\nbundles: []\n")
+
+    profiler = RtlBuddyAxiProfileDiscover(
+        name="t",
+        model_cfg=model,
+        suite_dir=str(tmp_path),
+        amend=str(amend_path),
+        executable=str(script),
+    )
+    assert profiler.run() == 0
+    argv = json.loads(record.read_text())
+    assert argv[argv.index("--amend") + 1] == str(amend_path)
+
+
+def test_discover_propagates_nonzero_exit(tmp_path: Path) -> None:
+    model = _make_model(tmp_path)
+    script, _ = _make_fake_profiler(tmp_path, exit_code=3)
+
+    profiler = RtlBuddyAxiProfileDiscover(
+        name="t",
+        model_cfg=model,
+        suite_dir=str(tmp_path),
+        executable=str(script),
+    )
+    assert profiler.run() == 3
+
+
+def test_discover_errors_when_executable_missing(tmp_path: Path) -> None:
+    model = _make_model(tmp_path)
+    profiler = RtlBuddyAxiProfileDiscover(
+        name="t",
+        model_cfg=model,
+        suite_dir=str(tmp_path),
+        executable="this-binary-definitely-does-not-exist",
+    )
+    with pytest.raises(FatalRtlBuddyError) as info:
+        profiler.run()
+    assert "axi-profiler" in str(info.value)
+
+
+# ---------------------------------------------------------------------------
+# RtlBuddyAxiProfileRun (unit)
+# ---------------------------------------------------------------------------
+
+
+def _write_run_fixture(
+    tmp_path: Path, *, axi_bundles_present: bool = True, fst_present: bool = True
+) -> tuple[Path, Path]:
+    """Build a self-contained suite_dir with tests.yaml + models.yaml.
+
+    Returns ``(suite_dir, tests_yaml_path)``. The fixture has one test
+    ``basic`` over a testbench ``tb_basic`` over a model ``soc``. Toggles
+    let individual tests exercise the missing-manifest / missing-FST
+    branches.
+    """
+    suite_dir = tmp_path / "verif" / "soc_top"
+    suite_dir.mkdir(parents=True)
+    src = suite_dir / "src" / "soc.sv"
+    src.parent.mkdir()
+    src.write_text("module soc; endmodule\n")
+
+    models_yaml = suite_dir / "models.yaml"
+    bundles_field = ""
+    if axi_bundles_present:
+        bundles_field = "    axi_bundles: src/axi-bundles.yaml\n"
+        (suite_dir / "src" / "axi-bundles.yaml").write_text(
+            "schema_version: '1.0'\nbundles: []\n"
+        )
+    models_yaml.write_text(
+        "rtl-buddy-filetype: model_config\n"
+        "models:\n"
+        "  - name: soc\n"
+        "    filelist:\n"
+        "      - src/soc.sv\n" + bundles_field
+    )
+
+    tests_yaml = suite_dir / "tests.yaml"
+    tests_yaml.write_text(
+        "rtl-buddy-filetype: test_config\n"
+        "testbenches:\n"
+        "  - name: tb_basic\n"
+        "    filelist:\n"
+        "      - src/soc.sv\n"
+        "tests:\n"
+        "  - name: basic\n"
+        "    desc: smoke\n"
+        "    model: soc\n"
+        "    model_path: models.yaml\n"
+        "    reglvl: 0\n"
+        "    testbench: tb_basic\n"
+        "    plusargs:\n"
+        "    plusdefines:\n"
+        "    uvm:\n"
+        "    preproc:\n"
+        "    postproc:\n"
+        "    sweep:\n"
+        "    sim_timeout:\n"
+    )
+
+    if fst_present:
+        fst_dir = suite_dir / "artefacts" / "basic"
+        fst_dir.mkdir(parents=True)
+        (fst_dir / "dump.fst").write_text("not a real FST, but a real file\n")
+
+    return suite_dir, tests_yaml
+
+
+def test_run_wrapper_builds_expected_argv(tmp_path: Path) -> None:
+    suite_dir, tests_yaml = _write_run_fixture(tmp_path)
+    script, record = _make_fake_profiler(tmp_path)
+
+    suite_cfg = SuiteConfig(str(tests_yaml))
+    test_cfg = suite_cfg.get_tests("basic")[0]
+
+    profiler = RtlBuddyAxiProfileRun(
+        name="t",
+        test_cfg=test_cfg,
+        suite_dir=str(suite_dir),
+        executable=str(script),
+    )
+    assert profiler.run() == 0
+
+    argv = json.loads(record.read_text())
+    assert argv[0] == "run"
+    assert argv[argv.index("--top") + 1] == "soc"
+    assert argv[argv.index("--input") + 1].endswith("artefacts/basic/dump.fst")
+    assert argv[argv.index("--manifest") + 1].endswith("src/axi-bundles.yaml")
+    assert argv[argv.index("--output") + 1].endswith(
+        "artefacts/axi/basic/axi-perf.json"
+    )
+    # tb_prefix defaults to the testbench name from tests.yaml.
+    assert argv[argv.index("--tb-prefix") + 1] == "tb_basic"
+
+
+def test_run_wrapper_tb_prefix_override_wins(tmp_path: Path) -> None:
+    suite_dir, tests_yaml = _write_run_fixture(tmp_path)
+    script, record = _make_fake_profiler(tmp_path)
+    test_cfg = SuiteConfig(str(tests_yaml)).get_tests("basic")[0]
+
+    profiler = RtlBuddyAxiProfileRun(
+        name="t",
+        test_cfg=test_cfg,
+        suite_dir=str(suite_dir),
+        tb_prefix_override="tb_soc.dut",
+        executable=str(script),
+    )
+    assert profiler.run() == 0
+    argv = json.loads(record.read_text())
+    assert argv[argv.index("--tb-prefix") + 1] == "tb_soc.dut"
+
+
+def test_run_wrapper_tb_prefix_empty_override_disables_flag(tmp_path: Path) -> None:
+    """Explicit empty string opts out of the --tb-prefix flag."""
+    suite_dir, tests_yaml = _write_run_fixture(tmp_path)
+    script, record = _make_fake_profiler(tmp_path)
+    test_cfg = SuiteConfig(str(tests_yaml)).get_tests("basic")[0]
+
+    profiler = RtlBuddyAxiProfileRun(
+        name="t",
+        test_cfg=test_cfg,
+        suite_dir=str(suite_dir),
+        tb_prefix_override="",
+        executable=str(script),
+    )
+    assert profiler.run() == 0
+    argv = json.loads(record.read_text())
+    assert "--tb-prefix" not in argv
+
+
+def test_run_wrapper_output_override(tmp_path: Path) -> None:
+    suite_dir, tests_yaml = _write_run_fixture(tmp_path)
+    script, record = _make_fake_profiler(tmp_path)
+    test_cfg = SuiteConfig(str(tests_yaml)).get_tests("basic")[0]
+    custom_out = suite_dir / "out" / "perf.json"
+    custom_out.parent.mkdir()
+
+    profiler = RtlBuddyAxiProfileRun(
+        name="t",
+        test_cfg=test_cfg,
+        suite_dir=str(suite_dir),
+        output=str(custom_out),
+        executable=str(script),
+    )
+    assert profiler.run() == 0
+    argv = json.loads(record.read_text())
+    assert argv[argv.index("--output") + 1] == str(custom_out)
+
+
+def test_run_wrapper_errors_when_axi_bundles_unset(tmp_path: Path) -> None:
+    """Model without `axi_bundles:` field → hint to set it + run discover."""
+    suite_dir, tests_yaml = _write_run_fixture(tmp_path, axi_bundles_present=False)
+    script, _ = _make_fake_profiler(tmp_path)
+    test_cfg = SuiteConfig(str(tests_yaml)).get_tests("basic")[0]
+
+    profiler = RtlBuddyAxiProfileRun(
+        name="t",
+        test_cfg=test_cfg,
+        suite_dir=str(suite_dir),
+        executable=str(script),
+    )
+    with pytest.raises(FatalRtlBuddyError) as info:
+        profiler.run()
+    msg = str(info.value)
+    assert "axi_bundles" in msg
+    assert "rb axi-profile discover soc" in msg
+
+
+def test_run_wrapper_errors_when_manifest_file_missing(tmp_path: Path) -> None:
+    """`axi_bundles:` set but the file doesn't exist → hint to run discover."""
+    suite_dir, tests_yaml = _write_run_fixture(tmp_path)
+    # Delete the manifest file but leave the field pointing at it.
+    (suite_dir / "src" / "axi-bundles.yaml").unlink()
+    script, _ = _make_fake_profiler(tmp_path)
+    test_cfg = SuiteConfig(str(tests_yaml)).get_tests("basic")[0]
+
+    profiler = RtlBuddyAxiProfileRun(
+        name="t",
+        test_cfg=test_cfg,
+        suite_dir=str(suite_dir),
+        executable=str(script),
+    )
+    with pytest.raises(FatalRtlBuddyError) as info:
+        profiler.run()
+    msg = str(info.value)
+    assert "manifest not found" in msg
+    assert "rb axi-profile discover soc" in msg
+
+
+def test_run_wrapper_errors_when_fst_missing(tmp_path: Path) -> None:
+    """No FST under artefacts/<test>/ → hint to run `rb test <test>` first."""
+    suite_dir, tests_yaml = _write_run_fixture(tmp_path, fst_present=False)
+    script, _ = _make_fake_profiler(tmp_path)
+    test_cfg = SuiteConfig(str(tests_yaml)).get_tests("basic")[0]
+
+    profiler = RtlBuddyAxiProfileRun(
+        name="t",
+        test_cfg=test_cfg,
+        suite_dir=str(suite_dir),
+        executable=str(script),
+    )
+    with pytest.raises(FatalRtlBuddyError) as info:
+        profiler.run()
+    msg = str(info.value)
+    assert "FST not found" in msg
+    assert "rb test basic" in msg
+
+
+def test_run_wrapper_propagates_nonzero_exit(tmp_path: Path) -> None:
+    suite_dir, tests_yaml = _write_run_fixture(tmp_path)
+    script, _ = _make_fake_profiler(tmp_path, exit_code=4)
+    test_cfg = SuiteConfig(str(tests_yaml)).get_tests("basic")[0]
+
+    profiler = RtlBuddyAxiProfileRun(
+        name="t",
+        test_cfg=test_cfg,
+        suite_dir=str(suite_dir),
+        executable=str(script),
+    )
+    assert profiler.run() == 4
+
+
+# ---------------------------------------------------------------------------
+# rb axi-profile (integration through Typer)
+# ---------------------------------------------------------------------------
+
+
+def test_rb_axi_profile_discover_invokes_stubbed_profiler(
+    minimal_project: Path,
+) -> None:
+    script, record = _make_fake_profiler(minimal_project)
+    runner, rb = _runner()
+    result = runner.invoke(
+        rb.app,
+        [
+            "axi-profile",
+            "discover",
+            "example",
+            "-c",
+            "models.yaml",
+            "--tool",
+            str(script),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    argv = json.loads(record.read_text())
+    assert argv[0] == "discover"
+    assert argv[argv.index("--top") + 1] == "example"
+
+
+def test_rb_axi_profile_run_invokes_stubbed_profiler(minimal_project: Path) -> None:
+    """End-to-end: rb axi-profile run <test> through the Typer app.
+
+    The minimal_project fixture's models.yaml lacks `axi_bundles:`, so
+    extend it in-place for this test and pre-create both the manifest
+    and the FST.
+    """
+    models_yaml = minimal_project / "models.yaml"
+    models_yaml.write_text(
+        models_yaml.read_text() + "    axi_bundles: src/axi-bundles.yaml\n"
+    )
+    (minimal_project / "src" / "axi-bundles.yaml").write_text(
+        "schema_version: '1.0'\nbundles: []\n"
+    )
+    fst_dir = minimal_project / "artefacts" / "basic"
+    fst_dir.mkdir(parents=True)
+    (fst_dir / "dump.fst").write_text("fake fst\n")
+
+    script, record = _make_fake_profiler(minimal_project)
+    runner, rb = _runner()
+    result = runner.invoke(
+        rb.app,
+        [
+            "axi-profile",
+            "run",
+            "basic",
+            "-c",
+            "tests.yaml",
+            "--tool",
+            str(script),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    argv = json.loads(record.read_text())
+    assert argv[0] == "run"
+    assert argv[argv.index("--input") + 1].endswith("artefacts/basic/dump.fst")
+    assert argv[argv.index("--manifest") + 1].endswith("src/axi-bundles.yaml")
+    # tb_basic is the testbench name in the fixture's tests.yaml.
+    assert argv[argv.index("--tb-prefix") + 1] == "tb_basic"
+
+
+def test_rb_axi_profile_no_subcommand_shows_help(minimal_project: Path) -> None:
+    """`rb axi-profile` with no subcommand must not run anything."""
+    runner, rb = _runner()
+    result = runner.invoke(rb.app, ["axi-profile"])
+    # Typer's no_args_is_help convention exits non-zero and emits help text.
+    assert result.exit_code != 0
+    assert "discover" in result.output
+    assert "run" in result.output

--- a/tests/test_config_loaders.py
+++ b/tests/test_config_loaders.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 from serde.yaml import from_yaml
 
+from rtl_buddy.config.model import ModelConfig, ModelConfigLoader
 from rtl_buddy.config.reg import RegConfig
 from rtl_buddy.config.rtl import RtlBuilderConfig
 from rtl_buddy.config.root import (
@@ -380,3 +381,122 @@ def test_discover_rtl_builder_names_raises_without_root_config(tmp_path, monkeyp
     # If we picked up a real root_config.yaml from above tmp_path, accept that
     # too — just confirm the contract holds.
     assert isinstance(names, list)
+
+
+# ---------------------------------------------------------------------------
+# ModelConfig — axi_bundles + axi_monitor_out
+# ---------------------------------------------------------------------------
+
+
+def test_model_config_axi_fields_default_none():
+    """Bare ModelConfig has no AXI fields set (back-compat)."""
+    model = ModelConfig(name="soc", filelist=["src/soc.sv"])
+    assert model.axi_bundles is None
+    assert model.axi_monitor_out is None
+    assert model.get_axi_bundles_path() is None
+    assert model.get_axi_monitor_out_path() is None
+
+
+def test_model_config_axi_bundles_resolves_relative_to_models_yaml(tmp_path):
+    """axi_bundles relative path resolves against the models.yaml directory."""
+    models_yaml = tmp_path / "design" / "soc" / "models.yaml"
+    models_yaml.parent.mkdir(parents=True)
+
+    model = ModelConfig(
+        name="soc",
+        filelist=["src/soc.sv"],
+        axi_bundles="src/axi-bundles.yaml",
+        path=str(models_yaml),
+    )
+    resolved = model.get_axi_bundles_path()
+    assert resolved == str(tmp_path / "design" / "soc" / "src" / "axi-bundles.yaml")
+
+
+def test_model_config_axi_monitor_out_resolves_relative(tmp_path):
+    """axi_monitor_out relative path resolves against the models.yaml directory.
+
+    Typical usage: monitor SV lives in the verif testbench tree, sibling
+    to the design tree.
+    """
+    models_yaml = tmp_path / "design" / "soc" / "models.yaml"
+    models_yaml.parent.mkdir(parents=True)
+
+    model = ModelConfig(
+        name="soc",
+        filelist=["src/soc.sv"],
+        axi_monitor_out="../../verif/soc_top/gen/axi_perf_mon.sv",
+        path=str(models_yaml),
+    )
+    resolved = model.get_axi_monitor_out_path()
+    assert resolved == str(tmp_path / "verif" / "soc_top" / "gen" / "axi_perf_mon.sv")
+
+
+def test_model_config_axi_paths_pass_absolute_through(tmp_path):
+    abs_bundles = tmp_path / "elsewhere" / "axi-bundles.yaml"
+    abs_monitor = tmp_path / "verif" / "axi_perf_mon.sv"
+    model = ModelConfig(
+        name="soc",
+        filelist=["src/soc.sv"],
+        axi_bundles=str(abs_bundles),
+        axi_monitor_out=str(abs_monitor),
+        path=str(tmp_path / "design" / "models.yaml"),
+    )
+    assert model.get_axi_bundles_path() == str(abs_bundles)
+    assert model.get_axi_monitor_out_path() == str(abs_monitor)
+
+
+def test_model_config_axi_paths_resolved_against_cwd_when_path_unset(
+    tmp_path, monkeypatch
+):
+    """When the loader hasn't set path yet, fall back to cwd.
+
+    In normal use the loader sets path; this just locks the fallback
+    so a bare ModelConfig in tests doesn't blow up on relative paths.
+    """
+    monkeypatch.chdir(tmp_path)
+    model = ModelConfig(
+        name="soc",
+        filelist=["src/soc.sv"],
+        axi_bundles="axi-bundles.yaml",
+    )
+    assert model.get_axi_bundles_path() == str(tmp_path / "axi-bundles.yaml")
+
+
+def test_model_config_loader_round_trips_axi_fields(tmp_path):
+    """models.yaml with the new fields round-trips through the loader.
+
+    The loader sets ``path`` so the helpers resolve relative paths
+    correctly without further wiring.
+    """
+    models_yaml = tmp_path / "design" / "models.yaml"
+    models_yaml.parent.mkdir()
+    models_yaml.write_text(
+        "rtl-buddy-filetype: model_config\n"
+        "models:\n"
+        "  - name: soc\n"
+        "    filelist:\n"
+        "      - src/soc.sv\n"
+        "    axi_bundles: src/soc/axi-bundles.yaml\n"
+        "    axi_monitor_out: ../verif/soc_top/gen/axi_perf_mon.sv\n"
+        "  - name: cpu\n"
+        "    filelist:\n"
+        "      - src/cpu.sv\n"
+    )
+
+    loader = ModelConfigLoader(str(models_yaml))
+
+    soc = loader.get_model("soc")
+    assert soc.axi_bundles == "src/soc/axi-bundles.yaml"
+    assert soc.axi_monitor_out == "../verif/soc_top/gen/axi_perf_mon.sv"
+    assert soc.get_axi_bundles_path() == str(
+        tmp_path / "design" / "src" / "soc" / "axi-bundles.yaml"
+    )
+    assert soc.get_axi_monitor_out_path() == str(
+        tmp_path / "verif" / "soc_top" / "gen" / "axi_perf_mon.sv"
+    )
+
+    cpu = loader.get_model("cpu")
+    assert cpu.axi_bundles is None
+    assert cpu.axi_monitor_out is None
+    assert cpu.get_axi_bundles_path() is None
+    assert cpu.get_axi_monitor_out_path() is None


### PR DESCRIPTION
## Summary

Restructures `rb axi-profile` from a single (model-keyed) command into a Typer subcommand group, and adds the primary user-facing verb **`rb axi-profile run <test>`**.

```
rb axi-profile run <test>             # ingest + aggregate (per-test)
rb axi-profile discover <model>       # write the manifest
```

The `run <test>` user model: from `verif/soc_top/`, after `rb test basic`, type `rb axi-profile run basic`. The wrapper figures out the rest by looking up the test in `tests.yaml`, the manifest in `models.yaml`'s `axi_bundles:` (added in #161 / #164), the FST at `artefacts/<test>/dump.fst` (same convention `rb wave` uses), and the testbench top scope from the test's `tb.name`.

## Error hints

| Missing | Hint |
|---|---|
| `axi_bundles` field absent | `model 'soc' has no 'axi_bundles:' in models.yaml ... run 'rb axi-profile discover soc' first` |
| Manifest file absent | `manifest not found at ... Run 'rb axi-profile discover soc' first` |
| FST absent | `FST not found at ... Run 'rb test basic' first to produce it` |

## What's in this PR

- New `RtlBuddyAxiProfileDiscover` + `RtlBuddyAxiProfileRun` wrappers in `tools/axi_profile_rtl_buddy.py`
- `axi_profile_app` Typer sub-app on `RtlBuddy` with `discover` + `run` subcommands (gen-monitor lands in #163)
- 18 new pytests covering wrappers + Typer integration paths (default + override outputs, manifest/FST hints, tb_prefix auto-extract/override/opt-out)
- `scripts/gen_cli_reference.py` includes `axi-profile` so the auto-generated CLI reference reflects the new group
- `docs/reference/cli.md` regenerated

## Supersedes

This PR supersedes #158 (initial discover-only wrapper) and #159 (`--tb-prefix` forwarding) — both were on a track that pre-dated the locked usage model from the #157 design discussion. Will close those once this lands.

## Test plan
- [x] `uv run pytest tests/test_axi_profile.py` — 18/18 pass
- [x] Full suite (minus 2 pre-existing pyright/schema-drift failures): 626 pass, 2 skipped
- [x] `uv run ruff check` clean
- [x] `uv run ruff format --check` clean
- [x] `uv run python scripts/gen_cli_reference.py --check` clean
- [ ] CI passes on the PR

## Stacked on
- #164 (`axi_bundles` + `axi_monitor_out` fields on ModelConfig)

## Follow-ups
- #163 — `gen-monitor` subcommand wiring (next PR)

Closes #162 | Part of #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)