### PR TITLE
feat(axi-profile): gen-monitor subcommand wiring

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -223,8 +223,9 @@ Usage: rtl-buddy axi-profile [OPTIONS] COMMAND [ARGS]...
 │ --help          Show this message and exit.                                          │
 ╰──────────────────────────────────────────────────────────────────────────────────────╯
 ╭─ Commands ───────────────────────────────────────────────────────────────────────────╮
-│ run       ingest a test's FST and emit per-test axi-perf.json                        │
-│ discover  parse RTL to (re)generate the model's axi-bundles.yaml manifest            │
+│ run          ingest a test's FST and emit per-test axi-perf.json                     │
+│ discover     parse RTL to (re)generate the model's axi-bundles.yaml manifest         │
+│ gen-monitor  emit the SV bind-style AXI monitor for the model's testbench            │
 ╰──────────────────────────────────────────────────────────────────────────────────────╯
 ```
 

--- a/src/rtl_buddy/rtl_buddy.py
+++ b/src/rtl_buddy/rtl_buddy.py
@@ -47,6 +47,7 @@ from .hub.cli import app as hub_app
 from .skill_install import app as skill_app
 from .tools.axi_profile_rtl_buddy import (
     RtlBuddyAxiProfileDiscover,
+    RtlBuddyAxiProfileGenMonitor,
     RtlBuddyAxiProfileRun,
 )
 from .tools.coverage import CoverageReporter
@@ -145,6 +146,10 @@ class RtlBuddy:
             "discover",
             help="parse RTL to (re)generate the model's axi-bundles.yaml manifest",
         )(self.do_cmd_axi_profile_discover)
+        self.axi_profile_app.command(
+            "gen-monitor",
+            help="emit the SV bind-style AXI monitor for the model's testbench",
+        )(self.do_cmd_axi_profile_gen_monitor)
         self.app.add_typer(
             self.axi_profile_app,
             name="axi-profile",
@@ -1317,6 +1322,77 @@ class RtlBuddy:
             suite_dir=os.path.dirname(os.path.abspath(test_config)),
             output=output,
             tb_prefix_override=tb_prefix,
+            executable=tool,
+        )
+        raise typer.Exit(profiler.run())
+
+    def do_cmd_axi_profile_gen_monitor(
+        self,
+        model_name: Annotated[str, typer.Argument(help="model from models.yaml")],
+        model_config: Annotated[
+            str, typer.Option("-c", "--model-config", help="models.yaml to use")
+        ] = "models.yaml",
+        output: Annotated[
+            str | None,
+            typer.Option(
+                "-o",
+                "--output",
+                help=(
+                    "output path for the generated SV monitor "
+                    "(default: the model's `axi_monitor_out:` "
+                    "from models.yaml)"
+                ),
+            ),
+        ] = None,
+        time_precision: Annotated[
+            str | None,
+            typer.Option(
+                "--time-precision",
+                help=(
+                    "IEEE-1800 timeprecision atom (1ns / 100ps / 1ps / ...). "
+                    "Must match the testbench's `timeprecision."
+                ),
+            ),
+        ] = None,
+        buffer_cap: Annotated[
+            int | None,
+            typer.Option(
+                "--buffer-cap",
+                help="Per-bundle FIFO depth cap. Drained only at $finish.",
+            ),
+        ] = None,
+        tool: Annotated[
+            str,
+            typer.Option("--tool", help="path to the axi-profiler binary"),
+        ] = "axi-profiler",
+    ):
+        """
+        emit the SV bind-style AXI monitor for the model's testbench
+
+        Reads the manifest path from `model.axi_bundles` and the
+        output path from `model.axi_monitor_out` (both in
+        models.yaml). The generated SV must be added to the
+        testbench's filelist; pointing `axi_monitor_out:` at the
+        verif tree (e.g. `../verif/<tb>/gen/axi_perf_mon.sv`) makes
+        that a one-time step.
+        """
+        model_cfg = ModelConfigLoader(model_config).get_model(model_name)
+        log_event(
+            logger,
+            logging.INFO,
+            "command.axi_profile_gen_monitor",
+            command="axi-profile",
+            subcommand="gen-monitor",
+            model=model_name,
+            output=output,
+        )
+        profiler = RtlBuddyAxiProfileGenMonitor(
+            name=self.name + "/axi-profile/gen-monitor",
+            model_cfg=model_cfg,
+            suite_dir=os.getcwd(),
+            output=output,
+            time_precision=time_precision,
+            buffer_cap=buffer_cap,
             executable=tool,
         )
         raise typer.Exit(profiler.run())

