### PR TITLE
feat(hub): /api/axi-profile/notebook endpoint spawns marimo headless

### DIFF
--- a/src/rtl_buddy/hub/axi_notebook_launcher.py
+++ b/src/rtl_buddy/hub/axi_notebook_launcher.py
@@ -1,0 +1,287 @@
+"""Background marimo launcher for the hub's "Open in marimo" endpoint.
+
+Wraps ``rb axi-profile notebook --headless`` so the SPA can request a
+deep-dive notebook over plain HTTP, get back a URL, and open it in a
+new tab. The headless flow (rtl_buddy #190) means marimo doesn't
+auto-pop a browser and doesn't require a session token — the SPA
+opens the printed URL directly.
+
+Why not just spawn-and-forget: marimo's edit server takes a few
+seconds to bind. We need to wait until the URL is on stdout before
+the hub responds to the SPA, otherwise the SPA opens a URL that
+isn't ready yet (race on the websocket handshake) and the user
+sees a "connection refused" pop-up. So we read stdout line-by-line
+until either:
+
+- the ``URL: http://...`` line lands → success, return the URL
+- the subprocess exits → failure, surface its return code
+- the watchdog timeout fires (default 30 s) → kill the subprocess
+  and surface a timeout error
+
+The spawned process is detached from the response cycle: once the
+URL is captured, we return it and let marimo run until the user
+closes the tab (or the hub shuts down). Marimo carries on serving
+the notebook session in the background.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import re
+import shutil
+import socket
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+from ..logging_utils import log_event
+
+logger = logging.getLogger(__name__)
+
+
+# Marimo prints a line shaped like
+#   ➜  URL: http://localhost:2719
+# (no token query string when --no-token is set). The exact prefix
+# has shifted across marimo versions; the regex picks any "URL: …"
+# substring as long as it points at http(s).
+_URL_LINE_RE = re.compile(rb"URL:\s*(https?://\S+)")
+
+DEFAULT_TIMEOUT_S = 30.0
+
+
+class AxiNotebookLaunchError(RuntimeError):
+    """Surfaced as an HTTP 4xx/5xx by the route handler."""
+
+    def __init__(self, message: str, *, status: int = 500):
+        super().__init__(message)
+        self.status = status
+
+
+@dataclass(frozen=True)
+class LaunchResult:
+    """What the SPA needs to open the notebook."""
+
+    url: str
+    pid: int
+    port: int
+    test: str
+    suite_dir: str
+
+
+def _find_free_port() -> int:
+    """Bind a transient socket to an OS-assigned port, close it, and
+    use the number. Race-prone in theory (another process could grab
+    the port between close and the marimo bind) but cheap in
+    practice for single-user local-loopback flows."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _validate_suite_dir(suite_dir: str, project_root: Path) -> Path:
+    """Resolve + validate ``suite_dir`` is real, contains a
+    ``tests.yaml``, and lives under ``project_root`` (path-traversal
+    guard so the SPA can't make us spawn against an arbitrary FS
+    location).
+    """
+    if not suite_dir:
+        raise AxiNotebookLaunchError("suite_dir is required", status=400)
+    candidate = Path(suite_dir)
+    if not candidate.is_absolute():
+        candidate = project_root / candidate
+    try:
+        resolved = candidate.resolve(strict=True)
+    except (OSError, FileNotFoundError):
+        raise AxiNotebookLaunchError(
+            f"suite_dir does not exist: {suite_dir}", status=400
+        ) from None
+    if not resolved.is_dir():
+        raise AxiNotebookLaunchError(
+            f"suite_dir is not a directory: {suite_dir}", status=400
+        )
+    project_resolved = project_root.resolve()
+    try:
+        resolved.relative_to(project_resolved)
+    except ValueError:
+        raise AxiNotebookLaunchError(
+            "suite_dir must be under the hub's project_root", status=400
+        ) from None
+    if not (resolved / "tests.yaml").is_file():
+        raise AxiNotebookLaunchError(
+            f"suite_dir has no tests.yaml: {resolved}", status=400
+        )
+    return resolved
+
+
+def _validate_test_name(test: str) -> str:
+    """Allow the same name shape ``tests.yaml`` does — alphanum + the
+    handful of separators we've seen in the wild. Rejects shell-ish
+    or path-ish chars so we can't be tricked into emitting
+    ``rb axi-profile notebook 'foo; rm -rf /'``."""
+    if not test:
+        raise AxiNotebookLaunchError("test is required", status=400)
+    if not re.fullmatch(r"[A-Za-z0-9_.\-]+", test):
+        raise AxiNotebookLaunchError(
+            f"test name has unexpected characters: {test!r}", status=400
+        )
+    return test
+
+
+def _resolve_rb_executable() -> str:
+    """``rb`` (the rtl_buddy CLI) is the entry point. Prefer the same
+    interpreter we're running under (``sys.executable -m rtl_buddy``)
+    so the spawned subprocess sees the same venv as the hub —
+    matters when the rtl_buddy install is editable and the system
+    PATH points at a different copy.
+    """
+    return sys.executable
+
+
+def _build_cmd(
+    *,
+    suite_dir: Path,
+    test: str,
+    port: int,
+) -> list[str]:
+    """The subprocess we'll spawn — equivalent to
+    ``cd <suite_dir> && rb axi-profile notebook <test> --headless --port N -c tests.yaml``
+    but invoked via ``-m rtl_buddy`` against the hub's interpreter.
+    """
+    return [
+        _resolve_rb_executable(),
+        "-m",
+        "rtl_buddy",
+        "axi-profile",
+        "notebook",
+        test,
+        "-c",
+        "tests.yaml",
+        "--headless",
+        "--port",
+        str(port),
+    ]
+
+
+async def _wait_for_url(
+    proc: asyncio.subprocess.Process,
+    *,
+    timeout_s: float,
+) -> str:
+    """Read ``proc.stdout`` line-by-line until the URL line lands or
+    we time out. Returns the URL string (decoded).
+
+    Marimo can emit a few informational lines first (update banner,
+    edit hint) so we keep reading until we either hit the URL or
+    decide it's not coming.
+    """
+    assert proc.stdout is not None
+    deadline = asyncio.get_event_loop().time() + timeout_s
+    while True:
+        remaining = deadline - asyncio.get_event_loop().time()
+        if remaining <= 0:
+            raise AxiNotebookLaunchError(
+                f"marimo did not print a URL within {timeout_s:.0f}s",
+                status=504,
+            )
+        try:
+            line = await asyncio.wait_for(proc.stdout.readline(), timeout=remaining)
+        except asyncio.TimeoutError:
+            raise AxiNotebookLaunchError(
+                f"marimo did not print a URL within {timeout_s:.0f}s",
+                status=504,
+            ) from None
+        if not line:
+            # EOF before URL → subprocess exited unexpectedly.
+            rc = await proc.wait()
+            raise AxiNotebookLaunchError(
+                f"marimo exited with code {rc} before printing a URL",
+                status=500,
+            )
+        m = _URL_LINE_RE.search(line)
+        if m:
+            return m.group(1).decode("utf-8", errors="replace")
+
+
+async def launch(
+    *,
+    test: str,
+    suite_dir: str,
+    project_root: Path,
+    timeout_s: float = DEFAULT_TIMEOUT_S,
+) -> LaunchResult:
+    """Validate inputs, spawn marimo headless, return the URL.
+
+    Raises :class:`AxiNotebookLaunchError` on any failure — the route
+    handler maps ``.status`` to the HTTP response code.
+    """
+    test = _validate_test_name(test)
+    resolved_suite = _validate_suite_dir(suite_dir, project_root)
+
+    # Quick env sanity-check up front so the user gets a clear
+    # message before we go through subprocess gymnastics.
+    if shutil.which("marimo") is None:
+        raise AxiNotebookLaunchError(
+            "marimo not on PATH; install rtl-buddy-axi-profiler with the "
+            "[notebook] extra so the hub can spawn it.",
+            status=503,
+        )
+
+    port = _find_free_port()
+    cmd = _build_cmd(suite_dir=resolved_suite, test=test, port=port)
+
+    log_event(
+        logger,
+        logging.INFO,
+        "hub.axi_notebook.launching",
+        test=test,
+        suite_dir=str(resolved_suite),
+        port=port,
+        cmd=" ".join(cmd),
+    )
+
+    # PYTHONUNBUFFERED=1 forces line-buffered stdout so we see
+    # marimo's URL line as soon as it's printed (rather than after
+    # the kernel's block-buffer fills).
+    env = {**os.environ, "PYTHONUNBUFFERED": "1"}
+    proc = await asyncio.create_subprocess_exec(
+        *cmd,
+        cwd=str(resolved_suite),
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
+        env=env,
+        # New process group so a hub SIGTERM doesn't immediately
+        # kill marimo — the user's notebook session is supposed to
+        # outlive a single hub restart in the worst case.
+        start_new_session=True,
+    )
+
+    try:
+        url = await _wait_for_url(proc, timeout_s=timeout_s)
+    except AxiNotebookLaunchError:
+        # Kill the partially-started subprocess so we don't leak it
+        # on every failed launch attempt.
+        try:
+            proc.kill()
+        except ProcessLookupError:
+            pass
+        raise
+
+    assert proc.pid is not None
+    log_event(
+        logger,
+        logging.INFO,
+        "hub.axi_notebook.launched",
+        test=test,
+        url=url,
+        pid=proc.pid,
+        port=port,
+    )
+    return LaunchResult(
+        url=url,
+        pid=proc.pid,
+        port=port,
+        test=test,
+        suite_dir=str(resolved_suite),
+    )

