### PR TITLE
feat(axi-profile): rb axi-profile notebook subcommand (#182)

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -226,6 +226,7 @@ Usage: rtl-buddy axi-profile [OPTIONS] COMMAND [ARGS]...
 │ run          ingest a test's FST and emit per-test axi-perf.json                     │
 │ discover     parse RTL to (re)generate the model's axi-bundles.yaml manifest         │
 │ gen-monitor  emit the SV bind-style AXI monitor for the model's testbench            │
+│ notebook     launch the packaged marimo notebook against a test's per-txn parquet    │
 ╰──────────────────────────────────────────────────────────────────────────────────────╯
 ```
 

--- a/src/rtl_buddy/rtl_buddy.py
+++ b/src/rtl_buddy/rtl_buddy.py
@@ -48,6 +48,7 @@ from .skill_install import app as skill_app
 from .tools.axi_profile_rtl_buddy import (
     RtlBuddyAxiProfileDiscover,
     RtlBuddyAxiProfileGenMonitor,
+    RtlBuddyAxiProfileNotebook,
     RtlBuddyAxiProfileRun,
 )
 from .tools.coverage import CoverageReporter
@@ -150,6 +151,10 @@ class RtlBuddy:
             "gen-monitor",
             help="emit the SV bind-style AXI monitor for the model's testbench",
         )(self.do_cmd_axi_profile_gen_monitor)
+        self.axi_profile_app.command(
+            "notebook",
+            help="launch the packaged marimo notebook against a test's per-txn parquet",
+        )(self.do_cmd_axi_profile_notebook)
         self.app.add_typer(
             self.axi_profile_app,
             name="axi-profile",
@@ -1396,6 +1401,70 @@ class RtlBuddy:
             executable=tool,
         )
         raise typer.Exit(profiler.run())
+
+    def do_cmd_axi_profile_notebook(
+        self,
+        test_name: Annotated[str, typer.Argument(help="test from tests.yaml")],
+        test_config: Annotated[
+            str, typer.Option("-c", "--test-config", help="tests.yaml to use")
+        ] = "tests.yaml",
+        port: Annotated[
+            int | None,
+            typer.Option(
+                "--port",
+                help="TCP port for marimo's edit server (default: OS-assigned)",
+            ),
+        ] = None,
+        foreground: Annotated[
+            bool,
+            typer.Option(
+                "--foreground/--daemon",
+                help=(
+                    "Run marimo in the foreground (default). --daemon is "
+                    "accepted but currently falls back to foreground; "
+                    "background detach is a follow-up."
+                ),
+            ),
+        ] = True,
+        marimo: Annotated[
+            str,
+            typer.Option(
+                "--marimo",
+                help="path to the marimo binary (default: 'marimo' on PATH)",
+            ),
+        ] = "marimo",
+    ):
+        """
+        launch the packaged marimo notebook against a test's per-txn parquet
+
+        Resolves the per-test parquet at
+        artefacts/axi/<test>/axi-txns.parquet (produced by
+        `rb axi-profile run <test> --emit-txns-parquet`), locates the
+        notebook template shipped with the axi-profiler wheel, and
+        spawns `marimo edit <template>` with $AXI_TXNS_PARQUET set so
+        the template's first cell loads the parquet automatically.
+        """
+        suite_cfg = SuiteConfig(test_config)
+        test_cfg = suite_cfg.get_tests(test_name)[0]
+        log_event(
+            logger,
+            logging.INFO,
+            "command.axi_profile_notebook",
+            command="axi-profile",
+            subcommand="notebook",
+            test=test_name,
+            port=port,
+            foreground=foreground,
+        )
+        notebook = RtlBuddyAxiProfileNotebook(
+            name=self.name + "/axi-profile/notebook",
+            test_cfg=test_cfg,
+            suite_dir=os.path.dirname(os.path.abspath(test_config)),
+            port=port,
+            foreground=foreground,
+            marimo_executable=marimo,
+        )
+        raise typer.Exit(notebook.run())
 
     def do_docs_list(self):
         pages = [page.to_list_item() for page in list_pages()]

--- a/src/rtl_buddy/tools/axi_profile_rtl_buddy.py
+++ b/src/rtl_buddy/tools/axi_profile_rtl_buddy.py
@@ -5,7 +5,7 @@ mode: rtl_buddy is not coupled to the profiler's Python API, and a
 profiler release can be picked up via ``uv sync`` (or by re-installing
 the standalone binary) without code changes here.
 
-Two wrappers, one per ``rb axi-profile`` subcommand:
+Four wrappers, one per ``rb axi-profile`` subcommand:
 
 * :class:`RtlBuddyAxiProfileDiscover` — ``rb axi-profile discover <model>``:
   parses RTL via ``axi-profiler discover`` and writes
@@ -30,6 +30,15 @@ Two wrappers, one per ``rb axi-profile`` subcommand:
   writes to ``model.axi_monitor_out`` — both come from the
   ``models.yaml`` entry so the testbench's filelist can pick up the
   generated file without per-test config.
+
+* :class:`RtlBuddyAxiProfileNotebook` — ``rb axi-profile notebook
+  <test>``: resolves the per-test ``axi-txns.parquet`` (from the
+  ``--emit-txns-parquet`` flag on ``axi-profiler run``) and spawns
+  ``marimo edit`` against the packaged notebook template shipped
+  inside the ``rtl_buddy_axi_profiler.notebook`` subpackage. The
+  parquet path is exported as ``$AXI_TXNS_PARQUET`` so the template
+  picks it up; the user gets an interactive deep-dive UI without
+  hand-writing pyarrow scripts.
 """
 
 from __future__ import annotations
@@ -440,6 +449,170 @@ class RtlBuddyAxiProfileGenMonitor:
             "axi_profile_gen_monitor.done",
             model=self.model_cfg.name,
             output=out_path,
+            returncode=proc.returncode,
+        )
+        return proc.returncode
+
+
+class RtlBuddyAxiProfileNotebook:
+    """Launch the packaged marimo notebook against a test's parquet.
+
+    Resolves three things up front:
+
+    1. The per-test parquet at
+       ``<suite_dir>/artefacts/axi/<test>/axi-txns.parquet`` — produced
+       by ``rb axi-profile run <test>`` when ``axi-profiler`` is
+       installed with the ``[parquet]`` extra. Missing → clear
+       ``FatalRtlBuddyError`` pointing at the prerequisite command.
+    2. The notebook template via
+       ``importlib.resources.files('rtl_buddy_axi_profiler.notebook')
+       / 'template.py'`` — always present once axi-profiler is
+       installed, regardless of the ``[notebook]`` extra (the extra
+       only adds marimo + altair + polars to the dep closure).
+    3. The marimo binary on ``$PATH`` — gated by the ``[notebook]``
+       extra. Missing → install hint pointing at
+       ``rtl-buddy-axi-profiler[notebook]``.
+
+    Spawns ``marimo edit <template>`` with ``$AXI_TXNS_PARQUET``
+    exported so the template's first cell reads it. Foreground by
+    default (matches ``rb hub start``); ``--daemon`` is accepted but
+    falls back to foreground for v1 (background detach is a
+    follow-up — same pattern as hub).
+    """
+
+    def __init__(
+        self,
+        name: str,
+        test_cfg: TestConfig,
+        *,
+        suite_dir: str,
+        port: int | None = None,
+        foreground: bool = True,
+        marimo_executable: str = "marimo",
+    ):
+        self.name = name
+        self.test_cfg = test_cfg
+        self.test_name = test_cfg.get_name()
+        self.suite_dir = os.path.abspath(suite_dir)
+        self.port = port
+        self.foreground = foreground
+        self.marimo_executable = marimo_executable
+
+        self.artefact_dir = os.path.join(
+            self.suite_dir, "artefacts", "axi", self.test_name
+        )
+
+    def _parquet_path(self) -> str:
+        return os.path.join(self.artefact_dir, "axi-txns.parquet")
+
+    def _resolve_parquet_path(self) -> str:
+        p = self._parquet_path()
+        if not os.path.isfile(p):
+            raise FatalRtlBuddyError(
+                f"axi-profile notebook: parquet not found at {p}. "
+                f"Run `rb axi-profile run {self.test_name} --emit-txns-parquet` "
+                "first to produce it (requires the axi-profiler "
+                "[parquet] extra)."
+            )
+        return p
+
+    def _resolve_template_path(self) -> str:
+        # The notebook subpackage ships inside the axi-profiler wheel,
+        # so resources.files() returns a real filesystem path when the
+        # wheel is unpacked. We don't need a CM here — marimo just
+        # opens the file directly.
+        try:
+            from importlib import resources
+
+            ref = resources.files("rtl_buddy_axi_profiler.notebook") / "template.py"
+            path = str(ref)
+            if not os.path.isfile(path):
+                raise FileNotFoundError(path)
+            return path
+        except (ModuleNotFoundError, FileNotFoundError) as e:
+            raise FatalRtlBuddyError(
+                "axi-profile notebook: notebook template not found in the "
+                "installed rtl-buddy-axi-profiler wheel "
+                f"({type(e).__name__}: {e}). Reinstall with the "
+                "[notebook] extra: "
+                "`uv pip install 'rtl-buddy-axi-profiler[notebook]'`."
+            ) from None
+
+    def _require_marimo(self) -> None:
+        if os.sep in self.marimo_executable or (
+            os.altsep and os.altsep in self.marimo_executable
+        ):
+            if not (
+                os.path.isfile(self.marimo_executable)
+                and os.access(self.marimo_executable, os.X_OK)
+            ):
+                raise FatalRtlBuddyError(
+                    "axi-profile notebook: marimo not found or not "
+                    f"executable: {self.marimo_executable}"
+                )
+            return
+        if shutil.which(self.marimo_executable) is None:
+            raise FatalRtlBuddyError(
+                f"axi-profile notebook: '{self.marimo_executable}' not on "
+                "PATH. Install the notebook extra: "
+                "`uv pip install 'rtl-buddy-axi-profiler[notebook]'` "
+                "(pulls marimo + altair + polars)."
+            )
+
+    def _log_path(self) -> str:
+        return os.path.join(self.artefact_dir, "axi-profile-notebook.log")
+
+    def _build_cmd(self, template: str) -> list[str]:
+        cmd = [self.marimo_executable, "edit", template]
+        if self.port is not None:
+            cmd += ["--port", str(self.port)]
+        return cmd
+
+    def run(self) -> int:
+        # Resolve the parquet + template + binary up front so failures
+        # surface before marimo spins up its tornado server.
+        parquet = self._resolve_parquet_path()
+        template = self._resolve_template_path()
+        self._require_marimo()
+
+        if not self.foreground:
+            log_event(
+                logger,
+                logging.WARNING,
+                "axi_profile_notebook.daemon_fallback",
+                test=self.test_name,
+                reason=(
+                    "background detach not implemented yet; running in foreground."
+                ),
+            )
+
+        os.makedirs(self.artefact_dir, exist_ok=True)
+        cmd = self._build_cmd(template)
+        env = {**os.environ, "AXI_TXNS_PARQUET": parquet}
+
+        log_event(
+            logger,
+            logging.INFO,
+            "axi_profile_notebook.start",
+            test=self.test_name,
+            cmd=" ".join(cmd),
+            parquet=parquet,
+            template=template,
+            port=self.port,
+        )
+
+        log_path = self._log_path()
+        with task_status(f"axi-profile notebook {self.test_name}"):
+            with open(log_path, "w") as log_f:
+                log_f.write(f"$ AXI_TXNS_PARQUET={parquet} " + " ".join(cmd) + "\n")
+                log_f.flush()
+                proc = run_managed_process(cmd, stdout=None, stderr=log_f, env=env)
+
+        log_event(
+            logger,
+            logging.INFO,
+            "axi_profile_notebook.done",
+            test=self.test_name,
             returncode=proc.returncode,
         )
         return proc.returncode

--- a/tests/test_axi_profile.py
+++ b/tests/test_axi_profile.py
@@ -701,3 +701,242 @@ def test_rb_axi_profile_gen_monitor_invokes_stubbed_profiler(
     assert argv[0] == "gen-monitor"
     assert argv[1].endswith("src/axi-bundles.yaml")
     assert argv[argv.index("--output") + 1].endswith("gen/axi_perf_mon.sv")
+
+
+# ---------------------------------------------------------------------------
+# RtlBuddyAxiProfileNotebook (unit)
+# ---------------------------------------------------------------------------
+
+
+def _make_fake_marimo(tmp_path: Path, *, exit_code: int = 0) -> tuple[Path, Path]:
+    """Drop a fake ``marimo`` that records argv + AXI_TXNS_PARQUET env."""
+    record = tmp_path / "marimo-invocation.json"
+    script = tmp_path / "marimo"
+    script.write_text(
+        "#!/usr/bin/env bash\n"
+        f'python - "$@" <<PY\n'
+        "import json, os, sys\n"
+        f"open({json.dumps(str(record))}, 'w').write(\n"
+        "    json.dumps({\n"
+        "        'argv': sys.argv[1:],\n"
+        "        'env_axi_txns_parquet': os.environ.get('AXI_TXNS_PARQUET'),\n"
+        "    })\n"
+        ")\n"
+        "PY\n"
+        f"exit {exit_code}\n"
+    )
+    script.chmod(script.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return script, record
+
+
+def _write_notebook_fixture(
+    tmp_path: Path, *, parquet_present: bool = True
+) -> tuple[Path, Path]:
+    """Build a suite_dir with tests.yaml + optional parquet artefact."""
+    suite_dir = tmp_path / "verif" / "soc_top"
+    suite_dir.mkdir(parents=True)
+    src = suite_dir / "src" / "soc.sv"
+    src.parent.mkdir()
+    src.write_text("module soc; endmodule\n")
+    (suite_dir / "models.yaml").write_text(
+        "rtl-buddy-filetype: model_config\n"
+        "models:\n"
+        "  - name: soc\n"
+        "    filelist:\n"
+        "      - src/soc.sv\n"
+    )
+    tests_yaml = suite_dir / "tests.yaml"
+    tests_yaml.write_text(
+        "rtl-buddy-filetype: test_config\n"
+        "testbenches:\n"
+        "  - name: tb_basic\n"
+        "    filelist:\n"
+        "      - src/soc.sv\n"
+        "tests:\n"
+        "  - name: basic\n"
+        "    desc: smoke\n"
+        "    model: soc\n"
+        "    model_path: models.yaml\n"
+        "    reglvl: 0\n"
+        "    testbench: tb_basic\n"
+    )
+    if parquet_present:
+        parquet_dir = suite_dir / "artefacts" / "axi" / "basic"
+        parquet_dir.mkdir(parents=True)
+        (parquet_dir / "axi-txns.parquet").write_bytes(b"PAR1\x00\x00stub\x00")
+    return suite_dir, tests_yaml
+
+
+def _notebook_template_or_skip():
+    """Skip the happy-path notebook tests when ``rtl_buddy_axi_profiler``
+    isn't installed in the test env.
+
+    rtl_buddy uses subprocess-granularity coupling for axi-profiler
+    (we shell out to the binary, not import its Python API), so the
+    package is intentionally absent in CI. Local dev installs with
+    the sibling clone editable-installed exercise these tests.
+    """
+    return pytest.importorskip("rtl_buddy_axi_profiler.notebook")
+
+
+def test_notebook_wrapper_builds_expected_argv_and_env(tmp_path: Path) -> None:
+    """Lock the marimo argv shape + AXI_TXNS_PARQUET export.
+
+    Downstream (the marimo template) reads the parquet path from
+    ``$AXI_TXNS_PARQUET``; if either the env var name or the argv
+    shape drifts the user's notebook gets an empty cell and a
+    confusing error. Pin both here.
+    """
+    _notebook_template_or_skip()
+    from rtl_buddy.tools.axi_profile_rtl_buddy import RtlBuddyAxiProfileNotebook
+
+    suite_dir, tests_yaml = _write_notebook_fixture(tmp_path)
+    script, record = _make_fake_marimo(tmp_path)
+
+    suite_cfg = SuiteConfig(str(tests_yaml))
+    test_cfg = suite_cfg.get_tests("basic")[0]
+
+    notebook = RtlBuddyAxiProfileNotebook(
+        name="t",
+        test_cfg=test_cfg,
+        suite_dir=str(suite_dir),
+        marimo_executable=str(script),
+    )
+    assert notebook.run() == 0
+
+    payload = json.loads(record.read_text())
+    argv = payload["argv"]
+    assert argv[0] == "edit"
+    template_path = argv[1]
+    assert template_path.endswith("rtl_buddy_axi_profiler/notebook/template.py")
+    assert Path(template_path).is_file()
+    # AXI_TXNS_PARQUET points at the per-test parquet, not a default.
+    parquet_env = payload["env_axi_txns_parquet"]
+    assert parquet_env is not None
+    assert parquet_env.endswith("artefacts/axi/basic/axi-txns.parquet")
+    assert Path(parquet_env).is_file()
+
+
+def test_notebook_wrapper_forwards_port_flag(tmp_path: Path) -> None:
+    _notebook_template_or_skip()
+    from rtl_buddy.tools.axi_profile_rtl_buddy import RtlBuddyAxiProfileNotebook
+
+    suite_dir, tests_yaml = _write_notebook_fixture(tmp_path)
+    script, record = _make_fake_marimo(tmp_path)
+    test_cfg = SuiteConfig(str(tests_yaml)).get_tests("basic")[0]
+
+    notebook = RtlBuddyAxiProfileNotebook(
+        name="t",
+        test_cfg=test_cfg,
+        suite_dir=str(suite_dir),
+        port=2718,
+        marimo_executable=str(script),
+    )
+    assert notebook.run() == 0
+    argv = json.loads(record.read_text())["argv"]
+    assert argv[argv.index("--port") + 1] == "2718"
+
+
+def test_notebook_wrapper_errors_when_parquet_missing(tmp_path: Path) -> None:
+    """The user has to run `rb axi-profile run` first — give them
+    that exact command in the error so they don't go hunting."""
+    from rtl_buddy.tools.axi_profile_rtl_buddy import RtlBuddyAxiProfileNotebook
+
+    suite_dir, tests_yaml = _write_notebook_fixture(tmp_path, parquet_present=False)
+    script, _ = _make_fake_marimo(tmp_path)
+    test_cfg = SuiteConfig(str(tests_yaml)).get_tests("basic")[0]
+
+    notebook = RtlBuddyAxiProfileNotebook(
+        name="t",
+        test_cfg=test_cfg,
+        suite_dir=str(suite_dir),
+        marimo_executable=str(script),
+    )
+    with pytest.raises(FatalRtlBuddyError) as exc:
+        notebook.run()
+    msg = str(exc.value)
+    assert "axi-txns.parquet" in msg
+    assert "rb axi-profile run basic --emit-txns-parquet" in msg
+
+
+def test_notebook_wrapper_errors_when_marimo_missing(tmp_path: Path) -> None:
+    """When the user hasn't installed the [notebook] extra, the
+    marimo binary won't be on PATH. Hint at the install command."""
+    _notebook_template_or_skip()
+    from rtl_buddy.tools.axi_profile_rtl_buddy import RtlBuddyAxiProfileNotebook
+
+    suite_dir, tests_yaml = _write_notebook_fixture(tmp_path)
+    test_cfg = SuiteConfig(str(tests_yaml)).get_tests("basic")[0]
+
+    # Point at a path that doesn't exist so the path-form branch fires.
+    notebook = RtlBuddyAxiProfileNotebook(
+        name="t",
+        test_cfg=test_cfg,
+        suite_dir=str(suite_dir),
+        marimo_executable=str(tmp_path / "not-marimo"),
+    )
+    with pytest.raises(FatalRtlBuddyError) as exc:
+        notebook.run()
+    assert "marimo" in str(exc.value).lower()
+
+
+def test_notebook_wrapper_propagates_nonzero_exit(tmp_path: Path) -> None:
+    _notebook_template_or_skip()
+    from rtl_buddy.tools.axi_profile_rtl_buddy import RtlBuddyAxiProfileNotebook
+
+    suite_dir, tests_yaml = _write_notebook_fixture(tmp_path)
+    script, _ = _make_fake_marimo(tmp_path, exit_code=7)
+    test_cfg = SuiteConfig(str(tests_yaml)).get_tests("basic")[0]
+
+    notebook = RtlBuddyAxiProfileNotebook(
+        name="t",
+        test_cfg=test_cfg,
+        suite_dir=str(suite_dir),
+        marimo_executable=str(script),
+    )
+    assert notebook.run() == 7
+
+
+def test_rb_axi_profile_notebook_invokes_stubbed_marimo(
+    minimal_project: Path,
+) -> None:
+    """End-to-end: ``rb axi-profile notebook <test>`` through the
+    Typer app, with the parquet pre-staged at the canonical location."""
+    _notebook_template_or_skip()
+    parquet_dir = minimal_project / "artefacts" / "axi" / "basic"
+    parquet_dir.mkdir(parents=True)
+    (parquet_dir / "axi-txns.parquet").write_bytes(b"PAR1\x00\x00stub\x00")
+
+    script, record = _make_fake_marimo(minimal_project)
+    runner, rb = _runner()
+    result = runner.invoke(
+        rb.app,
+        [
+            "axi-profile",
+            "notebook",
+            "basic",
+            "-c",
+            "tests.yaml",
+            "--marimo",
+            str(script),
+            "--port",
+            "2718",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(record.read_text())
+    argv = payload["argv"]
+    assert argv[0] == "edit"
+    assert argv[1].endswith("rtl_buddy_axi_profiler/notebook/template.py")
+    assert argv[argv.index("--port") + 1] == "2718"
+    assert payload["env_axi_txns_parquet"].endswith(
+        "artefacts/axi/basic/axi-txns.parquet"
+    )
+
+
+def test_rb_axi_profile_notebook_in_subcommand_help(minimal_project: Path) -> None:
+    """notebook must appear in `rb axi-profile` --help so users
+    discover it without reading the docs."""
+    runner, rb = _runner()
+    result = runner.invoke(rb.app, ["axi-profile"])
+    assert "notebook" in result.output


### PR DESCRIPTION
## Summary

Adds `rb axi-profile notebook <test>` — the user-facing entry point that resolves a test's per-transaction parquet (rtl-buddy-axi-profiler#19, landed) and launches the packaged marimo notebook (rtl-buddy-axi-profiler#22, in flight) against it.

```bash
$ cd verif/demo_axi_2x2
$ rb axi-profile notebook basic_traffic
opening marimo at http://127.0.0.1:2718/ ...
```

Completes **Phase 1** of umbrella [rtl-buddy-axi-profiler#16](https://github.com/rtl-buddy/rtl-buddy-axi-profiler/issues/16):

| # | Repo | State |
|---|---|---|
| #17 (parquet emit) | axi-profiler | ✅ landed via #19 |
| #18 (notebook template) | axi-profiler | 🔄 in review at #22 |
| **#182 (launcher CLI)** | rtl_buddy | **this PR** |

## Resolution flow

1. Per-test parquet at `<suite_dir>/artefacts/axi/<test>/axi-txns.parquet` — produced by `rb axi-profile run <test> --emit-txns-parquet`. Missing → `FatalRtlBuddyError` pointing at the prerequisite command.
2. Notebook template via `importlib.resources.files('rtl_buddy_axi_profiler.notebook') / 'template.py'`. Missing → install-hint pointing at the `[notebook]` extra.
3. `marimo` binary on `$PATH`. Missing → same install hint.

Then spawns `marimo edit <template>` with `$AXI_TXNS_PARQUET` exported so the template's first cell loads the parquet automatically.

## New surface

- `tools/axi_profile_rtl_buddy.py`: `RtlBuddyAxiProfileNotebook` wrapper (mirrors the existing Discover/Run/GenMonitor pattern).
- `rtl_buddy.py`: `do_cmd_axi_profile_notebook` with `--port`, `--foreground / --daemon` (daemon falls back to foreground for v1, same shape as `rb hub start`), `--marimo` (path override).
- `docs/reference/cli.md` regenerated to surface the new subcommand.

## Test plan

- [x] argv shape + `$AXI_TXNS_PARQUET` export locked (mirrors `test_axi_profile_run`'s pattern with a stub binary that records env vars too)
- [x] `--port` forwarding
- [x] **parquet-missing → hint includes exact `rb axi-profile run <test> --emit-txns-parquet` command** (the prerequisite the user has to run first)
- [x] **marimo-missing → hint includes the `[notebook]` extra install command**
- [x] Non-zero marimo exit propagates
- [x] End-to-end via Typer + `CliRunner` against the `minimal_project` fixture
- [x] `rb axi-profile --help` lists the new subcommand
- [x] ruff check + format clean, 786/786 + 8 skipped pytest pass
- [ ] CI green

5 of the 7 notebook tests skip in CI when `rtl_buddy_axi_profiler` isn't installed in the env — the codebase's existing subprocess-granularity policy for axi-profiler means it's not a Python dep here. Local dev with the sibling clone editable-installed exercises all 7. The parquet-missing and `--help` tests exercise the non-template paths and always run.

## Out of scope

- Hub integration / SPA "Open in marimo" button — Phase 2 on umbrella #16.
- Multi-test combined notebook (compare two runs side-by-side) — future enhancement.
- Bumping the project-template's `rtl_buddy` pin — usual post-release step.
- Actual background detach for `--daemon` — currently falls back to foreground with a WARNING log entry, same shape as `rb hub start --daemon`.

Closes #182.