### PR TITLE
feat(hub): wire models.yaml cdc back-pointer through to clock overlay

### DIFF
--- a/docs/concepts/hub.md
+++ b/docs/concepts/hub.md
@@ -79,6 +79,28 @@ Resolution rules:
 
 The view.json regenerates on every `rb hub start --model` invocation. Cache invalidation isn't modelled yet — restart the hub to pick up source-tree changes.
 
+### Clock-domain overlay (`cdc:` back-pointer)
+
+When the chosen model's `models.yaml` entry has a `cdc:` field, the hub also generates a clock-domain map and feeds it to the view-builder as `--cdc-annotations`:
+
+```yaml
+# models.yaml
+rtl-buddy-filetype: model_config
+models:
+  - name: ip_demo_tiny_npu
+    filelist: [...]
+    cdc: cdc.yaml          # or cdc.yaml#analysis_name to pin one analysis
+```
+
+The hub:
+
+1. Resolves the `cdc:` back-pointer to a `cdc.yaml` file.
+2. Picks the analysis — either the one named by the optional `#fragment`, or the one whose `model:` field matches the model name. Ambiguity is a hard error (the message tells you to add a `#fragment`).
+3. Invokes `rtl-buddy-cdc lint --emit-domain-map .rtl-buddy/cache/domain-<model>.json ...` with the analysis's SDC + waivers.
+4. Passes the resulting domain map to `rtl-buddy-view --cdc-annotations`. The clock overlay toggle in the SPA then has data to render.
+
+Models without a `cdc:` field skip this step entirely — view.json is generated without overlays and the toggle stays dark. `rtl-buddy-cdc` must be on `PATH` when the `cdc:` field is present; absence is a hub-start error (no silent dark toggle).
+
 ## Discovery (`.rtl-buddy/hub.json`)
 
 When the hub binds, it writes a small JSON record under the project root's `.rtl-buddy/` directory:

