### PR TITLE
test(hub): drain pending tasks before closing _ThreadedHub loop

### DIFF
--- a/tests/test_hub_send_cli.py
+++ b/tests/test_hub_send_cli.py
@@ -26,6 +26,25 @@ from rtl_buddy.hub.send import send_app
 from rtl_buddy.hub.server import HubServer
 
 
+def _drain_and_close(loop: asyncio.AbstractEventLoop) -> None:
+    """Cancel and drain pending tasks before closing the loop.
+
+    Without this, transport-close callbacks scheduled during
+    ``HubServer.shutdown`` outlive the loop and surface as
+    ``RuntimeError: Event loop is closed`` at some later test's
+    teardown when GC dispatches them.
+    """
+    try:
+        pending = [t for t in asyncio.all_tasks(loop) if not t.done()]
+        for t in pending:
+            t.cancel()
+        if pending:
+            loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
+        loop.run_until_complete(loop.shutdown_asyncgens())
+    finally:
+        loop.close()
+
+
 _VIEW_JSON = {
     "schema_version": "1.0",
     "tool": {"name": "rtl-buddy-view", "version": "0.1.0"},
@@ -101,7 +120,7 @@ class _ThreadedHub:
                 self._started.set()
                 raise
             finally:
-                loop.close()
+                _drain_and_close(loop)
 
         self._thread = threading.Thread(target=_runner, daemon=True, name="hub-thread")
         self._thread.start()

--- a/tests/test_wave_hub_bridge.py
+++ b/tests/test_wave_hub_bridge.py
@@ -27,6 +27,25 @@ from rtl_buddy.tools.wave_hub_bridge import (
 )
 
 
+def _drain_and_close(loop: asyncio.AbstractEventLoop) -> None:
+    """Cancel and drain pending tasks before closing the loop.
+
+    Without this, transport-close callbacks scheduled during
+    ``HubServer.shutdown`` outlive the loop and surface as
+    ``RuntimeError: Event loop is closed`` at some later test's
+    teardown when GC dispatches them.
+    """
+    try:
+        pending = [t for t in asyncio.all_tasks(loop) if not t.done()]
+        for t in pending:
+            t.cancel()
+        if pending:
+            loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
+        loop.run_until_complete(loop.shutdown_asyncgens())
+    finally:
+        loop.close()
+
+
 class _FakeListener:
     """Captures `send_to_surfer` calls; mirrors the listener observer hook."""
 
@@ -80,7 +99,7 @@ class _HubInThread:
                 self.started.set()
                 raise
             finally:
-                loop.close()
+                _drain_and_close(loop)
 
         self.thread = threading.Thread(target=_runner, daemon=True, name="hub-thread")
         self.thread.start()


### PR DESCRIPTION
## Summary

Fix a teardown race in the `_ThreadedHub` test helper used by `tests/test_hub_send_cli.py` and `tests/test_wave_hub_bridge.py`. The old `finally: loop.close()` in `_runner()` closes the loop while `HubServer.shutdown()`'s transport-close callbacks are still pending — they later fire on a closed loop and surface as `RuntimeError: Event loop is closed` at a **subsequent** test's teardown (non-deterministic, depends on GC ordering).

Replace `loop.close()` with a `_drain_and_close` helper that:
1. Cancels pending tasks on the loop,
2. Gathers them with `return_exceptions=True`,
3. Runs `loop.shutdown_asyncgens()`,
4. Then closes.

Two inline copies (one per file) — both files already carry near-duplicate `_ThreadedHub` classes by design.

## Why now

The flake is pre-existing but newly amplified by additional `_ThreadedHub`-using suites in the pipeline (the more such fixtures run in a session, the more pending callbacks pile up). #181's CI tripped on it. Landing this on main first means downstream PRs can rebase and pass cleanly.

## Test plan

- [x] Reproduced the flake locally on main+#181 (2 errors per full-suite run, varying tests).
- [x] Applied the fix on main and ran the full suite **3 consecutive times** — 772 passed, 3 skipped, 0 errors each time.
- [ ] Wait for CI green on this PR.
- [ ] After merge, rebase #181 and confirm its pytest goes green (it carries a third copy of `_ThreadedHub` in `test_cdc_publisher.py` that will need the same drain — easy follow-up on that PR).

## Out of scope

- Consolidating the three `_ThreadedHub` copies into a shared helper. Doable as a separate refactor PR; the drain pattern is small enough that two duplicates is fine for now.