### PR TITLE
feat(hub): rb hub start --model NAME with project-tree discovery

### DIFF
--- a/docs/concepts/hub.md
+++ b/docs/concepts/hub.md
@@ -58,6 +58,27 @@ uv run rb hub stop                    # graceful shutdown via SIGTERM
 
 When the hub knows where to find a `view.json` (via `[mapping].view_json` in `hub.toml`, default `.rtl-buddy/view.json`), the viewer HTTP layer also serves it at `GET /view.json`. Open the SPA with `?view=/view.json` to auto-load the design — e.g. `http://127.0.0.1:<http_port>/?view=/view.json` — instead of drag-and-dropping the file. The index page also gets a `window.__RTL_BUDDY_VIEW_URL__ = "/view.json"` injection that a future SPA bootstrap can read directly without the query param. If the configured file is missing, `/view.json` returns 404 and the SPA falls back to the empty state.
 
+### Picking a model at start time (`--model NAME`)
+
+`--model NAME` tells the hub to generate `view.json` on the fly from a model entry in `models.yaml`, instead of relying on a pre-staged file:
+
+```bash
+rb hub start --serve-viewer --model ip_demo_tiny_npu
+```
+
+Resolution rules:
+
+- The hub walks the project tree for every `models.yaml` it can find (skipping common build/VCS directories) and looks for an entry named `NAME`.
+- Exactly one match → load it, generate `view.json` into `.rtl-buddy/cache/view-<model>.json`, serve it.
+- Zero matches → error with the list of model names per discovered `models.yaml` so a typo is easy to spot.
+- Two or more matches → error naming all the conflicting `models.yaml` paths. Pass `--models-file PATH` to disambiguate.
+
+`--models-file PATH` skips the discovery walk entirely and loads the model from the named file. Use it when you have multiple `models.yaml` files in the tree with overlapping names.
+
+`--model` requires `--serve-viewer` (the generated `view.json` is only useful as something the SPA HTTP layer can serve). Without `--serve-viewer` the hub errors at startup rather than silently discarding the generated file.
+
+The view.json regenerates on every `rb hub start --model` invocation. Cache invalidation isn't modelled yet — restart the hub to pick up source-tree changes.
+
 ## Discovery (`.rtl-buddy/hub.json`)
 
 When the hub binds, it writes a small JSON record under the project root's `.rtl-buddy/` directory:

--- a/docs/reference/yaml.md
+++ b/docs/reference/yaml.md
@@ -219,6 +219,9 @@ models:
     filelist:
       - "-F my_design.f"
     spec: "../../spec/my_design/specs.yaml"
+    cdc:   "../../cdc/my_design/cdc.yaml"
+    synth: "../../synth/my_design/synth.yaml#fast"
+    tests: "../../verif/my_design/tests.yaml"
 ```
 
 **Optional fields:**
@@ -227,12 +230,16 @@ models:
 |-------|------|-------------|
 | `desc` | string | Human-readable model description |
 | `spec` | string | Path to the block's `specs.yaml`, relative to this `models.yaml` file. Used by `rb spec check-design` to link the design model to its specification. |
+| `cdc` | string | Path to the `cdc.yaml` that owns this model's CDC analysis, relative to this `models.yaml`. Optional `#analysis_name` fragment picks one analysis from a multi-analysis file (e.g. `cdc.yaml#full_design`). Read by `rb hub` to enable the clock-domain overlay; absent → overlay unavailable. |
+| `synth` | string | Path to the `synth.yaml` that owns this model's synthesis flow, relative to this `models.yaml`. Same `#synth_name` fragment semantics. Declared now for forward compatibility; no consumer reads it yet. |
+| `tests` | string | Path to the `tests.yaml` that owns this model's testbench/test suite, relative to this `models.yaml`. Same `#test_name` fragment semantics. Declared now for forward compatibility; no consumer reads it yet. |
 
 **Runtime effects:**
 
 - `tests.yaml` references a model by `name` using the `model` and `model_path` fields.
 - Model filelists are parsed by the filelist logic: `-F` recursion, `+incdir+`, `+libext+`, `-v`, `-y`, and plain source paths are all supported.
 - `spec` is not used at simulation time; it is only consumed by the `rb spec` traceability commands.
+- `cdc` / `synth` / `tests` are *back-pointers* — the downstream files still carry their own `model:` + `model_path:` references back to this one. The model-side entry is the source of truth for "which analysis owns this model" when there could otherwise be ambiguity (e.g. two `cdc.yaml` files reference the same model name).
 
 ---
 

--- a/src/rtl_buddy/config/model.py
+++ b/src/rtl_buddy/config/model.py
@@ -1,7 +1,7 @@
 import logging
+import os
 
 logger = logging.getLogger(__name__)
-import os
 import pprint
 
 from serde import serde, field
@@ -10,6 +10,48 @@ from typing import Literal
 
 from ..errors import FatalRtlBuddyError
 from ..logging_utils import log_event
+
+
+def split_back_pointer(value: str) -> tuple[str, str | None]:
+    """Split a ``cdc:``/``synth:``/``tests:`` back-pointer into
+    ``(path, entry_name | None)``.
+
+    The path side is the relative location of the downstream YAML
+    (resolved by the caller against the parent ``models.yaml``).
+    The optional ``#entry_name`` fragment names a single analysis /
+    synthesis / test inside that file — useful when one file holds
+    multiple and the model wants to pin one as canonical.
+    """
+    if "#" in value:
+        path, _, entry = value.partition("#")
+        entry = entry.strip()
+        return path, (entry if entry else None)
+    return value, None
+
+
+def resolve_back_pointer(
+    model: "ModelConfig", field_name: str
+) -> tuple[str, str | None] | None:
+    """Resolve ``model.<field_name>`` (one of ``cdc``/``synth``/``tests``)
+    into an absolute ``(path, entry_name | None)`` tuple.
+
+    Returns ``None`` when the field is unset on the model. Raises
+    ``FatalRtlBuddyError`` when the field is set but ``model.path``
+    is missing (loader didn't tag the model — programming error).
+    Delegates path resolution to ``ModelConfig._resolve_relative`` so
+    the cdc/synth/tests fields share semantics with the existing
+    ``axi_bundles`` / ``axi_monitor_out`` resolution.
+    """
+    raw = getattr(model, field_name, None)
+    if not raw:
+        return None
+    if not model.path:
+        raise FatalRtlBuddyError(
+            f"resolve_back_pointer: model {model.name!r} has no path "
+            f"attribute; cannot resolve {field_name}={raw!r}"
+        )
+    rel, entry = split_back_pointer(raw)
+    return model._resolve_relative(rel), entry
 
 
 @serde