--- a/src/rtl_buddy/hub/cdc_builder.py
+++ b/src/rtl_buddy/hub/cdc_builder.py
@@ -1,0 +1,255 @@
+"""On-demand domain_map.json generator for ``rb hub`` clock overlay.
+
+When a ``ModelConfig.cdc`` back-pointer is set (#168 schema), the hub
+invokes ``rtl-buddy-cdc lint --emit-domain-map ...`` to produce the
+clock-domain map that ``rtl-buddy-view --cdc-annotations`` consumes.
+The result is then baked into ``view.json`` and the SPA's clock
+overlay toggle works without further configuration.
+
+Two stages:
+
+  1. Resolve the back-pointer (``models.yaml::entry.cdc``) → load
+     the named ``cdc.yaml`` and pick the right analysis. The
+     fragment (``cdc.yaml#analysis_name``) wins when present;
+     otherwise we find the analysis whose ``model:`` field matches
+     ``model_cfg.name``.
+  2. Run ``rtl-buddy-cdc lint`` with ``--emit-domain-map`` plus the
+     SDC + waivers from the analysis, writing the domain map into
+     ``.rtl-buddy/cache/domain-<model>.json``. Lint output itself is
+     discarded — the hub doesn't surface CDC violations, only the
+     overlay.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+from ..config.cdc import CdcConfig, CdcSuiteConfig
+from ..config.model import ModelConfig, resolve_back_pointer
+from ..errors import FatalRtlBuddyError
+from ..logging_utils import log_event
+from ..tools.vlog_filelist import VlogFilelist
+from .view_builder import cache_dir
+
+logger = logging.getLogger(__name__)
+
+
+def domain_map_path(project_root: Path, model_name: str) -> Path:
+    """Stable cache path for the model's domain map.
+
+    Mirrors ``view_builder.view_json_path`` so the two cache files
+    sit next to each other under ``.rtl-buddy/cache/``.
+    """
+    return cache_dir(project_root) / f"domain-{model_name}.json"
+
+
+def _resolve_cdc_analysis(model_cfg: ModelConfig) -> CdcConfig | None:
+    """Resolve ``model_cfg.cdc`` back-pointer to a ``CdcConfig``.
+
+    Returns ``None`` when the back-pointer is unset (no overlay
+    requested). Raises ``FatalRtlBuddyError`` when the back-pointer
+    is set but the referenced file / analysis can't be loaded —
+    failing loud at hub start beats a silent dark overlay.
+    """
+    resolved = resolve_back_pointer(model_cfg, "cdc")
+    if resolved is None:
+        return None
+    cdc_yaml_path, analysis_name = resolved
+    if not Path(cdc_yaml_path).is_file():
+        raise FatalRtlBuddyError(
+            f"model {model_cfg.name!r} cdc back-pointer points at "
+            f"{cdc_yaml_path}: file does not exist"
+        )
+
+    suite = CdcSuiteConfig(cdc_yaml_path)
+
+    # If the back-pointer carried a ``#analysis_name`` fragment,
+    # honour it verbatim — the model author picked one specific
+    # analysis as canonical.
+    if analysis_name is not None:
+        analyses = suite.get_analyses(analysis_name)
+        return analyses[0]
+
+    # Otherwise pick the analysis whose ``model:`` field matches
+    # this model's name. Ambiguity (multiple analyses for the same
+    # model) is the user's bug — tell them to add a #fragment.
+    matches = [a for a in suite.get_analyses() if a.get_top() == model_cfg.name]
+    if len(matches) == 0:
+        names = ", ".join(suite.get_analysis_names()) or "(none)"
+        raise FatalRtlBuddyError(
+            f"model {model_cfg.name!r} cdc back-pointer points at "
+            f"{cdc_yaml_path}, but no analysis there has "
+            f"model: {model_cfg.name!r}. Analyses found: {names}. "
+            f"Add a '#analysis_name' fragment to the cdc: field to "
+            f"pick one explicitly."
+        )
+    if len(matches) > 1:
+        names = ", ".join(a.get_name() for a in matches)
+        raise FatalRtlBuddyError(
+            f"model {model_cfg.name!r} cdc back-pointer points at "
+            f"{cdc_yaml_path}, which has multiple analyses for this "
+            f"model ({names}). Pick one with 'cdc.yaml#analysis_name' "
+            f"in models.yaml."
+        )
+    return matches[0]
+
+
+def _resolve_cdc_executable() -> str:
+    exe = shutil.which("rtl-buddy-cdc")
+    if exe is None:
+        raise FatalRtlBuddyError(
+            "rb hub --model: model has a 'cdc:' back-pointer but "
+            "'rtl-buddy-cdc' is not on PATH. Either install "
+            "rtl-buddy-cdc into the active venv, or remove the cdc: "
+            "field from the model entry to skip the overlay."
+        )
+    return exe
+
+
+# Filelist entries we drop from the rtl-buddy-cdc command line —
+# CDC takes plain SystemVerilog source paths; ``-y`` / ``-F`` /
+# ``+incdir+`` directives don't apply.
+_FILELIST_SKIP_PREFIXES = ("+incdir+", "+libext+", "-y ", "-F ", "-f ")
+_FILELIST_SOURCE_PREFIX = "-v "
+
+
+def _source_files_from_filelist(fl_path: str) -> list[str]:
+    """Same extraction logic as RtlBuddyCdc, inlined for the hub
+    use case so we don't import a tool-internal helper."""
+    fl_dir = os.path.dirname(os.path.abspath(fl_path))
+    paths: list[str] = []
+    with open(fl_path) as f:
+        for raw in f:
+            line = raw.strip()
+            if not line or line.startswith("//"):
+                continue
+            if any(line.startswith(opt) for opt in _FILELIST_SKIP_PREFIXES):
+                continue
+            if line.startswith(_FILELIST_SOURCE_PREFIX):
+                line = line[len(_FILELIST_SOURCE_PREFIX) :]
+            paths.append(os.path.normpath(os.path.join(fl_dir, line)))
+    return paths
+
+
+def build_domain_map(
+    *,
+    project_root: Path,
+    model_cfg: ModelConfig,
+) -> Path | None:
+    """Generate the domain_map.json for ``model_cfg``'s clock overlay.
+
+    Returns:
+      - ``Path`` to the domain map when the model has a ``cdc:``
+        back-pointer that resolves to a valid analysis.
+      - ``None`` when the model has no ``cdc:`` field — overlay
+        unavailable, caller should fall back to running
+        rtl-buddy-view without ``--cdc-annotations``.
+
+    Raises ``FatalRtlBuddyError`` when the back-pointer IS set but
+    the resolution / lint subprocess fails — the user asked for the
+    overlay and a dark toggle would be worse than a clear startup
+    error.
+    """
+    analysis = _resolve_cdc_analysis(model_cfg)
+    if analysis is None:
+        return None
+
+    sdc_path = analysis.get_constraints()
+    if not os.path.isfile(sdc_path):
+        raise FatalRtlBuddyError(
+            f"cdc analysis {analysis.get_name()!r}: SDC not found at {sdc_path}"
+        )
+    waivers_path = analysis.get_waivers()
+    if waivers_path is not None and not os.path.isfile(waivers_path):
+        raise FatalRtlBuddyError(
+            f"cdc analysis {analysis.get_name()!r}: waivers file not "
+            f"found at {waivers_path}"
+        )
+
+    cache = cache_dir(project_root)
+    cache.mkdir(parents=True, exist_ok=True)
+    out_path = domain_map_path(project_root, model_cfg.name)
+
+    # Build a CDC-friendly filelist (unrolled + deduplicated). We
+    # write into the same artefacts area RtlBuddyCdc uses so a
+    # subsequent ``rb cdc`` invocation re-uses the elaboration.
+    artefact_dir = project_root / "artefacts" / "hub-cdc" / model_cfg.name
+    artefact_dir.mkdir(parents=True, exist_ok=True)
+    fl_path = str(artefact_dir / "cdc.f")
+    vlog_fl = VlogFilelist(
+        name=f"hub/cdc/{model_cfg.name}/filelist",
+        model_cfg=model_cfg,
+        output_path=fl_path,
+    )
+    vlog_fl.write_output(
+        output_filepath=fl_path, unroll=True, strip=False, deduplicate=True
+    )
+    sources = _source_files_from_filelist(fl_path)
+    if not sources:
+        raise FatalRtlBuddyError(
+            f"cdc analysis {analysis.get_name()!r}: filelist {fl_path} "
+            f"produced no sources"
+        )
+
+    cdc_exe = _resolve_cdc_executable()
+    log_path = artefact_dir / "cdc.log"
+    # ``--format json --output /dev/null`` keeps lint's chatter off
+    # the hub log; we only care about the emitted domain map. The
+    # ``--format text`` path is skipped — no human-facing lint
+    # report is needed for the hub.
+    cmd = [
+        cdc_exe,
+        "lint",
+        "--top",
+        analysis.get_top(),
+        "--sdc",
+        sdc_path,
+        "--emit-domain-map",
+        str(out_path),
+        "--format",
+        "json",
+        "--output",
+        os.devnull,
+    ]
+    if waivers_path is not None:
+        cmd += ["--waivers", waivers_path]
+    if analysis.frontend is not None:
+        cmd += ["--frontend", analysis.frontend]
+    cmd += sources
+
+    log_event(
+        logger,
+        logging.INFO,
+        "hub.cdc_builder.generating",
+        model=model_cfg.name,
+        analysis=analysis.get_name(),
+        path=str(out_path),
+    )
+    with open(log_path, "w") as logf:
+        logf.write("$ " + " ".join(cmd) + "\n")
+        logf.flush()
+        proc = subprocess.run(
+            cmd,
+            stdout=logf,
+            stderr=subprocess.STDOUT,
+        )
+    # rtl-buddy-cdc returns 0 for clean, 1 for rule violations,
+    # 2+ for elaboration failures. We tolerate violations because
+    # they don't impede the overlay (the domain map still gets
+    # emitted); we hard-fail on anything worse.
+    if proc.returncode not in (0, 1):
+        raise FatalRtlBuddyError(
+            f"cdc analysis {analysis.get_name()!r}: rtl-buddy-cdc "
+            f"exited with code {proc.returncode}; see {log_path}"
+        )
+    if not out_path.is_file():
+        raise FatalRtlBuddyError(
+            f"cdc analysis {analysis.get_name()!r}: rtl-buddy-cdc "
+            f"completed but produced no domain map at {out_path}; "
+            f"see {log_path}"
+        )
+    return out_path

