### PR TITLE
fix(hub model_discovery): skip nested git worktrees

### DIFF
--- a/src/rtl_buddy/hub/model_discovery.py
+++ b/src/rtl_buddy/hub/model_discovery.py
@@ -61,13 +61,28 @@ def discover_models_files(root: Path) -> list[Path]:
     """Return every ``models.yaml`` reachable under ``root``.
 
     Skips conventional build/VCS directories so vendored fixtures
-    don't pollute the candidate set. Order is deterministic
-    (alphabetical) so collision-error messages don't churn between
-    invocations.
+    don't pollute the candidate set, and skips nested git worktrees
+    (each one is a parallel checkout of the same project, so its
+    ``models.yaml`` files duplicate the parent's and would otherwise
+    fail discovery as cross-file name collisions). Order is
+    deterministic (alphabetical) so collision-error messages don't
+    churn between invocations.
     """
 
+    root_resolved = Path(root).resolve()
     results: list[Path] = []
     for dirpath, dirnames, filenames in os.walk(root):
+        # Skip git worktree subdirectories. Each worktree root has
+        # ``.git`` as a *file* (containing ``gitdir: <path>``) pointing
+        # back at the main repo's ``.git/worktrees/<name>`` metadata.
+        # The main checkout has ``.git`` as a directory and is already
+        # walked into normally — we only want to prune nested worktrees,
+        # not the starting root itself.
+        if Path(dirpath).resolve() != root_resolved and ".git" in filenames:
+            git_entry = Path(dirpath) / ".git"
+            if git_entry.is_file():
+                dirnames.clear()
+                continue
         # Mutate dirnames in place so os.walk skips our excludes.
         dirnames[:] = sorted(d for d in dirnames if d not in _SKIP_DIRS)
         if "models.yaml" in filenames:

--- a/tests/test_hub_model_discovery.py
+++ b/tests/test_hub_model_discovery.py
@@ -63,6 +63,30 @@ def test_discover_models_files_skips_excluded_dirs(tmp_path):
     assert [p.relative_to(tmp_path) for p in found] == [Path("block_a/models.yaml")]
 
 
+def test_discover_models_files_skips_nested_git_worktrees(tmp_path):
+    """A subdirectory whose ``.git`` is a file (the canonical worktree
+    marker) is a parallel checkout — its ``models.yaml`` files duplicate
+    the parent's and must not enter the candidate set."""
+    _write_models(tmp_path / "block_a" / "models.yaml", _MODELS_YAML_A)
+    # Simulate a worktree at .worktrees/feature-x/ with the project tree copied in.
+    wt = tmp_path / ".worktrees" / "feature-x"
+    (wt / ".git").parent.mkdir(parents=True, exist_ok=True)
+    (wt / ".git").write_text("gitdir: /elsewhere/.git/worktrees/feature-x\n")
+    _write_models(wt / "block_a" / "models.yaml", _MODELS_YAML_A)
+    _write_models(wt / "block_b" / "models.yaml", _MODELS_YAML_B)
+    found = model_discovery.discover_models_files(tmp_path)
+    assert [p.relative_to(tmp_path) for p in found] == [Path("block_a/models.yaml")]
+
+
+def test_discover_models_files_keeps_root_git_dir(tmp_path):
+    """The starting root's own .git/ (a *directory*, not a file) must not
+    trigger the worktree-skip path."""
+    (tmp_path / ".git").mkdir()
+    _write_models(tmp_path / "block_a" / "models.yaml", _MODELS_YAML_A)
+    found = model_discovery.discover_models_files(tmp_path)
+    assert [p.relative_to(tmp_path) for p in found] == [Path("block_a/models.yaml")]
+
+
 def test_discover_models_files_returns_alphabetical_order(tmp_path):
     """Order matters for collision-error messages — must be stable."""
     _write_models(tmp_path / "z_block" / "models.yaml", _MODELS_YAML_A)


### PR DESCRIPTION
## Summary

`rb hub start --model NAME` walks the project tree for `models.yaml` and errors when the same name resolves in more than one file. Git worktrees (e.g. `.worktrees/feature-x/`) are parallel checkouts of the same project, so every `models.yaml` in the main tree duplicates inside each worktree. Discovery currently treats those as cross-file name collisions and forces the user to pass `--models-file PATH`, defeating the auto-discovery convenience that the `--model` flow exists to provide.

## Repro (before this PR)

In a project that uses git worktrees under `.worktrees/`:

```
$ rb hub start --serve-viewer --model ip_demo_tiny_npu
hub model_discovery ambiguous
model 'ip_demo_tiny_npu' matches multiple models.yaml files; pass --models-file PATH to disambiguate:
  /…/rtl-buddy-ai-project/.worktrees/dev-local-axi-inter/design/demo-tiny-npu/models.yaml
  /…/rtl-buddy-ai-project/.worktrees/dev-local-tiny-npu-src-syn-exp-pipelining/design/demo-tiny-npu/models.yaml
  /…/rtl-buddy-ai-project/.worktrees/dev-local-vxp-vmem-sram/design/demo-tiny-npu/models.yaml
  /…/rtl-buddy-ai-project/design/demo-tiny-npu/models.yaml
```

Every entry past the last one is a duplicate from a worktree.

## Fix

Skip subdirectories whose `.git` is a file (the canonical worktree marker — git writes `gitdir: <main-repo>/.git/worktrees/<name>` into a regular file at each worktree root). The starting root's own `.git/` is a directory and is unaffected.

```py
if Path(dirpath).resolve() != root_resolved and ".git" in filenames:
    git_entry = Path(dirpath) / ".git"
    if git_entry.is_file():
        dirnames.clear()
        continue
```

Two new tests pin the behavior — one with a worktree under `.worktrees/feature-x/`, one asserting the root's own `.git/` directory is **not** mistaken for a worktree marker.

## Test plan

- [x] `uv run pytest tests/test_hub_model_discovery.py -v` — 15/15 pass (13 existing + 2 new)
- [x] `uv run pytest tests/test_hub_model_discovery.py tests/test_hub_viewer_http.py -q` — 43/43 pass (viewer_http calls into `discover_models_files`)
- [x] `uv run ruff check` + `ruff format --check` clean
- [x] Manual: `rb hub start --serve-viewer --model ip_demo_tiny_npu` against the original reproducer project now resolves to the single non-worktree `models.yaml`

## Origin

Surfaced while validating the deferred end-to-end test on expedera-sg/rtl-buddy-ai-project#41 (`rb hub` workflow on a project with active worktrees). Cross-repo meta: rtl-buddy/rtl_buddy#112.

🤖 Generated with [Claude Code](https://claude.com/claude-code)