@@ -30,6 +72,18 @@ class ModelConfig:
         SystemVerilog monitor file. Typically points into the verif
         testbench source tree so the file is picked up by the tb's
         filelist (e.g. ``../verif/soc_top/gen/axi_perf_mon.sv``).
+      cdc (str|None): Relative path from models.yaml to the cdc.yaml that owns
+        this model's CDC analysis. Optional ``#analysis_name`` fragment picks one
+        entry from a multi-analysis file (e.g. ``cdc.yaml#full_design``). Read by
+        ``rb hub`` to wire up the clock-domain overlay; absent → overlay
+        unavailable.
+      synth (str|None): Relative path from models.yaml to the synth.yaml that
+        owns this model's synthesis flow. Same ``#synth_name`` fragment semantics.
+        Not consumed by any tool yet — declared now so the schema doesn't churn
+        when future hub overlays (e.g. synthesis QoR) want to look it up.
+      tests (str|None): Relative path from models.yaml to the tests.yaml that
+        owns this model's testbench/test suite. Same ``#test_name`` fragment
+        semantics. Not consumed by any tool yet.
       path (str|None): Path to the model config file. Will usually be set by the loader.
     """
 
@@ -39,6 +93,9 @@ class ModelConfig:
     spec: str | None = None
     axi_bundles: str | None = None
     axi_monitor_out: str | None = None
+    cdc: str | None = None
+    synth: str | None = None
+    tests: str | None = None
     path: str | None = None
 
     def _resolve_relative(self, rel: str) -> str:

--- a/src/rtl_buddy/hub/cli.py
+++ b/src/rtl_buddy/hub/cli.py
@@ -32,7 +32,9 @@ from . import config as hub_config
 from . import discovery
 from . import launchagent
 from . import loop as hub_loop
+from . import model_discovery as hub_model_discovery
 from . import status_client
+from . import view_builder as hub_view_builder
 
 
 logger = logging.getLogger(__name__)
@@ -124,6 +126,31 @@ def cmd_start(
             max=65535,
         ),
     ] = None,
+    model: Annotated[
+        str | None,
+        typer.Option(
+            "--model",
+            help=(
+                "Generate view.json on hub start for this model name (looked "
+                "up in models.yaml). Replaces the legacy workflow of running "
+                "`rb hier <model> --format json -o .rtl-buddy/view.json` "
+                "manually before each hub start. When unset the hub falls "
+                "back to [mapping].view_json from hub.toml. Requires "
+                "--serve-viewer."
+            ),
+        ),
+    ] = None,
+    models_file: Annotated[
+        Path | None,
+        typer.Option(
+            "--models-file",
+            help=(
+                "Explicit models.yaml that owns the --model entry. Skips the "
+                "project-tree discovery walk. Use this to disambiguate when "
+                "the same model name exists in more than one models.yaml."
+            ),
+        ),
+    ] = None,
 ) -> None:
     """Bind, write ``hub.json``, run the server loop.
 
@@ -144,6 +171,19 @@ def cmd_start(
     if viewer_bundle is not None and not serve_viewer:
         emit_console_text(
             "rb hub start --viewer-bundle: ignored without --serve-viewer.",
+            style="yellow",
+        )
+    if model is not None and not serve_viewer:
+        # The view.json is only served by the viewer HTTP layer;
+        # generating it without --serve-viewer would silently
+        # discard the work. Fail loud instead.
+        raise FatalRtlBuddyError(
+            "rb hub start --model: requires --serve-viewer "
+            "(the generated view.json is only served via the SPA HTTP layer)."
+        )
+    if models_file is not None and model is None:
+        emit_console_text(
+            "rb hub start --models-file: ignored without --model.",
             style="yellow",
         )
 
@@ -173,6 +213,24 @@ def cmd_start(
             existing.pid, discovery.discovery_path(project_root)
         )
 
+    # When --model is given, resolve and generate the view.json
+    # before the asyncio loop starts so a missing model or a tool
+    # failure surfaces synchronously with a clear error, not as a
+    # 404 the user discovers in the browser later.
+    view_json_override: Path | None = None
+    if model is not None:
+        _models_yaml, loader = hub_model_discovery.resolve_model(
+            project_root, model, models_file=models_file
+        )
+        model_cfg = loader.get_model(model)
+        view_json_override = hub_view_builder.build_view_json(
+            project_root=project_root, model_cfg=model_cfg
+        )
+        emit_console_text(
+            f"rb hub: generated view.json for {model!r} at {view_json_override}",
+            style="green",
+        )
+
     log_event(
         logger,
         logging.INFO,
@@ -183,6 +241,7 @@ def cmd_start(
         foreground=foreground,
         serve_viewer=serve_viewer,
         viewer_bundle=str(viewer_bundle) if viewer_bundle else "",
+        model=model or "",
     )
     raise typer.Exit(
         code=hub_loop.serve(
@@ -190,6 +249,7 @@ def cmd_start(
             cfg,
             serve_viewer=serve_viewer,
             viewer_bundle=viewer_bundle,
+            view_json_override=view_json_override,
         )
     )
 

--- a/src/rtl_buddy/hub/loop.py
+++ b/src/rtl_buddy/hub/loop.py
@@ -123,8 +123,14 @@ async def _run(
     *,
     serve_viewer: bool = False,
     viewer_bundle: Path | None = None,
+    view_json_override: Path | None = None,
 ) -> int:
-    if config.mapping.view_json:
+    if view_json_override is not None:
+        # ``rb hub start --model`` already resolved + generated the
+        # view.json before we got here. Use it as-is, ignoring
+        # hub.toml's [mapping].view_json — the CLI flag wins.
+        view_json_path = view_json_override
+    elif config.mapping.view_json:
         view_json_path = (project_root / config.mapping.view_json).resolve()
     else:
         view_json_path = default_view_json_path(project_root)
@@ -247,8 +253,15 @@ def serve(
     *,
     serve_viewer: bool = False,
     viewer_bundle: Path | None = None,
+    view_json_override: Path | None = None,
 ) -> int:
-    """Run the hub event loop until exit. Returns the process exit code."""
+    """Run the hub event loop until exit. Returns the process exit code.
+
+    ``view_json_override`` takes precedence over ``[mapping].view_json``
+    from hub.toml — used by ``rb hub start --model NAME`` to feed in
+    the freshly-generated cache path without touching the user's
+    hub.toml.
+    """
 
     try:
         return asyncio.run(
@@ -257,6 +270,7 @@ def serve(
                 config,
                 serve_viewer=serve_viewer,
                 viewer_bundle=viewer_bundle,
+                view_json_override=view_json_override,
             )
         )
     except _PortInUseError as exc:

--- a/src/rtl_buddy/hub/model_discovery.py
+++ b/src/rtl_buddy/hub/model_discovery.py
@@ -1,0 +1,187 @@
+"""Model discovery for ``rb hub start --model NAME``.
+
+Walks the project tree for ``models.yaml`` files, aggregates the
+named entries, and resolves a single match for the user-supplied
+``--model NAME`` (with optional ``--models-file`` override).
+
+Cross-file name collisions are explicit errors that point the user
+at ``--models-file PATH`` for disambiguation. This matches the
+contract spelled out in issue #167.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+from serde.yaml import from_yaml
+
+from ..config.model import ModelConfigFile, ModelConfigLoader
+from ..errors import FatalRtlBuddyError
+from ..logging_utils import log_event
+
+logger = logging.getLogger(__name__)
+
+
+# Directories we never descend into during the discovery walk. Build
+# artefacts and VCS metadata can contain copied YAML files (e.g.
+# example fixtures vendored under tests/), which would otherwise show
+# up as spurious matches.
+_SKIP_DIRS = frozenset(
+    {
+        ".git",
+        ".hg",
+        ".svn",
+        "node_modules",
+        "__pycache__",
+        ".venv",
+        "venv",
+        "artefacts",
+        "build",
+        "dist",
+        ".tox",
+        ".pytest_cache",
+        ".ruff_cache",
+        ".mypy_cache",
+    }
+)
+
+
+@dataclass(frozen=True)
+class ModelMatch:
+    """One ``--model NAME`` candidate during discovery."""
+
+    models_file: Path
+    model_name: str
+
+
+def discover_models_files(root: Path) -> list[Path]:
+    """Return every ``models.yaml`` reachable under ``root``.
+
+    Skips conventional build/VCS directories so vendored fixtures
+    don't pollute the candidate set. Order is deterministic
+    (alphabetical) so collision-error messages don't churn between
+    invocations.
+    """
+
+    results: list[Path] = []
+    for dirpath, dirnames, filenames in os.walk(root):
+        # Mutate dirnames in place so os.walk skips our excludes.
+        dirnames[:] = sorted(d for d in dirnames if d not in _SKIP_DIRS)
+        if "models.yaml" in filenames:
+            results.append(Path(dirpath) / "models.yaml")
+    return results
+
+
+def _read_model_names(path: Path) -> list[str]:
+    """Best-effort name extraction without full ``ModelConfigLoader``
+    validation — the discovery walk shouldn't fatal-error on a
+    sibling project's malformed models.yaml that the user isn't
+    asking about. Returns ``[]`` on parse failure (logged at DEBUG).
+    """
+
+    try:
+        data = from_yaml(ModelConfigFile, path.read_text())
+    except Exception as exc:
+        log_event(
+            logger,
+            logging.DEBUG,
+            "hub.model_discovery.parse_skipped",
+            path=str(path),
+            error=str(exc),
+        )
+        return []
+    return [m.name for m in data.models]
+
+
+def find_matches(models_files: list[Path], model_name: str) -> list[ModelMatch]:
+    """Return every ``(models_file, model_name)`` pair where ``models_file``
+    contains an entry named ``model_name``.
+    """
+
+    matches: list[ModelMatch] = []
+    for mf in models_files:
+        if model_name in _read_model_names(mf):
+            matches.append(ModelMatch(models_file=mf, model_name=model_name))
+    return matches
+
+
+def resolve_model(
+    root: Path,
+    model_name: str,
+    *,
+    models_file: Path | None = None,
+) -> tuple[Path, "ModelConfigLoader"]:
+    """Resolve ``model_name`` to the owning ``models.yaml`` + loader.
+
+    - ``models_file`` set → load directly, no discovery walk.
+    - ``models_file`` unset → walk the project root for every
+      ``models.yaml``. Error on zero or multiple matches.
+
+    Returns ``(models_yaml_path, ModelConfigLoader)``. The loader's
+    duplicate-name guard runs as part of construction (per #169).
+    """
+
+    if models_file is not None:
+        if not models_file.is_file():
+            raise FatalRtlBuddyError(f"--models-file {models_file}: not a file")
+        loader = ModelConfigLoader(str(models_file))
+        # Trigger lookup so a missing model name surfaces with the
+        # loader's own diagnostic.
+        loader.get_model(model_name)
+        return models_file, loader
+
+    models_files = discover_models_files(root)
+    if not models_files:
+        raise FatalRtlBuddyError(
+            f"no models.yaml found under {root}; "
+            f"use --models-file PATH to point at one explicitly"
+        )
+
+    matches = find_matches(models_files, model_name)
+    if len(matches) == 0:
+        # Build a sample list of names from every file so the user
+        # can see if they had a typo.
+        sample: list[str] = []
+        for mf in models_files:
+            for n in _read_model_names(mf):
+                sample.append(
+                    f"{mf.relative_to(root) if mf.is_relative_to(root) else mf}::{n}"
+                )
+        log_event(
+            logger,
+            logging.ERROR,
+            "hub.model_discovery.not_found",
+            model=model_name,
+            root=str(root),
+            candidates=sample,
+        )
+        candidates_msg = (
+            "\n  ".join(sample) if sample else "(no models defined in any file)"
+        )
+        raise FatalRtlBuddyError(
+            f"model {model_name!r} not found in any models.yaml under {root}.\n"
+            f"  candidates:\n  {candidates_msg}"
+        )
+
+    if len(matches) > 1:
+        paths_msg = "\n  ".join(str(m.models_file) for m in matches)
+        log_event(
+            logger,
+            logging.ERROR,
+            "hub.model_discovery.ambiguous",
+            model=model_name,
+            root=str(root),
+            matches=[str(m.models_file) for m in matches],
+        )
+        raise FatalRtlBuddyError(
+            f"model {model_name!r} matches multiple models.yaml files; "
+            f"pass --models-file PATH to disambiguate:\n  {paths_msg}"
+        )
+
+    chosen = matches[0]
+    loader = ModelConfigLoader(str(chosen.models_file))
+    loader.get_model(model_name)  # validate
+    return chosen.models_file, loader

--- a/src/rtl_buddy/hub/view_builder.py
+++ b/src/rtl_buddy/hub/view_builder.py
@@ -1,0 +1,99 @@
+"""On-demand view.json generator for ``rb hub start --model NAME``.
+
+Wraps the existing ``RtlBuddyView`` subprocess wrapper. Result is
+written to a stable path under ``<project_root>/.rtl-buddy/cache/``
+so the HTTP server's ``/view.json`` endpoint can find it
+deterministically across hub restarts. The (re)generation runs
+synchronously at hub start; cache invalidation isn't modelled here
+because rtl-buddy-view itself is fast enough on the demo designs we
+target (~1-3s) and "restart hub to refresh design" is the expected
+workflow.
+
+If/when on-demand re-generation per HTTP request becomes desirable
+(model picker, file-watch refresh), wrap this builder in a
+content-hash cache; the layout was chosen to make that drop-in.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+from pathlib import Path
+
+from ..config.model import ModelConfig
+from ..errors import FatalRtlBuddyError
+from ..logging_utils import log_event
+from ..tools.hier_rtl_buddy_view import RtlBuddyView
+
+logger = logging.getLogger(__name__)
+
+
+def cache_dir(project_root: Path) -> Path:
+    """Cache lives under ``.rtl-buddy/cache/`` so it sits next to
+    hub.toml + hub.log — one project-local directory,
+    .gitignore-friendly via existing ``.rtl-buddy/`` ignores."""
+    return project_root / ".rtl-buddy" / "cache"
+
+
+def view_json_path(project_root: Path, model_name: str) -> Path:
+    """Per-model output path. Stable so the SPA's ``/view.json``
+    request always hits the same file regardless of generation state.
+    """
+    return cache_dir(project_root) / f"view-{model_name}.json"
+
+
+def _resolve_viewer_executable() -> str:
+    """Locate the ``rtl-buddy-view`` binary or raise a clear error.
+    Same lookup convention as ``RtlBuddyView.run``.
+    """
+    exe = shutil.which("rtl-buddy-view")
+    if exe is None:
+        raise FatalRtlBuddyError(
+            "rb hub --model: 'rtl-buddy-view' not found on PATH. "
+            "Install rtl-buddy-view into the active venv "
+            "(`uv add rtl-buddy-view` or `pip install rtl-buddy-view`)."
+        )
+    return exe
+
+
+def build_view_json(
+    *,
+    project_root: Path,
+    model_cfg: ModelConfig,
+) -> Path:
+    """Generate view.json for ``model_cfg`` at the stable cache path
+    and return it. Raises ``FatalRtlBuddyError`` when the
+    rtl-buddy-view subprocess fails — the hub treats a missing
+    view.json as a fatal startup error, not a degraded mode.
+    """
+
+    cache = cache_dir(project_root)
+    cache.mkdir(parents=True, exist_ok=True)
+    out_path = view_json_path(project_root, model_cfg.name)
+
+    viewer_exe = _resolve_viewer_executable()
+
+    log_event(
+        logger,
+        logging.INFO,
+        "hub.view_builder.generating",
+        model=model_cfg.name,
+        path=str(out_path),
+    )
+    runner = RtlBuddyView(
+        name=f"hub/view/{model_cfg.name}",
+        model_cfg=model_cfg,
+        suite_dir=str(project_root),
+        format="json",
+        output=str(out_path),
+        executable=viewer_exe,
+    )
+    rc = runner.run()
+    if rc != 0 or not out_path.is_file():
+        raise FatalRtlBuddyError(
+            f"rb hub --model {model_cfg.name}: rtl-buddy-view exited with "
+            f"code {rc}; see {Path(runner.artefact_dir) / 'hier.log'} for "
+            f"details."
+        )
+
+    return out_path

--- a/tests/test_config_loaders.py
+++ b/tests/test_config_loaders.py
@@ -394,6 +394,110 @@ models:
 
 
 # ---------------------------------------------------------------------------
+# ModelConfig back-pointers (cdc / synth / tests)
+# ---------------------------------------------------------------------------
+
+
+def test_model_config_back_pointers_default_to_none(tmp_path):
+    from rtl_buddy.config.model import ModelConfigLoader
+
+    body = """\
+rtl-buddy-filetype: model_config
+models:
+  - name: mod_a
+    filelist: [a.sv]
+"""
+    path = tmp_path / "models.yaml"
+    path.write_text(body)
+    loader = ModelConfigLoader(str(path))
+    mod = loader.get_model("mod_a")
+    assert mod.cdc is None
+    assert mod.synth is None
+    assert mod.tests is None
+
+
+def test_model_config_back_pointers_loaded(tmp_path):
+    from rtl_buddy.config.model import ModelConfigLoader
+
+    body = """\
+rtl-buddy-filetype: model_config
+models:
+  - name: mod_a
+    filelist: [a.sv]
+    cdc: cdc.yaml
+    synth: synth.yaml#fast
+    tests: tests.yaml#smoke
+"""
+    path = tmp_path / "models.yaml"
+    path.write_text(body)
+    loader = ModelConfigLoader(str(path))
+    mod = loader.get_model("mod_a")
+    assert mod.cdc == "cdc.yaml"
+    assert mod.synth == "synth.yaml#fast"
+    assert mod.tests == "tests.yaml#smoke"
+
+
+def test_split_back_pointer_no_fragment():
+    from rtl_buddy.config.model import split_back_pointer
+
+    assert split_back_pointer("cdc.yaml") == ("cdc.yaml", None)
+
+
+def test_split_back_pointer_with_fragment():
+    from rtl_buddy.config.model import split_back_pointer
+
+    assert split_back_pointer("cdc.yaml#full_design") == ("cdc.yaml", "full_design")
+
+
+def test_split_back_pointer_empty_fragment_is_none():
+    """``cdc.yaml#`` parses to ``("cdc.yaml", None)`` — an empty fragment
+    is treated as "no entry specified" rather than "entry named the empty
+    string", which would fail downstream lookups with a confusing error."""
+    from rtl_buddy.config.model import split_back_pointer
+
+    assert split_back_pointer("cdc.yaml#") == ("cdc.yaml", None)
+
+
+def test_resolve_back_pointer_absent_returns_none(tmp_path):
+    from rtl_buddy.config.model import ModelConfig, resolve_back_pointer
+
+    model = ModelConfig(name="m", filelist=[], path=str(tmp_path / "models.yaml"))
+    assert resolve_back_pointer(model, "cdc") is None
+
+
+def test_resolve_back_pointer_relative_to_models_yaml(tmp_path):
+    """``cdc: ../shared/cdc.yaml#foo`` from a models.yaml at
+    ``<root>/blocks/dma/models.yaml`` resolves to
+    ``<root>/blocks/shared/cdc.yaml``, entry ``foo``."""
+    from rtl_buddy.config.model import ModelConfig, resolve_back_pointer
+
+    models_path = tmp_path / "blocks" / "dma" / "models.yaml"
+    models_path.parent.mkdir(parents=True)
+    model = ModelConfig(
+        name="m",
+        filelist=[],
+        cdc="../shared/cdc.yaml#foo",
+        path=str(models_path),
+    )
+    resolved = resolve_back_pointer(model, "cdc")
+    assert resolved is not None
+    abs_path, entry = resolved
+    assert Path(abs_path) == tmp_path / "blocks" / "shared" / "cdc.yaml"
+    assert entry == "foo"
+
+
+def test_resolve_back_pointer_no_path_raises():
+    """A ModelConfig that the loader never tagged (no ``.path``) is a
+    programming error — ``resolve_back_pointer`` can't anchor the
+    relative cdc/synth/tests path without it."""
+    from rtl_buddy.config.model import ModelConfig, resolve_back_pointer
+
+    model = ModelConfig(name="m", filelist=[], cdc="cdc.yaml", path=None)
+    with pytest.raises(FatalRtlBuddyError, match="has no path"):
+        resolve_back_pointer(model, "cdc")
+
+
+# ---------------------------------------------------------------------------
 # Project-root discovery
 # ---------------------------------------------------------------------------
 

--- a/tests/test_hub_cli.py
+++ b/tests/test_hub_cli.py
@@ -157,6 +157,81 @@ def test_start_runs_preflight_only_when_blocked(runner: CliRunner, project_root:
     assert "already running" in str(result.exception)
 
 
+def test_start_model_requires_serve_viewer(runner: CliRunner, project_root: Path):
+    """``--model`` without ``--serve-viewer`` is a configuration error
+    — the generated view.json is only served by the SPA HTTP layer,
+    so producing it without ``--serve-viewer`` would be silent waste."""
+    result = runner.invoke(hub_app, ["start", "--model", "demo"])
+    assert result.exit_code != 0
+    assert "requires --serve-viewer" in str(result.exception)
+
+
+def test_start_models_file_without_model_warns(
+    runner: CliRunner, project_root: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """``--models-file`` is only meaningful as a disambiguator for
+    ``--model``. Used alone it's almost certainly a mistake."""
+    # Use a live-record block so cmd_start exits before reaching
+    # serve(); we just want to observe the warning emitted by the
+    # preamble.
+    discovery.write_record(
+        project_root,
+        pid=os.getpid(),
+        tcp="127.0.0.1:65001",
+        server_version="0.0.0+test",
+    )
+    result = runner.invoke(
+        hub_app, ["start", "--models-file", str(project_root / "missing.yaml")]
+    )
+    assert "--models-file: ignored without --model" in result.output
+
+
+def test_start_model_resolves_and_generates_view_json(
+    runner: CliRunner,
+    project_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Happy path: discovery finds the models.yaml, the (mocked)
+    view-builder writes view.json at the cache path, and serve() is
+    invoked with that override. We block at serve() so we don't have
+    to actually run the asyncio loop in CliRunner."""
+    (project_root / "models.yaml").write_text(
+        "rtl-buddy-filetype: model_config\nmodels:\n  - name: demo\n    filelist: []\n"
+    )
+    served_with = {}
+
+    def fake_serve(*args, **kwargs):
+        served_with["kwargs"] = kwargs
+        return 0
+
+    from rtl_buddy.hub import cli as hub_cli
+    from rtl_buddy.hub import view_builder as hub_view_builder
+
+    monkeypatch.setattr(hub_cli.hub_loop, "serve", fake_serve)
+    # Pretend rtl-buddy-view is on PATH and writes a JSON blob.
+    monkeypatch.setattr(
+        hub_view_builder.shutil, "which", lambda _: "/fake/rtl-buddy-view"
+    )
+
+    class FakeRunner:
+        def __init__(self, **kwargs):
+            self.artefact_dir = str(project_root / "artefacts" / "hier" / "demo")
+            Path(self.artefact_dir).mkdir(parents=True, exist_ok=True)
+            self._out = Path(kwargs["output"])
+
+        def run(self) -> int:
+            self._out.write_text('{"schema_version": "1.0", "top": "demo"}')
+            return 0
+
+    monkeypatch.setattr(hub_view_builder, "RtlBuddyView", FakeRunner)
+
+    result = runner.invoke(hub_app, ["start", "--serve-viewer", "--model", "demo"])
+    assert result.exit_code == 0, result.output
+    expected_path = project_root / ".rtl-buddy" / "cache" / "view-demo.json"
+    assert expected_path.is_file()
+    assert served_with["kwargs"]["view_json_override"] == expected_path
+
+
 def test_log_missing_file(runner: CliRunner, project_root: Path):
     result = runner.invoke(hub_app, ["log"])
     assert result.exit_code == 1, result.output

--- a/tests/test_hub_model_discovery.py
+++ b/tests/test_hub_model_discovery.py
@@ -1,0 +1,162 @@
+"""Tests for ``rb hub`` model discovery + resolution.
+
+Covers the discovery walk, name-collision error path, and the
+explicit ``--models-file`` override behaviour. The hub-side
+view-builder is mocked out — these tests pin the discovery contract
+without needing the rtl-buddy-view binary installed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+from rtl_buddy.errors import FatalRtlBuddyError
+from rtl_buddy.hub import model_discovery
+
+
+_MODELS_YAML_A = dedent("""\
+    rtl-buddy-filetype: model_config
+    models:
+      - name: alpha
+        filelist: [src/a.sv]
+      - name: beta
+        filelist: [src/b.sv]
+""")
+
+_MODELS_YAML_B = dedent("""\
+    rtl-buddy-filetype: model_config
+    models:
+      - name: beta
+        filelist: [other/b.sv]
+      - name: gamma
+        filelist: [other/c.sv]
+""")
+
+
+def _write_models(path: Path, body: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body)
+    return path
+
+
+def test_discover_models_files_finds_yaml_in_tree(tmp_path):
+    _write_models(tmp_path / "block_a" / "models.yaml", _MODELS_YAML_A)
+    _write_models(tmp_path / "block_b" / "deep" / "models.yaml", _MODELS_YAML_B)
+    found = model_discovery.discover_models_files(tmp_path)
+    assert sorted(p.relative_to(tmp_path) for p in found) == [
+        Path("block_a/models.yaml"),
+        Path("block_b/deep/models.yaml"),
+    ]
+
+
+def test_discover_models_files_skips_excluded_dirs(tmp_path):
+    """A models.yaml under .git/ / artefacts/ / node_modules/ is
+    fixture / vendored data, not a real candidate."""
+    _write_models(tmp_path / "block_a" / "models.yaml", _MODELS_YAML_A)
+    _write_models(tmp_path / ".git" / "models.yaml", _MODELS_YAML_B)
+    _write_models(tmp_path / "artefacts" / "models.yaml", _MODELS_YAML_B)
+    _write_models(tmp_path / "node_modules" / "models.yaml", _MODELS_YAML_B)
+    found = model_discovery.discover_models_files(tmp_path)
+    assert [p.relative_to(tmp_path) for p in found] == [Path("block_a/models.yaml")]
+
+
+def test_discover_models_files_returns_alphabetical_order(tmp_path):
+    """Order matters for collision-error messages — must be stable."""
+    _write_models(tmp_path / "z_block" / "models.yaml", _MODELS_YAML_A)
+    _write_models(tmp_path / "a_block" / "models.yaml", _MODELS_YAML_A)
+    _write_models(tmp_path / "m_block" / "models.yaml", _MODELS_YAML_A)
+    found = model_discovery.discover_models_files(tmp_path)
+    rel = [p.relative_to(tmp_path) for p in found]
+    assert rel == sorted(rel)
+
+
+def test_find_matches_returns_all_files_with_name(tmp_path):
+    mf_a = _write_models(tmp_path / "block_a" / "models.yaml", _MODELS_YAML_A)
+    mf_b = _write_models(tmp_path / "block_b" / "models.yaml", _MODELS_YAML_B)
+    matches = model_discovery.find_matches([mf_a, mf_b], "beta")
+    assert sorted(m.models_file for m in matches) == sorted([mf_a, mf_b])
+
+
+def test_find_matches_zero_when_name_absent(tmp_path):
+    mf_a = _write_models(tmp_path / "block_a" / "models.yaml", _MODELS_YAML_A)
+    matches = model_discovery.find_matches([mf_a], "no_such_model")
+    assert matches == []
+
+
+def test_find_matches_tolerates_malformed_yaml(tmp_path):
+    """A parse error in a sibling models.yaml shouldn't blow up the
+    walk — we just don't return it as a match candidate."""
+    mf_good = _write_models(tmp_path / "block_a" / "models.yaml", _MODELS_YAML_A)
+    mf_bad = _write_models(
+        tmp_path / "block_b" / "models.yaml", "not: a valid: schema\n"
+    )
+    matches = model_discovery.find_matches([mf_good, mf_bad], "alpha")
+    assert [m.models_file for m in matches] == [mf_good]
+
+
+# ---------------------------------------------------------------------------
+# resolve_model — the main public entry point
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_model_with_explicit_models_file(tmp_path):
+    """``--models-file PATH`` skips discovery and loads the named file."""
+    mf = _write_models(tmp_path / "block_a" / "models.yaml", _MODELS_YAML_A)
+    _write_models(tmp_path / "block_b" / "models.yaml", _MODELS_YAML_B)  # ignored
+    chosen, loader = model_discovery.resolve_model(tmp_path, "beta", models_file=mf)
+    assert chosen == mf
+    assert loader.get_model("beta").name == "beta"
+
+
+def test_resolve_model_explicit_models_file_missing_model_raises(tmp_path):
+    mf = _write_models(tmp_path / "block_a" / "models.yaml", _MODELS_YAML_A)
+    with pytest.raises(FatalRtlBuddyError, match="not found"):
+        model_discovery.resolve_model(tmp_path, "no_such", models_file=mf)
+
+
+def test_resolve_model_explicit_models_file_does_not_exist_raises(tmp_path):
+    with pytest.raises(FatalRtlBuddyError, match="not a file"):
+        model_discovery.resolve_model(
+            tmp_path, "alpha", models_file=tmp_path / "missing.yaml"
+        )
+
+
+def test_resolve_model_single_match_via_discovery(tmp_path):
+    _write_models(tmp_path / "block_a" / "models.yaml", _MODELS_YAML_A)
+    _write_models(tmp_path / "block_b" / "models.yaml", _MODELS_YAML_B)
+    chosen, loader = model_discovery.resolve_model(tmp_path, "alpha")
+    assert chosen == tmp_path / "block_a" / "models.yaml"
+    assert loader.get_model("alpha").name == "alpha"
+
+
+def test_resolve_model_zero_matches_raises_with_candidates(tmp_path):
+    _write_models(tmp_path / "block_a" / "models.yaml", _MODELS_YAML_A)
+    with pytest.raises(FatalRtlBuddyError) as excinfo:
+        model_discovery.resolve_model(tmp_path, "no_such_model")
+    msg = str(excinfo.value)
+    assert "no_such_model" in msg
+    # candidates listing helps the user spot a typo
+    assert "alpha" in msg
+    assert "beta" in msg
+
+
+def test_resolve_model_ambiguous_match_raises_with_paths(tmp_path):
+    """``beta`` lives in both files → error names both paths and
+    points at --models-file as the fix."""
+    mf_a = _write_models(tmp_path / "block_a" / "models.yaml", _MODELS_YAML_A)
+    mf_b = _write_models(tmp_path / "block_b" / "models.yaml", _MODELS_YAML_B)
+    with pytest.raises(FatalRtlBuddyError) as excinfo:
+        model_discovery.resolve_model(tmp_path, "beta")
+    msg = str(excinfo.value)
+    assert "beta" in msg
+    assert str(mf_a) in msg
+    assert str(mf_b) in msg
+    assert "--models-file" in msg
+
+
+def test_resolve_model_no_models_yaml_anywhere_raises(tmp_path):
+    with pytest.raises(FatalRtlBuddyError, match="no models.yaml found"):
+        model_discovery.resolve_model(tmp_path, "alpha")

--- a/tests/test_hub_view_builder.py
+++ b/tests/test_hub_view_builder.py
@@ -1,0 +1,116 @@
+"""Tests for ``rb hub`` view.json builder.
+
+The real generation invokes ``rtl-buddy-view`` (the external viewer
+binary) which we don't want to require in CI. We mock the
+``RtlBuddyView`` subprocess wrapper, so these tests only pin the
+plumbing: cache layout, executable-missing error path, and exit-code
+handling.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from rtl_buddy.config.model import ModelConfig
+from rtl_buddy.errors import FatalRtlBuddyError
+from rtl_buddy.hub import view_builder
+
+
+def _model(tmp_path: Path) -> ModelConfig:
+    return ModelConfig(name="demo", filelist=[], path=str(tmp_path / "models.yaml"))
+
+
+def test_cache_dir_under_rtl_buddy_subdir(tmp_path):
+    assert view_builder.cache_dir(tmp_path) == tmp_path / ".rtl-buddy" / "cache"
+
+
+def test_view_json_path_stable_per_model(tmp_path):
+    assert (
+        view_builder.view_json_path(tmp_path, "demo")
+        == tmp_path / ".rtl-buddy" / "cache" / "view-demo.json"
+    )
+
+
+def test_build_view_json_missing_viewer_binary_raises(tmp_path, monkeypatch):
+    """``rtl-buddy-view`` not on PATH → fatal error at hub start, not
+    at first HTTP request."""
+    monkeypatch.setattr(view_builder.shutil, "which", lambda _: None)
+    with pytest.raises(FatalRtlBuddyError, match="not found on PATH"):
+        view_builder.build_view_json(project_root=tmp_path, model_cfg=_model(tmp_path))
+
+
+def test_build_view_json_success_writes_to_stable_path(tmp_path, monkeypatch):
+    """When the subprocess wrapper exits 0 and writes the JSON, the
+    builder returns the stable cache path."""
+    monkeypatch.setattr(view_builder.shutil, "which", lambda _: "/fake/rtl-buddy-view")
+
+    captured = {}
+
+    class FakeRunner:
+        def __init__(self, **kwargs):
+            captured["kwargs"] = kwargs
+            self.artefact_dir = str(tmp_path / "artefacts" / "hier" / "demo")
+            Path(self.artefact_dir).mkdir(parents=True, exist_ok=True)
+
+        def run(self) -> int:
+            # Pretend rtl-buddy-view wrote the file.
+            out = Path(captured["kwargs"]["output"])
+            out.parent.mkdir(parents=True, exist_ok=True)
+            out.write_text('{"schema_version": "1.0", "top": "demo", "nodes": []}')
+            return 0
+
+    monkeypatch.setattr(view_builder, "RtlBuddyView", FakeRunner)
+
+    result = view_builder.build_view_json(
+        project_root=tmp_path, model_cfg=_model(tmp_path)
+    )
+    assert result == view_builder.view_json_path(tmp_path, "demo")
+    assert result.is_file()
+    # Verify the wrapper got configured for JSON output at the cache
+    # path — covers the contract the builder makes with RtlBuddyView.
+    assert captured["kwargs"]["format"] == "json"
+    assert captured["kwargs"]["output"] == str(result)
+    assert captured["kwargs"]["executable"] == "/fake/rtl-buddy-view"
+
+
+def test_build_view_json_subprocess_failure_raises(tmp_path, monkeypatch):
+    """Non-zero exit from rtl-buddy-view → fatal error referencing the
+    log file (rtl-buddy-view's hier.log under artefacts/)."""
+    monkeypatch.setattr(view_builder.shutil, "which", lambda _: "/fake/rtl-buddy-view")
+
+    class FailingRunner:
+        def __init__(self, **kwargs):
+            self.artefact_dir = str(tmp_path / "artefacts" / "hier" / "demo")
+            Path(self.artefact_dir).mkdir(parents=True, exist_ok=True)
+            (Path(self.artefact_dir) / "hier.log").write_text("$ rtl-buddy-view ...\n")
+
+        def run(self) -> int:
+            return 7
+
+    monkeypatch.setattr(view_builder, "RtlBuddyView", FailingRunner)
+
+    with pytest.raises(FatalRtlBuddyError, match=r"hier\.log"):
+        view_builder.build_view_json(project_root=tmp_path, model_cfg=_model(tmp_path))
+
+
+def test_build_view_json_creates_cache_dir(tmp_path, monkeypatch):
+    """The .rtl-buddy/cache directory may not exist yet on a fresh
+    project — the builder should create it."""
+    assert not view_builder.cache_dir(tmp_path).exists()
+    monkeypatch.setattr(view_builder.shutil, "which", lambda _: "/fake/rtl-buddy-view")
+
+    class FakeRunner:
+        def __init__(self, **kwargs):
+            self.artefact_dir = str(tmp_path / "artefacts" / "hier" / "demo")
+            Path(self.artefact_dir).mkdir(parents=True, exist_ok=True)
+            self._out = Path(kwargs["output"])
+
+        def run(self) -> int:
+            self._out.write_text("{}")
+            return 0
+
+    monkeypatch.setattr(view_builder, "RtlBuddyView", FakeRunner)
+    view_builder.build_view_json(project_root=tmp_path, model_cfg=_model(tmp_path))
+    assert view_builder.cache_dir(tmp_path).is_dir()


### PR DESCRIPTION
## Summary

Implements [#167](https://github.com/rtl-buddy/rtl_buddy/issues/167). Stacks on [#171](https://github.com/rtl-buddy/rtl_buddy/pull/171) ([#168](https://github.com/rtl-buddy/rtl_buddy/issues/168)) which stacks on [#170](https://github.com/rtl-buddy/rtl_buddy/pull/170) ([#169](https://github.com/rtl-buddy/rtl_buddy/issues/169)). Rebase down the stack as each base merges.

\`\`\`bash
rb hub start --serve-viewer --model ip_demo_tiny_npu
# or, when names collide:
rb hub start --serve-viewer --model dma --models-file design/dma/models.yaml
\`\`\`

## What lands

- **\`rb hub start --model NAME\`** — at start-up the hub:
  1. Walks the project tree for every \`models.yaml\` (skipping \`.git\`, \`artefacts\`, \`node_modules\`, etc.; alphabetical for stable error messages).
  2. Picks the entry named \`NAME\`. Zero matches → error with the candidates list per file. Multiple matches → error naming all conflicting files + pointing at \`--models-file PATH\`.
  3. Invokes the existing \`RtlBuddyView\` subprocess wrapper to generate \`view.json\` into \`.rtl-buddy/cache/view-<model>.json\`.
  4. Feeds that path through \`serve()\` as a \`view_json_override\` that wins over \`hub.toml [mapping].view_json\`.

- **\`--models-file PATH\`** — skips the discovery walk and loads from the named file. Required when there's a cross-file collision.

- **\`--model\` requires \`--serve-viewer\`** — generated view.json is only useful as something the SPA HTTP layer can serve; failing loud beats silent waste.

## Out of scope

- **Cache invalidation** — view.json regenerates on every hub start. rtl-buddy-view runs in ~1-3s on the demo designs, and "restart hub to refresh" is the expected workflow until the SPA model picker (rtl-buddy-view#72 Part 2) wants on-demand per-request generation.
- **\`--model-config\` overrides** — for selecting a different cdc/synth/tests entry per the back-pointers in [#168](https://github.com/rtl-buddy/rtl_buddy/pull/171). Separate issue when an overlay feature actually consumes them.

## Test plan

- [x] \`uv run pytest tests/test_hub_cli.py tests/test_hub_model_discovery.py tests/test_hub_view_builder.py -q --no-cov\` — 35 pass.
- [x] \`uv run pytest -q --no-cov\` — 688 pass, 2 skipped, 2 pre-existing asyncio errors in \`test_wave_hub_bridge.py\`.
- [x] \`uv run ruff check\` + \`uv run ruff format --check\` clean.
- [x] \`uv run python scripts/check_docs_frontmatter.py --check\` clean.
- [x] \`docs/concepts/hub.md\` updated with the new flag + discovery semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)