--- a/src/rtl_buddy/hub/view_builder.py
+++ b/src/rtl_buddy/hub/view_builder.py
@@ -65,7 +65,23 @@ def build_view_json(
     and return it. Raises ``FatalRtlBuddyError`` when the
     rtl-buddy-view subprocess fails — the hub treats a missing
     view.json as a fatal startup error, not a degraded mode.
+
+    When ``model_cfg.cdc`` is set, the builder first calls
+    ``cdc_builder.build_domain_map`` to produce the clock-domain map
+    via ``rtl-buddy-cdc --emit-domain-map`` and feeds the result as
+    ``--cdc-annotations`` to rtl-buddy-view. The SPA's clock overlay
+    toggle then has data to render against. Models without ``cdc:``
+    fall through to the no-overlay path unchanged.
     """
+
+    # Build the domain map FIRST so a misconfigured cdc: back-pointer
+    # fails before we spend cycles on rtl-buddy-view. Import locally
+    # to avoid a hub→cdc import cycle.
+    from . import cdc_builder
+
+    domain_map = cdc_builder.build_domain_map(
+        project_root=project_root, model_cfg=model_cfg
+    )
 
     cache = cache_dir(project_root)
     cache.mkdir(parents=True, exist_ok=True)
@@ -79,6 +95,7 @@ def build_view_json(
         "hub.view_builder.generating",
         model=model_cfg.name,
         path=str(out_path),
+        cdc_annotations=str(domain_map) if domain_map else "",
     )
     runner = RtlBuddyView(
         name=f"hub/view/{model_cfg.name}",
@@ -87,6 +104,7 @@ def build_view_json(
         format="json",
         output=str(out_path),
         executable=viewer_exe,
+        cdc_annotations=str(domain_map) if domain_map else None,
     )
     rc = runner.run()
     if rc != 0 or not out_path.is_file():

--- a/tests/test_hub_cdc_builder.py
+++ b/tests/test_hub_cdc_builder.py
@@ -1,0 +1,241 @@
+"""Tests for the hub-side cdc → domain_map builder.
+
+The real path invokes ``rtl-buddy-cdc lint --emit-domain-map`` which
+we don't want to require in CI; the subprocess is mocked. Tests pin:
+
+  - back-pointer resolution (no field, with fragment, by model match)
+  - error paths (file missing, multiple analyses, missing SDC)
+  - subprocess command shape (--top, --sdc, --emit-domain-map, sources)
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+from rtl_buddy.config.model import ModelConfig
+from rtl_buddy.errors import FatalRtlBuddyError
+from rtl_buddy.hub import cdc_builder
+
+
+_MODELS_YAML = dedent("""\
+    rtl-buddy-filetype: model_config
+    models:
+      - name: demo
+        filelist: ["-v src/a.sv"]
+        cdc: cdc.yaml
+""")
+
+_CDC_YAML_TEMPLATE = dedent("""\
+    rtl-buddy-filetype: cdc_config
+
+    analyses:
+      - name: "{analysis_name}"
+        desc: "demo cdc"
+        model: "demo"
+        model_path: "models.yaml"
+        tool: "rtl-buddy-cdc"
+        constraints: "demo.sdc"
+""")
+
+_CDC_YAML_MULTI = dedent("""\
+    rtl-buddy-filetype: cdc_config
+
+    analyses:
+      - name: "fast"
+        desc: "fast corner"
+        model: "demo"
+        model_path: "models.yaml"
+        tool: "rtl-buddy-cdc"
+        constraints: "demo.sdc"
+      - name: "slow"
+        desc: "slow corner"
+        model: "demo"
+        model_path: "models.yaml"
+        tool: "rtl-buddy-cdc"
+        constraints: "demo.sdc"
+""")
+
+
+def _seed_project(tmp_path: Path, *, cdc_field: str = "cdc.yaml") -> ModelConfig:
+    """Create a project skeleton with models.yaml + cdc.yaml + SDC +
+    one source file, and return a ModelConfig pointing at it (with
+    ``.path`` set so the cdc back-pointer can resolve)."""
+    (tmp_path / "src").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "src" / "a.sv").write_text("module a; endmodule\n")
+    (tmp_path / "demo.sdc").write_text(
+        "create_clock -name clk -period 10 [get_ports clk]\n"
+    )
+    models_path = tmp_path / "models.yaml"
+    body = dedent(f"""\
+        rtl-buddy-filetype: model_config
+        models:
+          - name: demo
+            filelist: ["-v src/a.sv"]
+            cdc: {cdc_field}
+    """)
+    models_path.write_text(body)
+    return ModelConfig(
+        name="demo",
+        filelist=["-v src/a.sv"],
+        cdc=cdc_field,
+        path=str(models_path),
+    )
+
+
+def test_domain_map_path_under_cache_dir(tmp_path):
+    assert (
+        cdc_builder.domain_map_path(tmp_path, "demo")
+        == tmp_path / ".rtl-buddy" / "cache" / "domain-demo.json"
+    )
+
+
+def test_build_domain_map_no_cdc_field_returns_none(tmp_path):
+    """A model without a ``cdc:`` back-pointer means "no overlay
+    requested" — the builder returns ``None`` and the caller skips
+    rtl-buddy-view's ``--cdc-annotations`` flag."""
+    model = ModelConfig(name="demo", filelist=[], path=str(tmp_path / "models.yaml"))
+    assert cdc_builder.build_domain_map(project_root=tmp_path, model_cfg=model) is None
+
+
+def test_build_domain_map_missing_cdc_yaml_raises(tmp_path):
+    """``cdc: cdc.yaml`` set but no such file → fail loud at hub
+    start. Better than silently dropping the overlay."""
+    model = _seed_project(tmp_path)
+    # Don't write the cdc.yaml file
+    with pytest.raises(FatalRtlBuddyError, match="cdc back-pointer.*does not exist"):
+        cdc_builder.build_domain_map(project_root=tmp_path, model_cfg=model)
+
+
+def test_build_domain_map_resolves_via_model_match(tmp_path, monkeypatch):
+    """Without a ``#fragment`` the builder picks the analysis whose
+    ``model:`` field matches the model's name."""
+    model = _seed_project(tmp_path)
+    (tmp_path / "cdc.yaml").write_text(
+        _CDC_YAML_TEMPLATE.format(analysis_name="demo_cdc")
+    )
+
+    captured = {}
+
+    monkeypatch.setattr(cdc_builder.shutil, "which", lambda _: "/fake/rtl-buddy-cdc")
+
+    def fake_run(cmd, stdout=None, stderr=None, **kwargs):
+        captured["cmd"] = cmd
+        # Pretend cdc wrote the file.
+        out = cmd[cmd.index("--emit-domain-map") + 1]
+        Path(out).parent.mkdir(parents=True, exist_ok=True)
+        Path(out).write_text('{"schema_version": "1.0", "clocks": []}')
+        return type("R", (), {"returncode": 0})()
+
+    monkeypatch.setattr(cdc_builder.subprocess, "run", fake_run)
+
+    result = cdc_builder.build_domain_map(project_root=tmp_path, model_cfg=model)
+    assert result == cdc_builder.domain_map_path(tmp_path, "demo")
+    assert result.is_file()
+    cmd = captured["cmd"]
+    assert cmd[0] == "/fake/rtl-buddy-cdc"
+    assert "lint" in cmd
+    assert "--top" in cmd
+    assert "demo" in cmd
+    assert "--sdc" in cmd
+    assert "--emit-domain-map" in cmd
+    # SDC should be the absolute path resolved against cdc.yaml.
+    sdc_idx = cmd.index("--sdc")
+    assert Path(cmd[sdc_idx + 1]) == tmp_path / "demo.sdc"
+
+
+def test_build_domain_map_honours_fragment(tmp_path, monkeypatch):
+    """``cdc: cdc.yaml#slow`` pins one analysis even when there are
+    multiple candidates."""
+    model = _seed_project(tmp_path, cdc_field="cdc.yaml#slow")
+    (tmp_path / "cdc.yaml").write_text(_CDC_YAML_MULTI)
+
+    captured = {}
+    monkeypatch.setattr(cdc_builder.shutil, "which", lambda _: "/fake/rtl-buddy-cdc")
+
+    def fake_run(cmd, stdout=None, stderr=None, **kwargs):
+        captured["cmd"] = cmd
+        out = cmd[cmd.index("--emit-domain-map") + 1]
+        Path(out).parent.mkdir(parents=True, exist_ok=True)
+        Path(out).write_text("{}")
+        return type("R", (), {"returncode": 0})()
+
+    monkeypatch.setattr(cdc_builder.subprocess, "run", fake_run)
+    cdc_builder.build_domain_map(project_root=tmp_path, model_cfg=model)
+    # ``--top`` is "demo" for both analyses, but the analysis NAME
+    # used in error messages / paths comes from the fragment. We
+    # don't expose the analysis name on the command line, so the
+    # easiest signal is that the call didn't raise the
+    # "multiple analyses" error.
+    assert "--emit-domain-map" in captured["cmd"]
+
+
+def test_build_domain_map_ambiguous_without_fragment_raises(tmp_path):
+    """Two analyses, same model, no fragment → tell the user to
+    pick one with a #fragment in models.yaml."""
+    model = _seed_project(tmp_path)
+    (tmp_path / "cdc.yaml").write_text(_CDC_YAML_MULTI)
+    with pytest.raises(FatalRtlBuddyError, match="multiple analyses"):
+        cdc_builder.build_domain_map(project_root=tmp_path, model_cfg=model)
+
+
+def test_build_domain_map_missing_sdc_raises(tmp_path):
+    """Analysis points at an SDC file that doesn't exist → fail loud
+    (vs. letting rtl-buddy-cdc emit a confusing error downstream)."""
+    model = _seed_project(tmp_path)
+    (tmp_path / "demo.sdc").unlink()
+    (tmp_path / "cdc.yaml").write_text(
+        _CDC_YAML_TEMPLATE.format(analysis_name="demo_cdc")
+    )
+    with pytest.raises(FatalRtlBuddyError, match="SDC not found"):
+        cdc_builder.build_domain_map(project_root=tmp_path, model_cfg=model)
+
+
+def test_build_domain_map_missing_executable_raises(tmp_path, monkeypatch):
+    model = _seed_project(tmp_path)
+    (tmp_path / "cdc.yaml").write_text(
+        _CDC_YAML_TEMPLATE.format(analysis_name="demo_cdc")
+    )
+    monkeypatch.setattr(cdc_builder.shutil, "which", lambda _: None)
+    with pytest.raises(FatalRtlBuddyError, match="rtl-buddy-cdc.*not on PATH"):
+        cdc_builder.build_domain_map(project_root=tmp_path, model_cfg=model)
+
+
+def test_build_domain_map_subprocess_failure_raises(tmp_path, monkeypatch):
+    """Non-zero exit (other than 1, which is "violations") → fail."""
+    model = _seed_project(tmp_path)
+    (tmp_path / "cdc.yaml").write_text(
+        _CDC_YAML_TEMPLATE.format(analysis_name="demo_cdc")
+    )
+    monkeypatch.setattr(cdc_builder.shutil, "which", lambda _: "/fake/rtl-buddy-cdc")
+
+    def fake_run(cmd, stdout=None, stderr=None, **kwargs):
+        return type("R", (), {"returncode": 7})()
+
+    monkeypatch.setattr(cdc_builder.subprocess, "run", fake_run)
+    with pytest.raises(FatalRtlBuddyError, match=r"exited with code 7"):
+        cdc_builder.build_domain_map(project_root=tmp_path, model_cfg=model)
+
+
+def test_build_domain_map_tolerates_violations_exit_1(tmp_path, monkeypatch):
+    """CDC exit-1 means rule violations were found — the elaboration
+    still succeeded and the domain map was emitted. The hub doesn't
+    care about lint violations; the overlay should work."""
+    model = _seed_project(tmp_path)
+    (tmp_path / "cdc.yaml").write_text(
+        _CDC_YAML_TEMPLATE.format(analysis_name="demo_cdc")
+    )
+    monkeypatch.setattr(cdc_builder.shutil, "which", lambda _: "/fake/rtl-buddy-cdc")
+
+    def fake_run(cmd, stdout=None, stderr=None, **kwargs):
+        out = cmd[cmd.index("--emit-domain-map") + 1]
+        Path(out).parent.mkdir(parents=True, exist_ok=True)
+        Path(out).write_text("{}")
+        return type("R", (), {"returncode": 1})()
+
+    monkeypatch.setattr(cdc_builder.subprocess, "run", fake_run)
+    result = cdc_builder.build_domain_map(project_root=tmp_path, model_cfg=model)
+    assert result is not None
+    assert result.is_file()