--- a/src/rtl_buddy/tools/axi_profile_rtl_buddy.py
+++ b/src/rtl_buddy/tools/axi_profile_rtl_buddy.py
@@ -24,7 +24,12 @@ Two wrappers, one per ``rb axi-profile`` subcommand:
   value when the wrapping scope name diverges from the testbench
   name (e.g. a custom Verilator wrapper).
 
-The ``gen-monitor`` subcommand wrapper lands separately (#163).
+* :class:`RtlBuddyAxiProfileGenMonitor` — ``rb axi-profile gen-monitor
+  <model>``: emits a SystemVerilog bind-style monitor for the stream
+  ingest path. Reads the manifest from ``model.axi_bundles`` and
+  writes to ``model.axi_monitor_out`` — both come from the
+  ``models.yaml`` entry so the testbench's filelist can pick up the
+  generated file without per-test config.
 """
 
 from __future__ import annotations
@@ -313,6 +318,127 @@ class RtlBuddyAxiProfileRun:
             logging.INFO,
             "axi_profile_run.done",
             test=self.test_name,
+            output=out_path,
+            returncode=proc.returncode,
+        )
+        return proc.returncode
+
+
+class RtlBuddyAxiProfileGenMonitor:
+    """Emit the SV bind-style monitor for a model via ``axi-profiler gen-monitor``.
+
+    Single-shot. Both the manifest input and the SV output path are
+    looked up in ``models.yaml`` (``axi_bundles`` /
+    ``axi_monitor_out``), so the user just types
+    ``rb axi-profile gen-monitor <model>`` and the wrapper handles
+    discovery + destination. The user is responsible for adding the
+    generated SV to the testbench's filelist once.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        model_cfg: ModelConfig,
+        *,
+        suite_dir: str,
+        output: str | None = None,
+        time_precision: str | None = None,
+        buffer_cap: int | None = None,
+        executable: str = "axi-profiler",
+    ):
+        self.name = name
+        self.model_cfg = model_cfg
+        self.output_override = output
+        self.time_precision = time_precision
+        self.buffer_cap = buffer_cap
+        self.executable = executable
+
+        artefact_root = Path(suite_dir) / "artefacts" / "axi" / model_cfg.name
+        artefact_root.mkdir(parents=True, exist_ok=True)
+        self.artefact_dir = str(artefact_root)
+
+    def _log_path(self) -> str:
+        return os.path.join(self.artefact_dir, "axi-profile-gen-monitor.log")
+
+    def _resolve_manifest_path(self) -> str:
+        manifest = self.model_cfg.get_axi_bundles_path()
+        if manifest is None:
+            raise FatalRtlBuddyError(
+                f"axi-profile gen-monitor: model '{self.model_cfg.name}' "
+                "has no `axi_bundles:` in models.yaml. Add the field "
+                "pointing at the checked-in axi-bundles.yaml manifest, "
+                "then run "
+                f"`rb axi-profile discover {self.model_cfg.name}` to "
+                "generate one if it doesn't exist."
+            )
+        if not os.path.isfile(manifest):
+            raise FatalRtlBuddyError(
+                f"axi-profile gen-monitor: manifest not found at "
+                f"{manifest}. "
+                f"Run `rb axi-profile discover {self.model_cfg.name}` first."
+            )
+        return manifest
+
+    def _resolve_output_path(self) -> str:
+        if self.output_override:
+            return self.output_override
+        configured = self.model_cfg.get_axi_monitor_out_path()
+        if configured is None:
+            raise FatalRtlBuddyError(
+                f"axi-profile gen-monitor: model '{self.model_cfg.name}' "
+                "has no `axi_monitor_out:` in models.yaml. Add the "
+                "field pointing at the SV path inside your testbench "
+                "tree (e.g. `../verif/<tb>/gen/axi_perf_mon.sv`) or "
+                "pass `--output <path>` explicitly."
+            )
+        return configured
+
+    def _build_cmd(self, manifest: str, out_path: str) -> list[str]:
+        cmd = [
+            self.executable,
+            "gen-monitor",
+            manifest,
+            "--output",
+            out_path,
+        ]
+        if self.time_precision:
+            cmd += ["--time-precision", self.time_precision]
+        if self.buffer_cap is not None:
+            cmd += ["--buffer-cap", str(self.buffer_cap)]
+        return cmd
+
+    def run(self) -> int:
+        _require_axi_profiler(self.executable)
+
+        manifest = self._resolve_manifest_path()
+        out_path = self._resolve_output_path()
+        # The downstream gen-monitor opens the output for write; make
+        # sure the parent directory exists so a typical
+        # `../verif/<tb>/gen/...` path doesn't fail on first run.
+        os.makedirs(os.path.dirname(os.path.abspath(out_path)), exist_ok=True)
+
+        cmd = self._build_cmd(manifest, out_path)
+        log_event(
+            logger,
+            logging.INFO,
+            "axi_profile_gen_monitor.start",
+            model=self.model_cfg.name,
+            cmd=" ".join(cmd),
+            output=out_path,
+        )
+
+        log_path = self._log_path()
+        with task_status(f"axi-profile gen-monitor {self.model_cfg.name}"):
+            with open(log_path, "w") as log_f:
+                log_f.write("$ " + " ".join(cmd) + "\n")
+                log_f.flush()
+                proc = run_managed_process(cmd, stdout=None, stderr=log_f)
+
+        log_event(
+            logger,
+            logging.INFO,
+            "axi_profile_gen_monitor.done",
+            model=self.model_cfg.name,
             output=out_path,
             returncode=proc.returncode,
         )

