### PR TITLE
config(model): cdc / synth / tests back-pointer fields

### DIFF
--- a/docs/reference/yaml.md
+++ b/docs/reference/yaml.md
@@ -219,6 +219,9 @@ models:
     filelist:
       - "-F my_design.f"
     spec: "../../spec/my_design/specs.yaml"
+    cdc:   "../../cdc/my_design/cdc.yaml"
+    synth: "../../synth/my_design/synth.yaml#fast"
+    tests: "../../verif/my_design/tests.yaml"
 ```
 
 **Optional fields:**
@@ -227,12 +230,16 @@ models:
 |-------|------|-------------|
 | `desc` | string | Human-readable model description |
 | `spec` | string | Path to the block's `specs.yaml`, relative to this `models.yaml` file. Used by `rb spec check-design` to link the design model to its specification. |
+| `cdc` | string | Path to the `cdc.yaml` that owns this model's CDC analysis, relative to this `models.yaml`. Optional `#analysis_name` fragment picks one analysis from a multi-analysis file (e.g. `cdc.yaml#full_design`). Read by `rb hub` to enable the clock-domain overlay; absent → overlay unavailable. |
+| `synth` | string | Path to the `synth.yaml` that owns this model's synthesis flow, relative to this `models.yaml`. Same `#synth_name` fragment semantics. Declared now for forward compatibility; no consumer reads it yet. |
+| `tests` | string | Path to the `tests.yaml` that owns this model's testbench/test suite, relative to this `models.yaml`. Same `#test_name` fragment semantics. Declared now for forward compatibility; no consumer reads it yet. |
 
 **Runtime effects:**
 
 - `tests.yaml` references a model by `name` using the `model` and `model_path` fields.
 - Model filelists are parsed by the filelist logic: `-F` recursion, `+incdir+`, `+libext+`, `-v`, `-y`, and plain source paths are all supported.
 - `spec` is not used at simulation time; it is only consumed by the `rb spec` traceability commands.
+- `cdc` / `synth` / `tests` are *back-pointers* — the downstream files still carry their own `model:` + `model_path:` references back to this one. The model-side entry is the source of truth for "which analysis owns this model" when there could otherwise be ambiguity (e.g. two `cdc.yaml` files reference the same model name).
 
 ---
 

--- a/src/rtl_buddy/config/model.py
+++ b/src/rtl_buddy/config/model.py
@@ -1,7 +1,7 @@
 import logging
+import os
 
 logger = logging.getLogger(__name__)
-import os
 import pprint
 
 from serde import serde, field
@@ -10,6 +10,48 @@ from typing import Literal
 
 from ..errors import FatalRtlBuddyError
 from ..logging_utils import log_event
+
+
+def split_back_pointer(value: str) -> tuple[str, str | None]:
+    """Split a ``cdc:``/``synth:``/``tests:`` back-pointer into
+    ``(path, entry_name | None)``.
+
+    The path side is the relative location of the downstream YAML
+    (resolved by the caller against the parent ``models.yaml``).
+    The optional ``#entry_name`` fragment names a single analysis /
+    synthesis / test inside that file — useful when one file holds
+    multiple and the model wants to pin one as canonical.
+    """
+    if "#" in value:
+        path, _, entry = value.partition("#")
+        entry = entry.strip()
+        return path, (entry if entry else None)
+    return value, None
+
+
+def resolve_back_pointer(
+    model: "ModelConfig", field_name: str
+) -> tuple[str, str | None] | None:
+    """Resolve ``model.<field_name>`` (one of ``cdc``/``synth``/``tests``)
+    into an absolute ``(path, entry_name | None)`` tuple.
+
+    Returns ``None`` when the field is unset on the model. Raises
+    ``FatalRtlBuddyError`` when the field is set but ``model.path``
+    is missing (loader didn't tag the model — programming error).
+    Delegates path resolution to ``ModelConfig._resolve_relative`` so
+    the cdc/synth/tests fields share semantics with the existing
+    ``axi_bundles`` / ``axi_monitor_out`` resolution.
+    """
+    raw = getattr(model, field_name, None)
+    if not raw:
+        return None
+    if not model.path:
+        raise FatalRtlBuddyError(
+            f"resolve_back_pointer: model {model.name!r} has no path "
+            f"attribute; cannot resolve {field_name}={raw!r}"
+        )
+    rel, entry = split_back_pointer(raw)
+    return model._resolve_relative(rel), entry
 
 
 @serde
