### PR TITLE
feat(axi-profile): --headless flag on rb axi-profile notebook

### DIFF
--- a/src/rtl_buddy/rtl_buddy.py
+++ b/src/rtl_buddy/rtl_buddy.py
@@ -1463,6 +1463,19 @@ class RtlBuddy:
                 ),
             ),
         ] = True,
+        headless: Annotated[
+            bool,
+            typer.Option(
+                "--headless",
+                help=(
+                    "Forward `--headless --no-token` to marimo. Used by the "
+                    "hub-initiated 'Open in marimo' flow (Phase 2 of the "
+                    "marimo umbrella) — the SPA opens the URL itself, so "
+                    "marimo shouldn't auto-pop a browser and the auth "
+                    "token is disabled for the loopback-only handoff."
+                ),
+            ),
+        ] = False,
         marimo: Annotated[
             str,
             typer.Option(
@@ -1492,6 +1505,7 @@ class RtlBuddy:
             test=test_name,
             port=port,
             foreground=foreground,
+            headless=headless,
         )
         notebook = RtlBuddyAxiProfileNotebook(
             name=self.name + "/axi-profile/notebook",
@@ -1499,6 +1513,7 @@ class RtlBuddy:
             suite_dir=os.path.dirname(os.path.abspath(test_config)),
             port=port,
             foreground=foreground,
+            headless=headless,
             marimo_executable=marimo,
         )
         raise typer.Exit(notebook.run())

--- a/src/rtl_buddy/tools/axi_profile_rtl_buddy.py
+++ b/src/rtl_buddy/tools/axi_profile_rtl_buddy.py
@@ -515,6 +515,7 @@ class RtlBuddyAxiProfileNotebook:
         suite_dir: str,
         port: int | None = None,
         foreground: bool = True,
+        headless: bool = False,
         marimo_executable: str = "marimo",
     ):
         self.name = name
@@ -523,6 +524,12 @@ class RtlBuddyAxiProfileNotebook:
         self.suite_dir = os.path.abspath(suite_dir)
         self.port = port
         self.foreground = foreground
