### PR TITLE
config: fail loud on duplicate names in models / cdc / synth / tests yaml

### DIFF
--- a/src/rtl_buddy/config/cdc.py
+++ b/src/rtl_buddy/config/cdc.py
@@ -198,6 +198,27 @@ class CdcSuiteConfig:
             )
             raise FatalRtlBuddyError(f'failed to load "{path}"') from e
 
+        # Fail loud on duplicate ``name:`` — the dict-comprehension
+        # below would silently overwrite the first analysis with the
+        # second, hiding the user's typo until they hit "analysis X
+        # not found" at lookup time.
+        seen: dict[str, int] = {}
+        for idx, analysis in enumerate(data.analyses):
+            if analysis.name in seen:
+                log_event(
+                    logger,
+                    logging.ERROR,
+                    "cdc_suite_config.duplicate_analysis",
+                    path=path,
+                    name=analysis.name,
+                    first_index=seen[analysis.name],
+                    second_index=idx,
+                )
+                raise FatalRtlBuddyError(
+                    f"{path}: duplicate analysis name {analysis.name!r}"
+                )
+            seen[analysis.name] = idx
+
         config_dir = os.path.dirname(os.path.abspath(path))
         try:
             self.analyses = {a.name: a.initialise(config_dir) for a in data.analyses}

--- a/src/rtl_buddy/config/model.py
+++ b/src/rtl_buddy/config/model.py
@@ -98,6 +98,26 @@ class ModelConfigLoader:
             )
             raise FatalRtlBuddyError(f'failed to load "{path}"') from e
 
