### PR TITLE
feat(axi-profile): plumb --emit-txns-parquet through rb axi-profile run

### DIFF
--- a/src/rtl_buddy/rtl_buddy.py
+++ b/src/rtl_buddy/rtl_buddy.py
@@ -1295,6 +1295,28 @@ class RtlBuddy:
                 ),
             ),
         ] = None,
+        emit_txns_parquet: Annotated[
+            bool,
+            typer.Option(
+                "--emit-txns-parquet",
+                help=(
+                    "Also emit a per-transaction parquet artifact at "
+                    "artefacts/axi/<test>/axi-txns.parquet — the canonical "
+                    "location `rb axi-profile notebook` reads. Requires "
+                    "the axi-profiler [parquet] extra (pyarrow)."
+                ),
+            ),
+        ] = False,
+        emit_txns_parquet_path: Annotated[
+            str | None,
+            typer.Option(
+                "--emit-txns-parquet-path",
+                help=(
+                    "Explicit path for the per-transaction parquet "
+                    "artefact. Implies --emit-txns-parquet."
+                ),
+            ),
+        ] = None,
         tool: Annotated[
             str,
             typer.Option("--tool", help="path to the axi-profiler binary"),
@@ -1306,10 +1328,23 @@ class RtlBuddy:
         Looks up `<test>` in tests.yaml, resolves the model, the
         checked-in axi-bundles.yaml manifest (model.axi_bundles in
         models.yaml), and the FST at artefacts/<test>/dump.fst, then
-        invokes axi-profiler run.
+        invokes axi-profiler run. Pass --emit-txns-parquet to also
+        produce the per-transaction parquet artefact that
+        `rb axi-profile notebook` consumes.
         """
         suite_cfg = SuiteConfig(test_config)
         test_cfg = suite_cfg.get_tests(test_name)[0]
+        # Resolve parquet emit:
+        #   explicit path → use it
+        #   bare --emit-txns-parquet → empty-string sentinel → wrapper picks default
+        #   neither → None → no emit (legacy behaviour)
+        parquet_arg: str | None
+        if emit_txns_parquet_path is not None:
+            parquet_arg = emit_txns_parquet_path
+        elif emit_txns_parquet:
+            parquet_arg = ""
+        else:
+            parquet_arg = None
         log_event(
             logger,
             logging.INFO,
@@ -1320,6 +1355,7 @@ class RtlBuddy:
             model=test_cfg.get_model().name,
             output=output,
             tb_prefix=tb_prefix,
+            emit_txns_parquet=parquet_arg,
         )
         profiler = RtlBuddyAxiProfileRun(
             name=self.name + "/axi-profile/run",
@@ -1327,6 +1363,7 @@ class RtlBuddy:
             suite_dir=os.path.dirname(os.path.abspath(test_config)),
             output=output,
             tb_prefix_override=tb_prefix,
+            emit_txns_parquet=parquet_arg,
             executable=tool,
         )
         raise typer.Exit(profiler.run())

--- a/src/rtl_buddy/tools/axi_profile_rtl_buddy.py
+++ b/src/rtl_buddy/tools/axi_profile_rtl_buddy.py
@@ -196,6 +196,7 @@ class RtlBuddyAxiProfileRun:
         suite_dir: str,
         output: str | None = None,
         tb_prefix_override: str | None = None,
+        emit_txns_parquet: str | None = None,
         executable: str = "axi-profiler",
     ):
         self.name = name
@@ -205,6 +206,12 @@ class RtlBuddyAxiProfileRun:
         self.suite_dir = os.path.abspath(suite_dir)
         self.output_override = output
         self.tb_prefix_override = tb_prefix_override
+        # None  → don't emit a parquet (axi-perf.json only, legacy default).
+        # str "" → emit at the artefact-dir default (axi-txns.parquet next
+        #          to axi-perf.json — convention `rb axi-profile notebook`
+        #          looks for).
+        # str path → emit at that explicit path.
+        self.emit_txns_parquet = emit_txns_parquet
         self.executable = executable
 
         artefact_root = Path(self.suite_dir) / "artefacts" / "axi" / self.test_name
@@ -219,6 +226,9 @@ class RtlBuddyAxiProfileRun:
 
     def _default_output_path(self) -> str:
         return os.path.join(self.artefact_dir, "axi-perf.json")
+
+    def _default_parquet_path(self) -> str:
+        return os.path.join(self.artefact_dir, "axi-txns.parquet")
 
     def _fst_path(self) -> str:
         # Same convention as `rb wave`: artefacts/<test>/dump.fst.
@@ -273,7 +283,13 @@ class RtlBuddyAxiProfileRun:
         return fl_path
 
     def _build_cmd(
-        self, fl_path: str, manifest: str, fst: str, out_path: str, tb_prefix: str
+        self,
+        fl_path: str,
+        manifest: str,
+        fst: str,
+        out_path: str,
+        tb_prefix: str,
+        parquet_path: str | None,
     ) -> list[str]:
         cmd = [
             self.executable,
@@ -291,6 +307,8 @@ class RtlBuddyAxiProfileRun:
         ]
         if tb_prefix:
             cmd += ["--tb-prefix", tb_prefix]
+        if parquet_path is not None:
+            cmd += ["--emit-txns-parquet", parquet_path]
         return cmd
 
     def run(self) -> int:
@@ -300,9 +318,18 @@ class RtlBuddyAxiProfileRun:
         fst = self._resolve_fst_path()
         tb_prefix = self._resolve_tb_prefix()
         out_path = self.output_override or self._default_output_path()
+        # Resolve the parquet destination: empty-string → artefact-dir
+        # default (canonical location for `rb axi-profile notebook`).
+        parquet_path: str | None
+        if self.emit_txns_parquet is None:
+            parquet_path = None
+        elif self.emit_txns_parquet == "":
+            parquet_path = self._default_parquet_path()
+        else:
+            parquet_path = self.emit_txns_parquet
 
         fl_path = self._write_filelist()
-        cmd = self._build_cmd(fl_path, manifest, fst, out_path, tb_prefix)
+        cmd = self._build_cmd(fl_path, manifest, fst, out_path, tb_prefix, parquet_path)
 
         log_event(
             logger,

--- a/tests/test_axi_profile.py
+++ b/tests/test_axi_profile.py
@@ -398,6 +398,98 @@ def test_run_wrapper_errors_when_fst_missing(tmp_path: Path) -> None:
     assert "rb test basic" in msg
 
 
+def test_run_wrapper_emits_parquet_at_artefact_default(tmp_path: Path) -> None:
+    """Empty-string `emit_txns_parquet` → wrapper picks the artefact-dir
+    default that `rb axi-profile notebook` reads (axi-txns.parquet
+    next to axi-perf.json)."""
+    suite_dir, tests_yaml = _write_run_fixture(tmp_path)
+    script, record = _make_fake_profiler(tmp_path)
+    test_cfg = SuiteConfig(str(tests_yaml)).get_tests("basic")[0]
+
+    profiler = RtlBuddyAxiProfileRun(
+        name="t",
+        test_cfg=test_cfg,
+        suite_dir=str(suite_dir),
+        emit_txns_parquet="",
+        executable=str(script),
+    )
+    assert profiler.run() == 0
+    argv = json.loads(record.read_text())
+    parquet_arg = argv[argv.index("--emit-txns-parquet") + 1]
+    assert parquet_arg.endswith("artefacts/axi/basic/axi-txns.parquet")
+
+
+def test_run_wrapper_emits_parquet_at_explicit_path(tmp_path: Path) -> None:
+    """Explicit path wins over the default."""
+    suite_dir, tests_yaml = _write_run_fixture(tmp_path)
+    script, record = _make_fake_profiler(tmp_path)
+    test_cfg = SuiteConfig(str(tests_yaml)).get_tests("basic")[0]
+    custom = tmp_path / "elsewhere" / "my-txns.parquet"
+
+    profiler = RtlBuddyAxiProfileRun(
+        name="t",
+        test_cfg=test_cfg,
+        suite_dir=str(suite_dir),
+        emit_txns_parquet=str(custom),
+        executable=str(script),
+    )
+    assert profiler.run() == 0
+    argv = json.loads(record.read_text())
+    assert argv[argv.index("--emit-txns-parquet") + 1] == str(custom)
+
+
+def test_run_wrapper_omits_parquet_flag_by_default(tmp_path: Path) -> None:
+    """Legacy behaviour: no --emit-txns-parquet flag unless asked."""
+    suite_dir, tests_yaml = _write_run_fixture(tmp_path)
+    script, record = _make_fake_profiler(tmp_path)
+    test_cfg = SuiteConfig(str(tests_yaml)).get_tests("basic")[0]
+
+    profiler = RtlBuddyAxiProfileRun(
+        name="t",
+        test_cfg=test_cfg,
+        suite_dir=str(suite_dir),
+        executable=str(script),
+    )
+    assert profiler.run() == 0
+    argv = json.loads(record.read_text())
+    assert "--emit-txns-parquet" not in argv
+
+
+def test_rb_axi_profile_run_emit_parquet_via_cli(minimal_project: Path) -> None:
+    """End-to-end: `rb axi-profile run --emit-txns-parquet` plumbs the
+    flag through to axi-profiler with the artefact-dir default path."""
+    models_yaml = minimal_project / "models.yaml"
+    models_yaml.write_text(
+        models_yaml.read_text() + "    axi_bundles: src/axi-bundles.yaml\n"
+    )
+    (minimal_project / "src" / "axi-bundles.yaml").write_text(
+        "schema_version: '1.0'\nbundles: []\n"
+    )
+    fst_dir = minimal_project / "artefacts" / "basic"
+    fst_dir.mkdir(parents=True)
+    (fst_dir / "dump.fst").write_text("fake fst\n")
+
+    script, record = _make_fake_profiler(minimal_project)
+    runner, rb = _runner()
+    result = runner.invoke(
+        rb.app,
+        [
+            "axi-profile",
+            "run",
+            "basic",
+            "-c",
+            "tests.yaml",
+            "--emit-txns-parquet",
+            "--tool",
+            str(script),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    argv = json.loads(record.read_text())
+    parquet_arg = argv[argv.index("--emit-txns-parquet") + 1]
+    assert parquet_arg.endswith("artefacts/axi/basic/axi-txns.parquet")
+
+
 def test_run_wrapper_propagates_nonzero_exit(tmp_path: Path) -> None:
     suite_dir, tests_yaml = _write_run_fixture(tmp_path)
     script, _ = _make_fake_profiler(tmp_path, exit_code=4)


### PR DESCRIPTION
## Summary

Surfaces the per-transaction parquet emit flag (axi-profiler #19) on the rtl_buddy wrapper so users no longer have to drop to the underlying \`axi-profiler\` CLI just to produce the artefact that \`rb axi-profile notebook\` (#186) consumes.

```bash
rb axi-profile run basic_traffic --emit-txns-parquet
# → writes artefacts/axi/basic_traffic/axi-txns.parquet alongside axi-perf.json
rb axi-profile notebook basic_traffic
```

Gap caught while validating the end-to-end Phase 1 flow on the project-template demo.

## Surface

Two new flags on \`rb axi-profile run\`:

| flag | default | behaviour |
|---|---|---|
| \`--emit-txns-parquet\` | off | emit at \`artefacts/axi/<test>/axi-txns.parquet\` (canonical location for \`rb axi-profile notebook\`) |
| \`--emit-txns-parquet-path <PATH>\` | — | explicit destination override |

## Internals

Wrapper uses an empty-string sentinel on the \`emit_txns_parquet\` constructor arg:

- \`None\` → don't emit (legacy default)
- \`""\` → wrapper picks the artefact-dir default
- \`"path"\` → explicit path passed straight through

Keeps the wrapper free to compute the canonical default from \`self.artefact_dir\` while still honouring explicit paths.

## Test plan

- [x] Wrapper: empty-string → \`--emit-txns-parquet <artefact_dir>/axi-txns.parquet\`
- [x] Wrapper: explicit path passed verbatim
- [x] Wrapper: omitted → no flag (legacy behaviour locked)
- [x] CLI end-to-end: \`rb axi-profile run basic --emit-txns-parquet\` plumbs through with default path
- [x] ruff check + format clean, mypy clean
- [x] 795 passed + 8 skipped pytest pass locally
- [x] \`docs/reference/cli.md\` regenerated
- [ ] CI green

## Out of scope

- Always-emit parquet by default — kept opt-in until axi-profiler's \`[parquet]\` extra ships in a release that the template's pin tracks.
- Multi-output emit (json + parquet + future formats) — fine to address when a third artifact type lands.

Followup to #186 (rb axi-profile notebook); closes the launcher-side ergonomics gap.