@@ -30,6 +72,18 @@ class ModelConfig:
         SystemVerilog monitor file. Typically points into the verif
         testbench source tree so the file is picked up by the tb's
         filelist (e.g. ``../verif/soc_top/gen/axi_perf_mon.sv``).
+      cdc (str|None): Relative path from models.yaml to the cdc.yaml that owns
+        this model's CDC analysis. Optional ``#analysis_name`` fragment picks one
+        entry from a multi-analysis file (e.g. ``cdc.yaml#full_design``). Read by
+        ``rb hub`` to wire up the clock-domain overlay; absent → overlay
+        unavailable.
+      synth (str|None): Relative path from models.yaml to the synth.yaml that
+        owns this model's synthesis flow. Same ``#synth_name`` fragment semantics.
+        Not consumed by any tool yet — declared now so the schema doesn't churn
+        when future hub overlays (e.g. synthesis QoR) want to look it up.
+      tests (str|None): Relative path from models.yaml to the tests.yaml that
+        owns this model's testbench/test suite. Same ``#test_name`` fragment
+        semantics. Not consumed by any tool yet.
       path (str|None): Path to the model config file. Will usually be set by the loader.
     """
 
@@ -39,6 +93,9 @@ class ModelConfig:
     spec: str | None = None
     axi_bundles: str | None = None
     axi_monitor_out: str | None = None
+    cdc: str | None = None
+    synth: str | None = None
+    tests: str | None = None
     path: str | None = None
 
     def _resolve_relative(self, rel: str) -> str:

--- a/tests/test_config_loaders.py
+++ b/tests/test_config_loaders.py
@@ -394,6 +394,110 @@ models:
 
 
 # ---------------------------------------------------------------------------
+# ModelConfig back-pointers (cdc / synth / tests)
+# ---------------------------------------------------------------------------
+
+
+def test_model_config_back_pointers_default_to_none(tmp_path):
+    from rtl_buddy.config.model import ModelConfigLoader
+
+    body = """\
+rtl-buddy-filetype: model_config
+models:
+  - name: mod_a
+    filelist: [a.sv]
+"""
+    path = tmp_path / "models.yaml"
+    path.write_text(body)
+    loader = ModelConfigLoader(str(path))
+    mod = loader.get_model("mod_a")
+    assert mod.cdc is None
+    assert mod.synth is None
+    assert mod.tests is None
+
+
+def test_model_config_back_pointers_loaded(tmp_path):
+    from rtl_buddy.config.model import ModelConfigLoader
+
+    body = """\
+rtl-buddy-filetype: model_config
+models:
+  - name: mod_a
+    filelist: [a.sv]
+    cdc: cdc.yaml
+    synth: synth.yaml#fast
+    tests: tests.yaml#smoke
+"""
+    path = tmp_path / "models.yaml"
+    path.write_text(body)
+    loader = ModelConfigLoader(str(path))
+    mod = loader.get_model("mod_a")
+    assert mod.cdc == "cdc.yaml"
+    assert mod.synth == "synth.yaml#fast"
+    assert mod.tests == "tests.yaml#smoke"
+
+
+def test_split_back_pointer_no_fragment():
+    from rtl_buddy.config.model import split_back_pointer
+
+    assert split_back_pointer("cdc.yaml") == ("cdc.yaml", None)
+
+
+def test_split_back_pointer_with_fragment():
+    from rtl_buddy.config.model import split_back_pointer
+
+    assert split_back_pointer("cdc.yaml#full_design") == ("cdc.yaml", "full_design")
+
+
+def test_split_back_pointer_empty_fragment_is_none():
+    """``cdc.yaml#`` parses to ``("cdc.yaml", None)`` — an empty fragment
+    is treated as "no entry specified" rather than "entry named the empty
+    string", which would fail downstream lookups with a confusing error."""
+    from rtl_buddy.config.model import split_back_pointer
+
+    assert split_back_pointer("cdc.yaml#") == ("cdc.yaml", None)
+
+
+def test_resolve_back_pointer_absent_returns_none(tmp_path):
+    from rtl_buddy.config.model import ModelConfig, resolve_back_pointer
+
+    model = ModelConfig(name="m", filelist=[], path=str(tmp_path / "models.yaml"))
+    assert resolve_back_pointer(model, "cdc") is None
+
+
+def test_resolve_back_pointer_relative_to_models_yaml(tmp_path):
+    """``cdc: ../shared/cdc.yaml#foo`` from a models.yaml at
+    ``<root>/blocks/dma/models.yaml`` resolves to
+    ``<root>/blocks/shared/cdc.yaml``, entry ``foo``."""
+    from rtl_buddy.config.model import ModelConfig, resolve_back_pointer
+
+    models_path = tmp_path / "blocks" / "dma" / "models.yaml"
+    models_path.parent.mkdir(parents=True)
+    model = ModelConfig(
+        name="m",
+        filelist=[],
+        cdc="../shared/cdc.yaml#foo",
+        path=str(models_path),
+    )
+    resolved = resolve_back_pointer(model, "cdc")
+    assert resolved is not None
+    abs_path, entry = resolved
+    assert Path(abs_path) == tmp_path / "blocks" / "shared" / "cdc.yaml"
+    assert entry == "foo"
+
+
+def test_resolve_back_pointer_no_path_raises():
+    """A ModelConfig that the loader never tagged (no ``.path``) is a
+    programming error — ``resolve_back_pointer`` can't anchor the
+    relative cdc/synth/tests path without it."""
+    from rtl_buddy.config.model import ModelConfig, resolve_back_pointer
+
+    model = ModelConfig(name="m", filelist=[], cdc="cdc.yaml", path=None)
+    with pytest.raises(FatalRtlBuddyError, match="has no path"):
+        resolve_back_pointer(model, "cdc")
+
+
+# ---------------------------------------------------------------------------
 # Project-root discovery
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Implements [#168](https://github.com/rtl-buddy/rtl_buddy/issues/168). Stacks on top of [#170](https://github.com/rtl-buddy/rtl_buddy/pull/170) ([#169](https://github.com/rtl-buddy/rtl_buddy/issues/169)) — base branch is \`config/duplicate-name-detection\`; rebase onto \`main\` after #170 lands.

Adds three optional fields to \`ModelConfig\`:

| Field | Consumer (now) | Future consumers |
| --- | --- | --- |
| \`cdc:\` | \`rb hub\` clock overlay (#167) | — |
| \`synth:\` | none yet | synthesis-QoR overlay |
| \`tests:\` | none yet | regression-status overlay |

All three accept an optional \`#entry_name\` fragment for picking one entry from a multi-analysis file (e.g. \`cdc.yaml#full_design\`). Paths are relative to the parent \`models.yaml\`.

\`synth:\` and \`tests:\` land now without consumers so the schema doesn't churn when future hub overlays plug in. All three fields are optional → existing \`models.yaml\` files keep working unchanged.

## Helpers

- \`split_back_pointer(value)\` → \`(path, entry | None)\` — parses \`path#fragment\`.
- \`resolve_back_pointer(model, field_name)\` → \`(abs_path, entry | None) | None\` — resolves the field, anchoring the relative path against \`model.path\` (the loader sets this when it returns a \`ModelConfig\` via \`get_model\`).

## Docs

\`docs/reference/yaml.md\` updated with the new fields + a note that the downstream files still carry their own \`model: + model_path:\` references; the model-side back-pointer is the disambiguator when multiple downstreams could claim ownership.

## Test plan

- [x] \`uv run pytest tests/test_config_loaders.py tests/test_cdc.py tests/test_synth.py -q --no-cov\` — 154 pass (8 new back-pointer tests).
- [x] \`uv run ruff check\` clean.
- [x] \`uv run ruff format --check\` clean.
- [x] \`uv run python scripts/check_docs_frontmatter.py --check\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)