+        # Fail loud on duplicate ``name:`` — silently letting the
+        # first or last win makes "model X not found" errors at
+        # lookup time and hides the user's typo. Caught here so
+        # every downstream consumer (rb cdc, rb synth, rb hier,
+        # rb hub) sees a single source of truth.
+        seen: dict[str, int] = {}
+        for idx, model in enumerate(self.models):
+            if model.name in seen:
+                log_event(
+                    logger,
+                    logging.ERROR,
+                    "model_config.duplicate_model",
+                    path=path,
+                    name=model.name,
+                    first_index=seen[model.name],
+                    second_index=idx,
+                )
+                raise FatalRtlBuddyError(f"{path}: duplicate model name {model.name!r}")
+            seen[model.name] = idx
+
     def get_model(self, model_name: str) -> ModelConfig:
         """
         Get a ModelConfig according to model_name.

--- a/src/rtl_buddy/config/suite.py
+++ b/src/rtl_buddy/config/suite.py
@@ -44,6 +44,41 @@ class SuiteConfig:
         self.path = path
 
         if data is not None:
+            # Fail loud on duplicate testbench / test names — the
+            # dict-comprehensions below would silently overwrite the
+            # first entry with the last, hiding the user's typo.
+            seen_tbs: dict[str, int] = {}
+            for idx, tb in enumerate(data.testbenches):
+                tb_name = tb.get_name()
+                if tb_name in seen_tbs:
+                    log_event(
+                        logger,
+                        logging.ERROR,
+                        "suite_config.duplicate_testbench",
+                        path=path,
+                        name=tb_name,
+                        first_index=seen_tbs[tb_name],
+                        second_index=idx,
+                    )
+                    raise FatalRtlBuddyError(
+                        f"{path}: duplicate testbench name {tb_name!r}"
+                    )
+                seen_tbs[tb_name] = idx
+            seen_tests: dict[str, int] = {}
+            for idx, t in enumerate(data.tests):
+                if t.name in seen_tests:
+                    log_event(
+                        logger,
+                        logging.ERROR,
+                        "suite_config.duplicate_test",
+                        path=path,
+                        name=t.name,
+                        first_index=seen_tests[t.name],
+                        second_index=idx,
+                    )
+                    raise FatalRtlBuddyError(f"{path}: duplicate test name {t.name!r}")
+                seen_tests[t.name] = idx
+
             try:
                 tbs = {tb.get_name(): tb for tb in data.testbenches}
             except Exception as e:

--- a/src/rtl_buddy/config/synth.py
+++ b/src/rtl_buddy/config/synth.py
@@ -309,6 +309,26 @@ class SynthSuiteConfig:
             )
             raise FatalRtlBuddyError(f'failed to load "{path}"') from e
 
+        # Fail loud on duplicate ``name:`` — same rationale as the
+        # cdc.yaml side: the dict-comprehension below would silently
+        # overwrite the first synthesis with the second.
+        seen: dict[str, int] = {}
+        for idx, synthesis in enumerate(data.syntheses):
+            if synthesis.name in seen:
+                log_event(
+                    logger,
+                    logging.ERROR,
+                    "synth_suite_config.duplicate_synthesis",
+                    path=path,
+                    name=synthesis.name,
+                    first_index=seen[synthesis.name],
+                    second_index=idx,
+                )
+                raise FatalRtlBuddyError(
+                    f"{path}: duplicate synthesis name {synthesis.name!r}"
+                )
+            seen[synthesis.name] = idx
+
         config_dir = os.path.dirname(os.path.abspath(path))
         try:
             self.syntheses = {s.name: s.initialise(config_dir) for s in data.syntheses}

--- a/tests/test_cdc.py
+++ b/tests/test_cdc.py
@@ -267,6 +267,38 @@ def test_cdc_suite_config_missing_name_raises(tmp_path):
         cfg.get_analyses("nonexistent")
 
 
+def test_cdc_suite_config_duplicate_analysis_raises(tmp_path):
+    """Two analyses with the same name in one cdc.yaml is a hard
+    error — the dict-comprehension in CdcSuiteConfig.__init__
+    would silently overwrite the first with the second otherwise."""
+    from rtl_buddy.errors import FatalRtlBuddyError
+
+    (tmp_path / "models.yaml").write_text(_MODELS_YAML)
+    body = dedent("""\
+        rtl-buddy-filetype: cdc_config
+
+        analyses:
+          - name: "dup"
+            desc: "first"
+            model: "mod_a"
+            model_path: "models.yaml"
+            tool: "rtl-buddy-cdc"
+            constraints: "mod_a.sdc"
+            reglvl: 0
+          - name: "dup"
+            desc: "second"
+            model: "mod_b"
+            model_path: "models.yaml"
+            tool: "rtl-buddy-cdc"
+            constraints: "mod_b.sdc"
+            reglvl: 0
+    """)
+    path = tmp_path / "cdc.yaml"
+    path.write_text(body)
+    with pytest.raises(FatalRtlBuddyError, match="duplicate analysis name 'dup'"):
+        CdcSuiteConfig(str(path))
+
+
 def test_cdc_suite_config_picks_up_frontend_field(tmp_path):
     """Per-analysis `frontend:` round-trips through CdcConfigFile -> CdcConfig."""
     suite_yaml = _write_suite(tmp_path)

--- a/tests/test_config_loaders.py
+++ b/tests/test_config_loaders.py
@@ -316,6 +316,82 @@ def test_suite_config_missing_testbench_raises(tmp_path):
         SuiteConfig(str(suite))
 
 
+def test_suite_config_duplicate_testbench_raises(tmp_path):
+    """Two testbenches with the same name in one tests.yaml is a hard
+    error — letting the dict-comprehension silently overwrite the
+    first one hides typos until later 'X not found' errors fire."""
+    body = """\
+rtl-buddy-filetype: test_config
+testbenches:
+  - name: tb1
+    filelist: [src/a.sv]
+  - name: tb1
+    filelist: [src/b.sv]
+tests: []
+"""
+    path = tmp_path / "tests.yaml"
+    path.write_text(body)
+    with pytest.raises(FatalRtlBuddyError, match="duplicate testbench name 'tb1'"):
+        SuiteConfig(str(path))
+
+
+def test_suite_config_duplicate_test_raises(tmp_path):
+    body = """\
+rtl-buddy-filetype: test_config
+testbenches:
+  - name: tb1
+    filelist: [src/a.sv]
+tests:
+  - name: basic
+    desc: example
+    model: m
+    model_path: models.yaml
+    reglvl:
+    plusargs:
+    plusdefines:
+    uvm:
+    preproc:
+    postproc:
+    sweep:
+    testbench: tb1
+    sim_timeout:
+  - name: basic
+    desc: collision
+    model: m
+    model_path: models.yaml
+    reglvl:
+    plusargs:
+    plusdefines:
+    uvm:
+    preproc:
+    postproc:
+    sweep:
+    testbench: tb1
+    sim_timeout:
+"""
+    path = tmp_path / "tests.yaml"
+    path.write_text(body)
+    with pytest.raises(FatalRtlBuddyError, match="duplicate test name 'basic'"):
+        SuiteConfig(str(path))
+
+
+def test_model_config_loader_duplicate_model_raises(tmp_path):
+    from rtl_buddy.config.model import ModelConfigLoader
+
+    body = """\
+rtl-buddy-filetype: model_config
+models:
+  - name: mod_a
+    filelist: [a.sv]
+  - name: mod_a
+    filelist: [b.sv]
+"""
+    path = tmp_path / "models.yaml"
+    path.write_text(body)
+    with pytest.raises(FatalRtlBuddyError, match="duplicate model name 'mod_a'"):
+        ModelConfigLoader(str(path))
+
+
 # ---------------------------------------------------------------------------
 # Project-root discovery
 # ---------------------------------------------------------------------------

--- a/tests/test_synth.py
+++ b/tests/test_synth.py
@@ -228,6 +228,37 @@ def test_synth_suite_config_params_and_defines_loaded(tmp_path):
     assert synth_b.get_defines() == {"TARGET_SYNTH": 1}
 
 
+def test_synth_suite_config_duplicate_synthesis_raises(tmp_path):
+    """Two syntheses with the same name in one synth.yaml is a hard
+    error — the dict-comprehension in SynthSuiteConfig.__init__
+    would silently overwrite the first one otherwise."""
+    from rtl_buddy.errors import FatalRtlBuddyError
+
+    models_yaml = tmp_path / "models.yaml"
+    models_yaml.write_text(_MODELS_YAML)
+    body = dedent("""\
+        rtl-buddy-filetype: synth_config
+
+        syntheses:
+          - name: "dup"
+            desc: "first"
+            model: "mod_a"
+            model_path: "models.yaml"
+            tool: "yosys"
+            reglvl: 0
+          - name: "dup"
+            desc: "second"
+            model: "mod_b"
+            model_path: "models.yaml"
+            tool: "yosys"
+            reglvl: 0
+    """)
+    path = tmp_path / "synth.yaml"
+    path.write_text(body)
+    with pytest.raises(FatalRtlBuddyError, match="duplicate synthesis name 'dup'"):
+        SynthSuiteConfig(str(path))
+
+
 def test_synth_suite_config_missing_name_raises(tmp_path):
     from rtl_buddy.errors import FatalRtlBuddyError
 


### PR DESCRIPTION
## Summary

Implements [#169](https://github.com/rtl-buddy/rtl_buddy/issues/169).

Four config loaders silently swallowed duplicate-name entries via dict-comprehension overwrite (or first-match-wins linear scan):

| File | Loader | Line |
| --- | --- | --- |
| \`models.yaml\` | \`ModelConfigLoader.__init__\` | \`model.py:113\` (lookup did not check, dups co-existed) |
| \`cdc.yaml\` | \`CdcSuiteConfig.__init__\` | \`cdc.py:203\` |
| \`synth.yaml\` | \`SynthSuiteConfig.__init__\` | \`synth.py:314\` |
| \`tests.yaml\` | \`SuiteConfig.__init__\` | \`suite.py:48, 61\` (both testbenches AND tests) |

Now each loader detects duplicates at load time and raises \`FatalRtlBuddyError\` with the file path + duplicated name. Log event is keyed with \`<config>.duplicate_<entity>\` and includes both indices for debugging.

## Behavioural change

Strictly stricter than today. Any project relying on the silent overwrite was already broken — the lost entry was unreachable. The new error tells them which name + which file to fix; no downstream behaviour change for valid configs.

## Test plan

- [x] \`uv run pytest tests/test_cdc.py tests/test_synth.py tests/test_config_loaders.py -q --no-cov\` — 146 pass (4 new dup-detection tests added).
- [x] \`uv run pytest -q --no-cov\` — 658 pass, 2 skipped, 2 pre-existing asyncio errors in \`test_wave_hub_bridge.py\` (unchanged on \`main\`, Python 3.14 test isolation).
- [x] \`uv run ruff check\` clean.
- [x] \`uv run ruff format --check\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)