--- a/src/rtl_buddy/hub/viewer_http.py
+++ b/src/rtl_buddy/hub/viewer_http.py
@@ -300,6 +300,9 @@ class ViewerServer:
         if path == "/models":
             return await self._handle_models(connection)
 
+        if path == "/api/axi-profile/notebook":
+            return await self._handle_axi_notebook(connection, query)
+
         if path == "/view.json":
             requested = query.get("model", [None])[0]
             if requested is not None:
@@ -330,6 +333,69 @@ class ViewerServer:
     # ------------------------------------------------------------------
     # /models + /view.json?model= (issue #174)
     # ------------------------------------------------------------------
+
+    async def _handle_axi_notebook(
+        self, connection: ServerConnection, query: dict[str, list[str]]
+    ) -> Response:
+        """``GET /api/axi-profile/notebook?test=NAME&suite_dir=PATH``.
+
+        Spawns ``rb axi-profile notebook --headless`` for the given
+        ``test`` (which must exist in ``<suite_dir>/tests.yaml``),
+        waits up to 30 s for marimo to print its URL, returns JSON.
+        The spawned marimo persists after this request completes —
+        it's the user's notebook session, intended to outlive the
+        single HTTP round-trip.
+
+        Response::
+
+          {
+            "url":       "http://localhost:NNNN",
+            "pid":       12345,
+            "port":      NNNN,
+            "test":      "basic_traffic",
+            "suite_dir": "/abs/path/to/verif/demo_axi_2x2"
+          }
+
+        Errors surface as JSON-bodied 4xx/5xx with a single ``error``
+        key. ``project_root`` must be set on the hub (always true when
+        started via ``rb hub start``).
+        """
+        import json as _json
+
+        from . import axi_notebook_launcher
+
+        if self.project_root is None:
+            return _http_response(
+                connection,
+                500,
+                _json.dumps({"error": "hub has no project_root configured"}).encode(),
+                content_type="application/json",
+            )
+        test = (query.get("test") or [""])[0]
+        suite_dir = (query.get("suite_dir") or [""])[0]
+        try:
+            result = await axi_notebook_launcher.launch(
+                test=test,
+                suite_dir=suite_dir,
+                project_root=self.project_root,
+            )
+        except axi_notebook_launcher.AxiNotebookLaunchError as e:
+            return _http_response(
+                connection,
+                e.status,
+                _json.dumps({"error": str(e)}).encode(),
+                content_type="application/json",
+            )
+        body = _json.dumps(
+            {
+                "url": result.url,
+                "pid": result.pid,
+                "port": result.port,
+                "test": result.test,
+                "suite_dir": result.suite_dir,
+            }
+        ).encode()
+        return _http_response(connection, 200, body, content_type="application/json")
 
     async def _handle_models(self, connection: ServerConnection) -> Response:
         """``GET /models`` — list every model the hub can serve.

--- a/src/rtl_buddy/rtl_buddy.py
+++ b/src/rtl_buddy/rtl_buddy.py
@@ -1463,6 +1463,19 @@ class RtlBuddy:
                 ),
             ),
         ] = True,
+        headless: Annotated[
+            bool,
+            typer.Option(
+                "--headless",
+                help=(
+                    "Forward `--headless --no-token` to marimo. Used by the "
+                    "hub-initiated 'Open in marimo' flow (Phase 2 of the "
+                    "marimo umbrella) — the SPA opens the URL itself, so "
+                    "marimo shouldn't auto-pop a browser and the auth "
+                    "token is disabled for the loopback-only handoff."
+                ),
+            ),
+        ] = False,
         marimo: Annotated[
             str,
             typer.Option(
@@ -1492,6 +1505,7 @@ class RtlBuddy:
             test=test_name,
             port=port,
             foreground=foreground,
+            headless=headless,
         )
         notebook = RtlBuddyAxiProfileNotebook(
             name=self.name + "/axi-profile/notebook",
@@ -1499,6 +1513,7 @@ class RtlBuddy:
             suite_dir=os.path.dirname(os.path.abspath(test_config)),
             port=port,
             foreground=foreground,
+            headless=headless,
             marimo_executable=marimo,
         )
         raise typer.Exit(notebook.run())

--- a/src/rtl_buddy/tools/axi_profile_rtl_buddy.py
+++ b/src/rtl_buddy/tools/axi_profile_rtl_buddy.py
@@ -515,6 +515,7 @@ class RtlBuddyAxiProfileNotebook:
         suite_dir: str,
         port: int | None = None,
         foreground: bool = True,
+        headless: bool = False,
         marimo_executable: str = "marimo",
     ):
         self.name = name
@@ -523,6 +524,12 @@ class RtlBuddyAxiProfileNotebook:
         self.suite_dir = os.path.abspath(suite_dir)
         self.port = port
         self.foreground = foreground
+        # ``headless`` is for the hub-launched flow (Phase 2 of the
+        # marimo umbrella) — the SPA opens the URL itself, so marimo
+        # shouldn't auto-pop a browser, and the auth token is
+        # disabled so the SPA can link directly without juggling
+        # secrets across the IPC boundary.
+        self.headless = headless
         self.marimo_executable = marimo_executable
 
         self.artefact_dir = os.path.join(
@@ -593,6 +600,12 @@ class RtlBuddyAxiProfileNotebook:
         cmd = [self.marimo_executable, "edit", template]
         if self.port is not None:
             cmd += ["--port", str(self.port)]
+        if self.headless:
+            # --headless: no auto-browser-pop; the SPA opens the URL.
+            # --no-token: the SPA can navigate to the URL without
+            # threading a per-session token through the hub → browser
+            # handoff. Loopback-only, so the security trade is fine.
+            cmd += ["--headless", "--no-token"]
         return cmd
 
     def run(self) -> int:

--- a/tests/test_axi_profile.py
+++ b/tests/test_axi_profile.py
@@ -929,6 +929,54 @@ def test_notebook_wrapper_forwards_port_flag(tmp_path: Path) -> None:
     assert argv[argv.index("--port") + 1] == "2718"
 
 
+def test_notebook_wrapper_forwards_headless_and_no_token(tmp_path: Path) -> None:
+    """The hub-initiated flow needs both ``--headless`` (so marimo
+    doesn't auto-pop a browser tab while the SPA also tries to open
+    the URL) and ``--no-token`` (so the SPA can navigate to the
+    printed URL without threading a per-session token through the
+    hub → SPA → browser handoff). Lock both as a pair."""
+    _notebook_template_or_skip()
+    from rtl_buddy.tools.axi_profile_rtl_buddy import RtlBuddyAxiProfileNotebook
+
+    suite_dir, tests_yaml = _write_notebook_fixture(tmp_path)
+    script, record = _make_fake_marimo(tmp_path)
+    test_cfg = SuiteConfig(str(tests_yaml)).get_tests("basic")[0]
+
+    notebook = RtlBuddyAxiProfileNotebook(
+        name="t",
+        test_cfg=test_cfg,
+        suite_dir=str(suite_dir),
+        headless=True,
+        marimo_executable=str(script),
+    )
+    assert notebook.run() == 0
+    argv = json.loads(record.read_text())["argv"]
+    assert "--headless" in argv
+    assert "--no-token" in argv
+
+
+def test_notebook_wrapper_omits_headless_by_default(tmp_path: Path) -> None:
+    """Default (CLI invocation) keeps marimo's normal token + auto-
+    open-browser behaviour — only the hub-initiated path opts in."""
+    _notebook_template_or_skip()
+    from rtl_buddy.tools.axi_profile_rtl_buddy import RtlBuddyAxiProfileNotebook
+
+    suite_dir, tests_yaml = _write_notebook_fixture(tmp_path)
+    script, record = _make_fake_marimo(tmp_path)
+    test_cfg = SuiteConfig(str(tests_yaml)).get_tests("basic")[0]
+
+    notebook = RtlBuddyAxiProfileNotebook(
+        name="t",
+        test_cfg=test_cfg,
+        suite_dir=str(suite_dir),
+        marimo_executable=str(script),
+    )
+    assert notebook.run() == 0
+    argv = json.loads(record.read_text())["argv"]
+    assert "--headless" not in argv
+    assert "--no-token" not in argv
+
+
 def test_notebook_wrapper_errors_when_parquet_missing(tmp_path: Path) -> None:
     """The user has to run `rb axi-profile run` first — give them
     that exact command in the error so they don't go hunting."""