--- a/tests/test_hub_view_builder.py
+++ b/tests/test_hub_view_builder.py
@@ -114,3 +114,75 @@ def test_build_view_json_creates_cache_dir(tmp_path, monkeypatch):
     monkeypatch.setattr(view_builder, "RtlBuddyView", FakeRunner)
     view_builder.build_view_json(project_root=tmp_path, model_cfg=_model(tmp_path))
     assert view_builder.cache_dir(tmp_path).is_dir()
+
+
+def test_build_view_json_passes_cdc_annotations_when_back_pointer_set(
+    tmp_path, monkeypatch
+):
+    """When ``model.cdc`` is set, the view builder routes through
+    cdc_builder to produce a domain map and feeds the path to
+    rtl-buddy-view as ``--cdc-annotations``. Tested at the
+    integration boundary by stubbing cdc_builder."""
+    from rtl_buddy.hub import cdc_builder
+
+    fake_domain = tmp_path / ".rtl-buddy" / "cache" / "domain-demo.json"
+    monkeypatch.setattr(
+        cdc_builder,
+        "build_domain_map",
+        lambda **kwargs: fake_domain,
+    )
+    monkeypatch.setattr(view_builder.shutil, "which", lambda _: "/fake/rtl-buddy-view")
+
+    captured = {}
+
+    class FakeRunner:
+        def __init__(self, **kwargs):
+            captured["kwargs"] = kwargs
+            self.artefact_dir = str(tmp_path / "artefacts" / "hier" / "demo")
+            Path(self.artefact_dir).mkdir(parents=True, exist_ok=True)
+
+        def run(self) -> int:
+            out = Path(captured["kwargs"]["output"])
+            out.parent.mkdir(parents=True, exist_ok=True)
+            out.write_text('{"schema_version": "1.0"}')
+            return 0
+
+    monkeypatch.setattr(view_builder, "RtlBuddyView", FakeRunner)
+
+    model = ModelConfig(
+        name="demo",
+        filelist=[],
+        cdc="cdc.yaml",
+        path=str(tmp_path / "models.yaml"),
+    )
+    view_builder.build_view_json(project_root=tmp_path, model_cfg=model)
+    assert captured["kwargs"]["cdc_annotations"] == str(fake_domain)
+
+
+def test_build_view_json_no_cdc_annotations_when_back_pointer_absent(
+    tmp_path, monkeypatch
+):
+    """Without ``model.cdc`` the cdc_builder returns ``None`` and
+    rtl-buddy-view runs without ``--cdc-annotations``."""
+    from rtl_buddy.hub import cdc_builder
+
+    monkeypatch.setattr(cdc_builder, "build_domain_map", lambda **kwargs: None)
+    monkeypatch.setattr(view_builder.shutil, "which", lambda _: "/fake/rtl-buddy-view")
+
+    captured = {}
+
+    class FakeRunner:
+        def __init__(self, **kwargs):
+            captured["kwargs"] = kwargs
+            self.artefact_dir = str(tmp_path / "artefacts" / "hier" / "demo")
+            Path(self.artefact_dir).mkdir(parents=True, exist_ok=True)
+
+        def run(self) -> int:
+            out = Path(captured["kwargs"]["output"])
+            out.parent.mkdir(parents=True, exist_ok=True)
+            out.write_text("{}")
+            return 0
+
+    monkeypatch.setattr(view_builder, "RtlBuddyView", FakeRunner)
+    view_builder.build_view_json(project_root=tmp_path, model_cfg=_model(tmp_path))
+    assert captured["kwargs"]["cdc_annotations"] is None


