### PR TITLE
fix(process_utils): tolerate run_managed_process from worker thread

### DIFF
--- a/src/rtl_buddy/process_utils.py
+++ b/src/rtl_buddy/process_utils.py
@@ -1,6 +1,7 @@
 import os
 import signal
 import subprocess
+import threading
 from dataclasses import dataclass
 from typing import IO
 
@@ -91,9 +92,20 @@ def run_managed_process(
             raise KeyboardInterrupt
         raise SystemExit(128 + signum)
 
-    for signum in (signal.SIGINT, signal.SIGTERM):
-        previous_handlers[signum] = signal.getsignal(signum)
-        signal.signal(signum, _signal_handler)
+    # ``signal.signal`` only works in the main thread. When this
+    # helper is called from a worker thread (e.g. ``asyncio.to_thread``
+    # from the hub's HTTP handler in ``rb hub --model`` switching),
+    # we skip the signal-handler install. The main thread's existing
+    # SIGINT/SIGTERM handler still fires and the ``finally`` block
+    # below still terminates the process group on its way out, so the
+    # only thing lost is the in-worker re-raise of KeyboardInterrupt /
+    # SystemExit — which the worker thread can't propagate to the
+    # main thread anyway.
+    in_main_thread = threading.current_thread() is threading.main_thread()
+    if in_main_thread:
+        for signum in (signal.SIGINT, signal.SIGTERM):
+            previous_handlers[signum] = signal.getsignal(signum)
+            signal.signal(signum, _signal_handler)
 
     try:
         try:
@@ -120,5 +132,6 @@ def run_managed_process(
         _terminate_process_group(
             proc, terminate_signal=terminate_signal, kill_timeout=kill_timeout
         )
-        for signum, handler in previous_handlers.items():
-            signal.signal(signum, handler)
+        if in_main_thread:
+            for signum, handler in previous_handlers.items():
+                signal.signal(signum, handler)

--- a/tests/test_process_utils.py
+++ b/tests/test_process_utils.py
@@ -132,3 +132,35 @@ def test_run_managed_process_restores_signal_handlers(monkeypatch):
 
     assert signal.getsignal(signal.SIGINT) == original_int
     assert signal.getsignal(signal.SIGTERM) == original_term
+
+
+def test_run_managed_process_works_from_worker_thread(monkeypatch):
+    """``signal.signal()`` only works in the main thread, so callers
+    invoking ``run_managed_process`` from a worker thread (e.g. the
+    hub's ``asyncio.to_thread`` per-model lock in
+    ``rb hub start --model``) MUST NOT crash. The helper has to
+    detect non-main-thread context and skip the signal-handler
+    install/restore entirely.
+    """
+    import threading
+
+    proc = FakeProcess()
+    monkeypatch.setattr(
+        process_utils.subprocess,
+        "Popen",
+        lambda *args, **kwargs: proc,
+    )
+
+    result: dict = {}
+
+    def runner() -> None:
+        try:
+            result["value"] = process_utils.run_managed_process(["tool"])
+        except Exception as exc:  # pragma: no cover - failure path
+            result["error"] = exc
+
+    t = threading.Thread(target=runner)
+    t.start()
+    t.join(timeout=5.0)
+    assert "error" not in result, result.get("error")
+    assert result["value"].returncode == 0


### PR DESCRIPTION
## Summary

\`signal.signal()\` only works on the main thread, so calling \`run_managed_process\` from a worker thread crashes with \`ValueError: signal only works in main thread of the main interpreter\`.

This was a latent issue surfaced by [#175](https://github.com/rtl-buddy/rtl_buddy/pull/175) (\`rb hub start --model\` runtime switching): the per-model \`asyncio.Lock\` + \`asyncio.to_thread\` pattern in the viewer HTTP handler moves the \`rtl-buddy-view\` subprocess off the event loop, which means it now runs from a worker thread. The \`ValueError\` was being swallowed by the HTTP error path and surfacing to the user as a generic \`500\` from \`GET /view.json?model=NAME\` for every model switch — including the model the hub started with.

## Fix

Detect non-main-thread context and skip the SIGINT/SIGTERM handler install + restore in that case. The main thread's existing handlers still fire on signal delivery, and the \`finally\` block still tears down the subprocess group, so the only thing lost is the in-worker re-raise of \`KeyboardInterrupt\` / \`SystemExit\` — which a worker thread can't propagate to the main thread anyway.

## Test plan

- [x] New \`test_run_managed_process_works_from_worker_thread\` — invokes \`run_managed_process\` from a \`threading.Thread\` and asserts no exception.
- [x] Full \`uv run pytest\` — 742 pass, 2 skipped, 1 pre-existing asyncio flake in \`test_wave_hub_bridge.py\`.
- [x] Manual: with this fix applied locally, \`GET /view.json?model=ip_superm_tprf\` against a live hub returns 200 with a valid view.json body (was 500 before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)