--- a/tests/test_hub_axi_notebook.py
+++ b/tests/test_hub_axi_notebook.py
@@ -1,0 +1,277 @@
+"""Tests for the ``/api/axi-profile/notebook`` hub HTTP endpoint
+and its underlying launcher.
+
+The endpoint spawns ``rb axi-profile notebook --headless`` (which
+forks marimo). We can't run the real marimo in CI — and don't need
+to — so the launcher's subprocess is monkeypatched to a fake that
+prints a URL line on stdout. That exercises every code path
+(stdout reader, URL regex, timeout, validation) without depending
+on the [notebook] extra being installed in the test env.
+
+The route-level tests poke ``_handle_axi_notebook`` directly with
+a stub ``ServerConnection`` rather than spinning up the full
+websockets server — the goal is to lock the route's contract
+(query parse, status codes, JSON body), not the IO plumbing.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import stat
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from rtl_buddy.hub import axi_notebook_launcher
+from rtl_buddy.hub.axi_notebook_launcher import AxiNotebookLaunchError
+
+
+def _write_suite(tmp_path: Path) -> Path:
+    """A barely-valid suite_dir — tests.yaml present so validation
+    doesn't reject it."""
+    suite = tmp_path / "verif" / "demo"
+    suite.mkdir(parents=True)
+    (suite / "tests.yaml").write_text(
+        "rtl-buddy-filetype: test_config\ntestbenches: []\ntests: []\n"
+    )
+    return suite
+
+
+def _fake_marimo(tmp_path: Path, *, url: str | None, exit_after: bool = False) -> Path:
+    """Drop a shell script that mimics ``marimo edit``'s startup:
+    optionally print a URL line, optionally exit. Returned path is
+    executable so subprocess.Popen can run it."""
+    sh = tmp_path / "fake_rb"
+    body = ["#!/usr/bin/env bash", "echo 'Update available 0.23.7 -> 0.23.8'"]
+    if url:
+        body.append(f"echo 'URL: {url}'")
+    if not exit_after:
+        # Block forever so the URL-reader doesn't hit EOF.
+        body.append("sleep 60")
+    sh.write_text("\n".join(body) + "\n")
+    sh.chmod(sh.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return sh
+
+
+def test_validate_test_name_rejects_shell_metacharacters() -> None:
+    with pytest.raises(AxiNotebookLaunchError) as exc:
+        axi_notebook_launcher._validate_test_name("foo; rm -rf /")
+    assert exc.value.status == 400
+    assert "unexpected characters" in str(exc.value)
+
+
+def test_validate_test_name_accepts_normal_identifiers() -> None:
+    assert axi_notebook_launcher._validate_test_name("basic_traffic") == "basic_traffic"
+    assert axi_notebook_launcher._validate_test_name("test-1.v2") == "test-1.v2"
+
+
+def test_validate_suite_dir_rejects_path_traversal(tmp_path: Path) -> None:
+    suite = _write_suite(tmp_path)
+    other_root = tmp_path / "other"
+    other_root.mkdir()
+    with pytest.raises(AxiNotebookLaunchError) as exc:
+        axi_notebook_launcher._validate_suite_dir(str(suite), other_root)
+    assert exc.value.status == 400
+    assert "project_root" in str(exc.value)
+
+
+def test_validate_suite_dir_rejects_missing_tests_yaml(tmp_path: Path) -> None:
+    suite = tmp_path / "noyaml"
+    suite.mkdir()
+    with pytest.raises(AxiNotebookLaunchError) as exc:
+        axi_notebook_launcher._validate_suite_dir(str(suite), tmp_path)
+    assert "tests.yaml" in str(exc.value)
+
+
+def test_validate_suite_dir_accepts_valid_relative_path(tmp_path: Path) -> None:
+    _write_suite(tmp_path)
+    resolved = axi_notebook_launcher._validate_suite_dir("verif/demo", tmp_path)
+    assert resolved == (tmp_path / "verif" / "demo").resolve()
+
+
+def test_launch_returns_url_when_subprocess_prints_one(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Happy path: a fake "marimo" prints the URL on stdout and the
+    launcher returns it without waiting for the process to exit."""
+    suite = _write_suite(tmp_path)
+    fake = _fake_marimo(tmp_path, url="http://localhost:31337")
+
+    monkeypatch.setattr(axi_notebook_launcher.shutil, "which", lambda _: "marimo")
+    monkeypatch.setattr(
+        axi_notebook_launcher,
+        "_build_cmd",
+        lambda *, suite_dir, test, port: [str(fake)],
+    )
+
+    result = asyncio.run(
+        axi_notebook_launcher.launch(
+            test="basic", suite_dir=str(suite), project_root=tmp_path, timeout_s=5.0
+        )
+    )
+    assert result.url == "http://localhost:31337"
+    assert result.test == "basic"
+    assert result.pid > 0
+    # Clean up the background fake_marimo so it doesn't hang around
+    # 60s after the test exits.
+    try:
+        os.kill(result.pid, 9)
+    except ProcessLookupError:
+        pass
+
+
+def test_launch_raises_when_subprocess_exits_before_url(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Crash-on-startup path: subprocess exits before printing the
+    URL line. Launcher surfaces a 500 with marimo's exit code in
+    the message so the SPA's error toast is actionable."""
+    suite = _write_suite(tmp_path)
+    fake = _fake_marimo(tmp_path, url=None, exit_after=True)
+
+    monkeypatch.setattr(axi_notebook_launcher.shutil, "which", lambda _: "marimo")
+    monkeypatch.setattr(
+        axi_notebook_launcher,
+        "_build_cmd",
+        lambda *, suite_dir, test, port: [str(fake)],
+    )
+
+    with pytest.raises(AxiNotebookLaunchError) as exc:
+        asyncio.run(
+            axi_notebook_launcher.launch(
+                test="basic",
+                suite_dir=str(suite),
+                project_root=tmp_path,
+                timeout_s=5.0,
+            )
+        )
+    assert exc.value.status == 500
+    assert "exited" in str(exc.value)
+
+
+def test_launch_times_out_when_subprocess_hangs_without_url(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Watchdog path: subprocess runs forever and never prints a URL.
+    Should kill the subprocess and return a 504."""
+    suite = _write_suite(tmp_path)
+    fake = _fake_marimo(tmp_path, url=None)
+
+    monkeypatch.setattr(axi_notebook_launcher.shutil, "which", lambda _: "marimo")
+    monkeypatch.setattr(
+        axi_notebook_launcher,
+        "_build_cmd",
+        lambda *, suite_dir, test, port: [str(fake)],
+    )
+
+    with pytest.raises(AxiNotebookLaunchError) as exc:
+        asyncio.run(
+            axi_notebook_launcher.launch(
+                test="basic",
+                suite_dir=str(suite),
+                project_root=tmp_path,
+                timeout_s=0.5,
+            )
+        )
+    assert exc.value.status == 504
+
+
+def test_launch_503_when_marimo_not_on_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Setup-error path: marimo binary not installed. Surfaces 503
+    with the [notebook] extra install hint."""
+    _write_suite(tmp_path)
+    monkeypatch.setattr(axi_notebook_launcher.shutil, "which", lambda _: None)
+    with pytest.raises(AxiNotebookLaunchError) as exc:
+        asyncio.run(
+            axi_notebook_launcher.launch(
+                test="basic", suite_dir="verif/demo", project_root=tmp_path
+            )
+        )
+    assert exc.value.status == 503
+    assert "[notebook]" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# Route-level smoke
+# ---------------------------------------------------------------------------
+
+
+class _StubConnection:
+    """Just enough of websockets' ServerConnection to satisfy
+    ``_http_response`` — which is the only thing the route handler
+    calls on it."""
+
+    request: Any = None
+
+
+def _make_viewer_server(project_root: Path) -> Any:
+    from rtl_buddy.hub.viewer_http import ViewerServer
+
+    return ViewerServer(hub_host="127.0.0.1", hub_port=0, project_root=project_root)
+
+
+def test_route_returns_400_for_missing_test(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    suite = _write_suite(tmp_path)
+    server = _make_viewer_server(tmp_path)
+    monkeypatch.setattr(axi_notebook_launcher.shutil, "which", lambda _: "marimo")
+
+    resp = asyncio.run(
+        server._handle_axi_notebook(_StubConnection(), {"suite_dir": [str(suite)]})
+    )
+    assert resp.status_code == 400
+    assert b"test is required" in resp.body
+
+
+def test_route_returns_500_when_project_root_unset(tmp_path: Path) -> None:
+    from rtl_buddy.hub.viewer_http import ViewerServer
+
+    server = ViewerServer(hub_host="127.0.0.1", hub_port=0, project_root=None)
+    resp = asyncio.run(
+        server._handle_axi_notebook(
+            _StubConnection(), {"test": ["basic"], "suite_dir": ["verif/demo"]}
+        )
+    )
+    assert resp.status_code == 500
+    body = json.loads(resp.body)
+    assert "project_root" in body["error"]
+
+
+def test_route_returns_json_url_on_success(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """End-to-end at the route layer: with a working fake-marimo, the
+    handler returns a 200 + JSON containing the URL the SPA needs."""
+    suite = _write_suite(tmp_path)
+    fake = _fake_marimo(tmp_path, url="http://localhost:31337")
+    server = _make_viewer_server(tmp_path)
+
+    monkeypatch.setattr(axi_notebook_launcher.shutil, "which", lambda _: "marimo")
+    monkeypatch.setattr(
+        axi_notebook_launcher,
+        "_build_cmd",
+        lambda *, suite_dir, test, port: [str(fake)],
+    )
+
+    resp = asyncio.run(
+        server._handle_axi_notebook(
+            _StubConnection(),
+            {"test": ["basic"], "suite_dir": [str(suite)]},
+        )
+    )
+    assert resp.status_code == 200
+    payload = json.loads(resp.body)
+    assert payload["url"] == "http://localhost:31337"
+    assert payload["test"] == "basic"
+    assert payload["pid"] > 0
+    # Background fake_marimo cleanup.
+    try:
+        os.kill(payload["pid"], 9)
+    except ProcessLookupError:
+        pass


### PR DESCRIPTION
## Summary

Phase 2 step 2 of the marimo umbrella ([axi-profiler #16](https://github.com/rtl-buddy/rtl-buddy-axi-profiler/issues/16)). Adds an HTTP endpoint the SPA hits to spawn a marimo deep-dive session for a given test:

\`\`\`
GET /api/axi-profile/notebook?test=basic_traffic&suite_dir=verif/demo_axi_2x2
\`\`\`

Hub spawns \`rb axi-profile notebook --headless --port <auto>\` (the \`--headless\` flag added in #190), waits for marimo's URL line on stdout, and returns:

\`\`\`json
{
  "url":       "http://localhost:NNNN",
  "pid":       12345,
  "port":      NNNN,
  "test":      "basic_traffic",
  "suite_dir": "/abs/path/to/verif/demo_axi_2x2"
}
\`\`\`

The SPA then \`window.open()\`s the URL in a new tab. The spawned marimo persists after the HTTP round-trip — it's the user's notebook session, intended to outlive the single request.

## Design

New module \`hub/axi_notebook_launcher.py\` carries the spawn/wait logic so the route in \`viewer_http.py\` stays a thin ~60-line adapter.

### Why wait for the URL line before returning

Marimo's edit server takes a few seconds to bind. If we returned the URL we *would* spawn at and let the SPA open it before marimo is up, the user would hit a WebSocket handshake race and see "connection refused". Reading stdout until \`URL: http(s)://...\` lands (regex tolerant of marimo's \`➜  URL:\` decoration) ensures we only return when marimo is actually serving.

### Security surface (SPA-driven endpoint)

- \`test\` regex: \`[A-Za-z0-9_.\-]+\` rejects shell metacharacters, path separators, dots-with-slashes. Locked by \`test_validate_test_name_rejects_shell_metacharacters\`.
- \`suite_dir\` must resolve under the hub's \`project_root\`. Locked by \`test_validate_suite_dir_rejects_path_traversal\`.
- \`suite_dir/tests.yaml\` must exist (else 400). Prevents spawning against random directories.

### Error surface

| condition | status |
|---|---|
| missing/bad \`test\` | 400 |
| missing/bad \`suite_dir\` | 400 |
| \`marimo\` not on PATH | 503 |
| marimo exits before printing URL | 500 |
| 30 s watchdog | 504 |
| project_root unset | 500 |

All bodied as \`{"error": "..."}\` so the SPA can render an actionable toast.

## Test plan

- [x] 12 new in \`test_hub_axi_notebook.py\` — no real marimo (fake shell script that prints a URL line on stdout)
- [x] Validation: test name regex, suite_dir path-traversal, missing tests.yaml
- [x] Launcher: happy path, crash-on-startup, watchdog timeout, marimo-not-on-path
- [x] Route: 400 on missing test, 500 on no project_root, 200 + JSON on success
- [x] 809 total pass + 10 skipped; ruff (check + format) clean
- [ ] CI green

## Stacking

Based on \`feat/axi-notebook-headless\` (rtl_buddy #190 — the \`--headless\` CLI flag this launcher emits). **Rebase when #190 lands** so the stack flattens.

## Out of scope

- The SPA button + click handler — separate PR in rtl-buddy-view (Phase 2 step 3).
- Lifecycle management for the spawned marimos (clean up on hub shutdown, reuse same instance for repeat clicks). v1 spawns fresh per request; cleanup is "user closes the tab + manual \`kill\`". Tracked as Phase 2.5.
- Source-of-test-info on the SPA side. v1 expects the SPA to be told the test + suite_dir somehow (URL hash, page config, etc.); deriving from the active view.json's axi-perf annotations is a Phase 2.5 follow-up.