### PR DESCRIPTION
## Summary

Completes the deferred half of [#168](https://github.com/rtl-buddy/rtl_buddy/issues/168). [#171](https://github.com/rtl-buddy/rtl_buddy/pull/171) added the \`cdc:\` schema field to \`ModelConfig\`, but \`rb hub start --model\` never read it — so the SPA's clock overlay toggle stayed dark even on a perfectly-configured project. This hooks up the missing producer side.

## What lands

New module **\`rtl_buddy/hub/cdc_builder.py\`** — \`build_domain_map(project_root, model_cfg)\`:

1. \`resolve_back_pointer(model_cfg, \"cdc\")\` (#168 helper) → absolute cdc.yaml path + optional analysis fragment.
2. Loads \`cdc.yaml\`, picks the analysis:
   - \`cdc: cdc.yaml#fragment\` → the named analysis wins.
   - \`cdc: cdc.yaml\` → the analysis whose \`model:\` field matches the model name. Ambiguity is a hard error telling the user to add a fragment.
3. Builds an unrolled+dedup filelist (same shape \`RtlBuddyCdc\` uses) and runs:
   \`\`\`
   rtl-buddy-cdc lint --top <model> --sdc <sdc> --emit-domain-map .rtl-buddy/cache/domain-<model>.json --format json --output /dev/null [--waivers ...] [--frontend ...] <sources>
   \`\`\`
4. Returns the domain-map path (or \`None\` when no \`cdc:\` field).

**\`view_builder.py\`** now calls \`build_domain_map\` before \`RtlBuddyView\` and passes the result as \`cdc_annotations\`. Models without \`cdc:\` are unaffected.

## Error contract

| Situation | Behaviour |
| --- | --- |
| No \`cdc:\` field on model | \`build_domain_map\` returns \`None\`, no overlay, no error |
| \`cdc:\` set but file missing | \`FatalRtlBuddyError\` at hub start |
| \`cdc:\` set but \`rtl-buddy-cdc\` not on PATH | \`FatalRtlBuddyError\` with install hint |
| Multiple analyses match model name | \`FatalRtlBuddyError\` telling user to add \`#fragment\` |
| SDC referenced by analysis missing | \`FatalRtlBuddyError\` naming the SDC path |
| \`rtl-buddy-cdc\` exits 1 (lint violations) | Tolerated — elaboration produced the domain map |
| \`rtl-buddy-cdc\` exits ≥2 (elaboration failure) | \`FatalRtlBuddyError\` pointing at the log file |

## Usage

\`\`\`yaml
# models.yaml
rtl-buddy-filetype: model_config
models:
  - name: ip_demo_tiny_npu
    filelist: [...]
    cdc: cdc.yaml          # or cdc.yaml#analysis_name to pin one
\`\`\`

\`\`\`bash
rb hub start --serve-viewer --model ip_demo_tiny_npu
# → produces both view.json AND domain_map.json,
#   feeds the latter to rtl-buddy-view as --cdc-annotations
\`\`\`

Hard-refresh the SPA, flip the clock overlay toggle, see colours.

## Test plan

- [x] \`uv run pytest tests/test_hub_cdc_builder.py tests/test_hub_view_builder.py -q --no-cov\` — 18 pass (10 new cdc_builder tests + 2 new view_builder integration tests).
- [x] \`uv run pytest -q --no-cov\` — 733 pass, 2 skipped, 1 pre-existing asyncio error in test_wave_hub_bridge.
- [x] \`uv run ruff check\` + \`uv run ruff format --check\` clean.
- [x] \`uv run python scripts/check_docs_frontmatter.py --check\` clean.
- [x] \`docs/concepts/hub.md\` updated with the new behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)