+        # ``headless`` is for the hub-launched flow (Phase 2 of the
+        # marimo umbrella) — the SPA opens the URL itself, so marimo
+        # shouldn't auto-pop a browser, and the auth token is
+        # disabled so the SPA can link directly without juggling
+        # secrets across the IPC boundary.
+        self.headless = headless
         self.marimo_executable = marimo_executable
 
         self.artefact_dir = os.path.join(
@@ -593,6 +600,12 @@ class RtlBuddyAxiProfileNotebook:
         cmd = [self.marimo_executable, "edit", template]
         if self.port is not None:
             cmd += ["--port", str(self.port)]
+        if self.headless:
+            # --headless: no auto-browser-pop; the SPA opens the URL.
+            # --no-token: the SPA can navigate to the URL without
+            # threading a per-session token through the hub → browser
+            # handoff. Loopback-only, so the security trade is fine.
+            cmd += ["--headless", "--no-token"]
         return cmd
 
     def run(self) -> int:

--- a/tests/test_axi_profile.py
+++ b/tests/test_axi_profile.py
@@ -929,6 +929,54 @@ def test_notebook_wrapper_forwards_port_flag(tmp_path: Path) -> None:
     assert argv[argv.index("--port") + 1] == "2718"
 
 
+def test_notebook_wrapper_forwards_headless_and_no_token(tmp_path: Path) -> None:
+    """The hub-initiated flow needs both ``--headless`` (so marimo
+    doesn't auto-pop a browser tab while the SPA also tries to open
+    the URL) and ``--no-token`` (so the SPA can navigate to the
+    printed URL without threading a per-session token through the
+    hub → SPA → browser handoff). Lock both as a pair."""
+    _notebook_template_or_skip()
+    from rtl_buddy.tools.axi_profile_rtl_buddy import RtlBuddyAxiProfileNotebook
+
+    suite_dir, tests_yaml = _write_notebook_fixture(tmp_path)
+    script, record = _make_fake_marimo(tmp_path)
+    test_cfg = SuiteConfig(str(tests_yaml)).get_tests("basic")[0]
+
+    notebook = RtlBuddyAxiProfileNotebook(
+        name="t",
+        test_cfg=test_cfg,
+        suite_dir=str(suite_dir),
+        headless=True,
+        marimo_executable=str(script),
+    )
+    assert notebook.run() == 0
+    argv = json.loads(record.read_text())["argv"]
+    assert "--headless" in argv
+    assert "--no-token" in argv
+
+
+def test_notebook_wrapper_omits_headless_by_default(tmp_path: Path) -> None:
+    """Default (CLI invocation) keeps marimo's normal token + auto-
+    open-browser behaviour — only the hub-initiated path opts in."""
+    _notebook_template_or_skip()
+    from rtl_buddy.tools.axi_profile_rtl_buddy import RtlBuddyAxiProfileNotebook
+
+    suite_dir, tests_yaml = _write_notebook_fixture(tmp_path)
+    script, record = _make_fake_marimo(tmp_path)
+    test_cfg = SuiteConfig(str(tests_yaml)).get_tests("basic")[0]
+
+    notebook = RtlBuddyAxiProfileNotebook(
+        name="t",
+        test_cfg=test_cfg,
+        suite_dir=str(suite_dir),
+        marimo_executable=str(script),
+    )
+    assert notebook.run() == 0
+    argv = json.loads(record.read_text())["argv"]
+    assert "--headless" not in argv
+    assert "--no-token" not in argv
+
+
 def test_notebook_wrapper_errors_when_parquet_missing(tmp_path: Path) -> None:
     """The user has to run `rb axi-profile run` first — give them
     that exact command in the error so they don't go hunting."""


### PR DESCRIPTION
## Summary

Forwards \`--headless --no-token\` to marimo so the spawned edit server doesn't auto-open a browser tab and doesn't require an auth token. Targeted at the upcoming **hub-initiated "Open in marimo" flow** — Phase 2 of the marimo umbrella ([axi-profiler #16](https://github.com/rtl-buddy/rtl-buddy-axi-profiler/issues/16)) — where:

- The SPA is about to open the URL itself. Marimo's own auto-pop competes with the SPA navigation; \`--headless\` suppresses it.
- Threading a per-session access token through the hub → SPA → browser handoff is needless friction for a loopback-only IPC; \`--no-token\` makes the URL self-contained.

Default behaviour (CLI invocation: \`rb axi-profile notebook <test>\`) is **unchanged** — marimo still auto-opens the browser and requires the token. Only \`--headless\` opts into the hub-friendly behaviour.

## Surface

\`\`\`bash
# Existing flow — unchanged
rb axi-profile notebook basic_traffic

# New: hub-friendly mode
rb axi-profile notebook basic_traffic --headless --port 2719
# → marimo edit ... --port 2719 --headless --no-token
# → prints URL like http://localhost:2719/ (no token query string)
\`\`\`

## Test plan

- [x] New \`test_notebook_wrapper_forwards_headless_and_no_token\` asserts both flags land in the marimo argv when \`headless=True\`.
- [x] New \`test_notebook_wrapper_omits_headless_by_default\` locks the legacy CLI behaviour.
- [x] 9 / 9 notebook tests + 804 total pass locally; ruff (check + format) clean.
- [x] \`docs/reference/cli.md\` regenerated.
- [ ] CI green.

## Out of scope

- The hub HTTP endpoint that calls \`rb axi-profile notebook --headless\` — separate PR (Phase 2 step 2).
- SPA "Open in marimo" button — separate PR in rtl-buddy-view (Phase 2 step 3).

Foundation PR for Phase 2 of [axi-profiler #16](https://github.com/rtl-buddy/rtl-buddy-axi-profiler/issues/16).