--- a/tests/test_axi_profile.py
+++ b/tests/test_axi_profile.py
@@ -24,6 +24,7 @@ from rtl_buddy.errors import FatalRtlBuddyError
 from rtl_buddy.rtl_buddy import RtlBuddy
 from rtl_buddy.tools.axi_profile_rtl_buddy import (
     RtlBuddyAxiProfileDiscover,
+    RtlBuddyAxiProfileGenMonitor,
     RtlBuddyAxiProfileRun,
 )
 
@@ -488,3 +489,215 @@ def test_rb_axi_profile_no_subcommand_shows_help(minimal_project: Path) -> None:
     assert result.exit_code != 0
     assert "discover" in result.output
     assert "run" in result.output
+    assert "gen-monitor" in result.output
+
+
+# ---------------------------------------------------------------------------
+# RtlBuddyAxiProfileGenMonitor (unit)
+# ---------------------------------------------------------------------------
+
+
+def _make_gen_monitor_model(
+    tmp_path: Path,
+    *,
+    axi_bundles_present: bool = True,
+    axi_monitor_out: str | None = "../verif/soc_top/gen/axi_perf_mon.sv",
+    create_manifest_file: bool = True,
+) -> ModelConfig:
+    """Build a ModelConfig + on-disk manifest for gen-monitor tests."""
+    design = tmp_path / "design" / "soc"
+    design.mkdir(parents=True)
+    src = design / "soc.sv"
+    src.write_text("module soc; endmodule\n")
+
+    axi_bundles_field = "src/axi-bundles.yaml" if axi_bundles_present else None
+    if axi_bundles_present and create_manifest_file:
+        manifest = design / "src" / "axi-bundles.yaml"
+        manifest.parent.mkdir(exist_ok=True)
+        manifest.write_text("schema_version: '1.0'\nbundles: []\n")
+
+    return ModelConfig(
+        name="soc",
+        filelist=[str(src)],
+        axi_bundles=axi_bundles_field,
+        axi_monitor_out=axi_monitor_out,
+        path=str(design / "models.yaml"),
+    )
+
+
+def test_gen_monitor_wrapper_builds_expected_argv(tmp_path: Path) -> None:
+    model = _make_gen_monitor_model(tmp_path)
+    script, record = _make_fake_profiler(tmp_path)
+
+    profiler = RtlBuddyAxiProfileGenMonitor(
+        name="t",
+        model_cfg=model,
+        suite_dir=str(tmp_path),
+        executable=str(script),
+    )
+    assert profiler.run() == 0
+
+    argv = json.loads(record.read_text())
+    # `gen-monitor <manifest> --output <out>` (manifest is positional).
+    assert argv[0] == "gen-monitor"
+    assert argv[1].endswith("src/axi-bundles.yaml")
+    assert argv[argv.index("--output") + 1].endswith(
+        "verif/soc_top/gen/axi_perf_mon.sv"
+    )
+    # Both flags optional; omitted when not set.
+    assert "--time-precision" not in argv
+    assert "--buffer-cap" not in argv
+
+
+def test_gen_monitor_wrapper_forwards_optional_flags(tmp_path: Path) -> None:
+    model = _make_gen_monitor_model(tmp_path)
+    script, record = _make_fake_profiler(tmp_path)
+
+    profiler = RtlBuddyAxiProfileGenMonitor(
+        name="t",
+        model_cfg=model,
+        suite_dir=str(tmp_path),
+        time_precision="100ps",
+        buffer_cap=4096,
+        executable=str(script),
+    )
+    assert profiler.run() == 0
+    argv = json.loads(record.read_text())
+    assert argv[argv.index("--time-precision") + 1] == "100ps"
+    assert argv[argv.index("--buffer-cap") + 1] == "4096"
+
+
+def test_gen_monitor_wrapper_output_override(tmp_path: Path) -> None:
+    """--output overrides the `axi_monitor_out:` default."""
+    model = _make_gen_monitor_model(tmp_path)
+    custom_out = tmp_path / "elsewhere" / "mon.sv"
+    custom_out.parent.mkdir()
+    script, record = _make_fake_profiler(tmp_path)
+
+    profiler = RtlBuddyAxiProfileGenMonitor(
+        name="t",
+        model_cfg=model,
+        suite_dir=str(tmp_path),
+        output=str(custom_out),
+        executable=str(script),
+    )
+    assert profiler.run() == 0
+    argv = json.loads(record.read_text())
+    assert argv[argv.index("--output") + 1] == str(custom_out)
+
+
+def test_gen_monitor_wrapper_errors_when_axi_bundles_unset(tmp_path: Path) -> None:
+    model = _make_gen_monitor_model(tmp_path, axi_bundles_present=False)
+    script, _ = _make_fake_profiler(tmp_path)
+
+    profiler = RtlBuddyAxiProfileGenMonitor(
+        name="t",
+        model_cfg=model,
+        suite_dir=str(tmp_path),
+        executable=str(script),
+    )
+    with pytest.raises(FatalRtlBuddyError) as info:
+        profiler.run()
+    msg = str(info.value)
+    assert "axi_bundles" in msg
+    assert "rb axi-profile discover soc" in msg
+
+
+def test_gen_monitor_wrapper_errors_when_manifest_file_missing(tmp_path: Path) -> None:
+    model = _make_gen_monitor_model(
+        tmp_path, axi_bundles_present=True, create_manifest_file=False
+    )
+    script, _ = _make_fake_profiler(tmp_path)
+
+    profiler = RtlBuddyAxiProfileGenMonitor(
+        name="t",
+        model_cfg=model,
+        suite_dir=str(tmp_path),
+        executable=str(script),
+    )
+    with pytest.raises(FatalRtlBuddyError) as info:
+        profiler.run()
+    msg = str(info.value)
+    assert "manifest not found" in msg
+
+
+def test_gen_monitor_wrapper_errors_when_monitor_out_unset(tmp_path: Path) -> None:
+    """Model without `axi_monitor_out:` AND no --output → hint."""
+    model = _make_gen_monitor_model(tmp_path, axi_monitor_out=None)
+    script, _ = _make_fake_profiler(tmp_path)
+
+    profiler = RtlBuddyAxiProfileGenMonitor(
+        name="t",
+        model_cfg=model,
+        suite_dir=str(tmp_path),
+        executable=str(script),
+    )
+    with pytest.raises(FatalRtlBuddyError) as info:
+        profiler.run()
+    msg = str(info.value)
+    assert "axi_monitor_out" in msg
+
+
+def test_gen_monitor_wrapper_creates_parent_dirs(tmp_path: Path) -> None:
+    """The output's parent dir is created so first run doesn't fail."""
+    model = _make_gen_monitor_model(tmp_path)
+    script, _ = _make_fake_profiler(tmp_path)
+
+    profiler = RtlBuddyAxiProfileGenMonitor(
+        name="t",
+        model_cfg=model,
+        suite_dir=str(tmp_path),
+        executable=str(script),
+    )
+    assert profiler.run() == 0
+    # Parent of axi_monitor_out (../verif/soc_top/gen/) should exist.
+    out_parent = (tmp_path / "design" / "verif" / "soc_top" / "gen").resolve()
+    assert out_parent.is_dir()
+
+
+def test_gen_monitor_wrapper_propagates_nonzero_exit(tmp_path: Path) -> None:
+    model = _make_gen_monitor_model(tmp_path)
+    script, _ = _make_fake_profiler(tmp_path, exit_code=2)
+
+    profiler = RtlBuddyAxiProfileGenMonitor(
+        name="t",
+        model_cfg=model,
+        suite_dir=str(tmp_path),
+        executable=str(script),
+    )
+    assert profiler.run() == 2
+
+
+def test_rb_axi_profile_gen_monitor_invokes_stubbed_profiler(
+    minimal_project: Path,
+) -> None:
+    """End-to-end: rb axi-profile gen-monitor <model> through the Typer app."""
+    models_yaml = minimal_project / "models.yaml"
+    models_yaml.write_text(
+        models_yaml.read_text()
+        + "    axi_bundles: src/axi-bundles.yaml\n"
+        + "    axi_monitor_out: gen/axi_perf_mon.sv\n"
+    )
+    (minimal_project / "src" / "axi-bundles.yaml").write_text(
+        "schema_version: '1.0'\nbundles: []\n"
+    )
+
+    script, record = _make_fake_profiler(minimal_project)
+    runner, rb = _runner()
+    result = runner.invoke(
+        rb.app,
+        [
+            "axi-profile",
+            "gen-monitor",
+            "example",
+            "-c",
+            "models.yaml",
+            "--tool",
+            str(script),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    argv = json.loads(record.read_text())
+    assert argv[0] == "gen-monitor"
+    assert argv[1].endswith("src/axi-bundles.yaml")
+    assert argv[argv.index("--output") + 1].endswith("gen/axi_perf_mon.sv")


### PR DESCRIPTION
## Summary

Third and final piece of the `rb axi-profile` subcommand group restructure: emits the SV bind-style AXI monitor that the stream ingest path needs.

```
rb axi-profile gen-monitor <model>
```

Reads the manifest from `model.axi_bundles` (added in #161) and the SV output path from `model.axi_monitor_out` (also #161). Both come from `models.yaml` so the testbench's filelist can pick up the generated SV once and forget about it. The user is responsible for including the generated file in the testbench compile.

## Error hints (mirror `run`)

| Missing | Hint |
|---|---|
| `axi_bundles` field absent | "model 'soc' has no `axi_bundles:` ... run `rb axi-profile discover soc`" |
| Manifest file absent | "manifest not found at ... Run `rb axi-profile discover soc` first" |
| `axi_monitor_out` absent (and no `--output`) | "model 'soc' has no `axi_monitor_out:` ... or pass `--output <path>`" |

## What's in this PR

- New `RtlBuddyAxiProfileGenMonitor` wrapper in `tools/axi_profile_rtl_buddy.py`
- `gen-monitor` subcommand on the `axi_profile_app` Typer sub-app
- `--time-precision` / `--buffer-cap` forward through to the downstream
- Parent directory of the output path is created on first run so `../verif/<tb>/gen/...` doesn't fail on a fresh checkout
- 9 new pytests (positional manifest arg, output override, optional flags, all three error hints, parent-dir creation, exit propagation, end-to-end through Typer)
- `docs/reference/cli.md` regenerated

## Test plan
- [x] `uv run pytest tests/test_axi_profile.py` — 27/27 pass (18 R2 + 9 R3)
- [x] `uv run ruff check` clean
- [x] `uv run ruff format --check` clean
- [x] `uv run python scripts/gen_cli_reference.py --check` clean
- [x] CI passes on the PR

## Stacked on
- #164 (`axi_bundles` + `axi_monitor_out` ModelConfig fields)
- #165 (subcommand group + `run` codepath)

Closes #163 | Part of #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)