### PR TITLE
feat(hier): plumb --rdc-annotations through rb hier

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -205,6 +205,8 @@ Usage: rtl-buddy hier [OPTIONS] MODEL_NAME
 │ --frontend                 TEXT  parser frontend (verible|slang)                     │
 │ --cdc-annotations          TEXT  clock-domain map JSON from `rtl-buddy-cdc           │
 │                                  --emit-domain-map`                                  │
+│ --rdc-annotations          TEXT  reset-domain map JSON from `rtl-buddy-cdc           │
+│                                  --emit-reset-domain-map`                            │
 │ --clock-legend                   dot format only: emit a side legend of clock colors │
 │ --tool                     TEXT  path to the rtl-buddy-view binary                   │
 │                                  [default: rtl-buddy-view]                           │

--- a/src/rtl_buddy/rtl_buddy.py
+++ b/src/rtl_buddy/rtl_buddy.py
@@ -1173,6 +1173,13 @@ class RtlBuddy:
                 help="clock-domain map JSON from `rtl-buddy-cdc --emit-domain-map`",
             ),
         ] = None,
+        rdc_annotations: Annotated[
+            str | None,
+            typer.Option(
+                "--rdc-annotations",
+                help="reset-domain map JSON from `rtl-buddy-cdc --emit-reset-domain-map`",
+            ),
+        ] = None,
         clock_legend: Annotated[
             bool,
             typer.Option(
@@ -1206,6 +1213,7 @@ class RtlBuddy:
             output=output,
             frontend=frontend,
             cdc_annotations=cdc_annotations,
+            rdc_annotations=rdc_annotations,
             clock_legend=clock_legend,
             executable=tool,
         )

--- a/src/rtl_buddy/tools/hier_rtl_buddy_view.py
+++ b/src/rtl_buddy/tools/hier_rtl_buddy_view.py
@@ -46,6 +46,7 @@ class RtlBuddyView:
         output: str | None = None,
         frontend: str | None = None,
         cdc_annotations: str | None = None,
+        rdc_annotations: str | None = None,
         clock_legend: bool = False,
         executable: str = "rtl-buddy-view",
     ):
@@ -55,6 +56,7 @@ class RtlBuddyView:
         self.output = output
         self.frontend = frontend
         self.cdc_annotations = cdc_annotations
+        self.rdc_annotations = rdc_annotations
         self.clock_legend = clock_legend
         self.executable = executable
 
@@ -98,6 +100,8 @@ class RtlBuddyView:
             cmd += ["--frontend", self.frontend]
         if self.cdc_annotations is not None:
             cmd += ["--cdc-annotations", self.cdc_annotations]
+        if self.rdc_annotations is not None:
+            cmd += ["--rdc-annotations", self.rdc_annotations]
         if self.clock_legend:
             cmd += ["--clock-legend"]
         return cmd
@@ -126,6 +130,13 @@ class RtlBuddyView:
         ):
             raise FatalRtlBuddyError(
                 f"hier: cdc-annotations file not found: {self.cdc_annotations}"
+            )
+
+        if self.rdc_annotations is not None and not os.path.isfile(
+            self.rdc_annotations
+        ):
+            raise FatalRtlBuddyError(
+                f"hier: rdc-annotations file not found: {self.rdc_annotations}"
             )
 
         fl_path = self._write_filelist()

--- a/tests/test_hier.py
+++ b/tests/test_hier.py
@@ -4,7 +4,8 @@ The real ``rtl-buddy-view`` binary is not on PATH in CI, so these
 tests stub it with a tiny shell script that records its argv and
 exits with a controllable status. This pins the CLI shape we promise
 to the downstream viewer (``--top``, ``--filelist``, ``--format``,
-``--output``, ``--frontend``, ``--cdc-annotations``, ``--clock-legend``).
+``--output``, ``--frontend``, ``--cdc-annotations``, ``--rdc-annotations``,
+``--clock-legend``).
 """
 
 from __future__ import annotations
@@ -86,6 +87,8 @@ def test_wrapper_forwards_optional_flags(tmp_path: Path):
     )
     cdc_map = tmp_path / "domain_map.json"
     cdc_map.write_text("{}")
+    rdc_map = tmp_path / "reset_domain_map.json"
+    rdc_map.write_text("{}")
     output_file = tmp_path / "hier.dot"
     script, record = _make_fake_view(tmp_path)
 
@@ -97,6 +100,7 @@ def test_wrapper_forwards_optional_flags(tmp_path: Path):
         output=str(output_file),
         frontend="slang",
         cdc_annotations=str(cdc_map),
+        rdc_annotations=str(rdc_map),
         clock_legend=True,
         executable=str(script),
     )
@@ -107,6 +111,7 @@ def test_wrapper_forwards_optional_flags(tmp_path: Path):
     assert argv[argv.index("--output") + 1] == str(output_file)
     assert argv[argv.index("--frontend") + 1] == "slang"
     assert argv[argv.index("--cdc-annotations") + 1] == str(cdc_map)
+    assert argv[argv.index("--rdc-annotations") + 1] == str(rdc_map)
     assert "--clock-legend" in argv
 
 
@@ -150,6 +155,30 @@ def test_wrapper_rejects_missing_cdc_annotations(tmp_path: Path):
         executable=str(script),
     )
     with pytest.raises(FatalRtlBuddyError):
+        view.run()
+
+
+def test_wrapper_rejects_missing_rdc_annotations(tmp_path: Path):
+    from rtl_buddy.errors import FatalRtlBuddyError
+
+    src = tmp_path / "src" / "example.sv"
+    src.parent.mkdir()
+    src.write_text("module example; endmodule\n")
+    model = ModelConfig(
+        name="example",
+        filelist=[str(src)],
+        path=str(tmp_path / "models.yaml"),
+    )
+    script, _ = _make_fake_view(tmp_path)
+
+    view = RtlBuddyView(
+        name="t",
+        model_cfg=model,
+        suite_dir=str(tmp_path),
+        rdc_annotations=str(tmp_path / "missing.json"),
+        executable=str(script),
+    )
+    with pytest.raises(FatalRtlBuddyError, match="rdc-annotations file not found"):
         view.run()
 
 


### PR DESCRIPTION
## Summary

- Mirror the existing `--cdc-annotations` plumbing on the reset side: `rb hier --rdc-annotations <reset-map.json>` now forwards the path to `rtl-buddy-view --rdc-annotations`, so the SPA picks up the reset overlay produced by `rtl-buddy-cdc lint --emit-reset-domain-map`.
- `RtlBuddyView.__init__` gains `rdc_annotations`, `_build_cmd` appends `--rdc-annotations <path>`, and `run()` raises `FatalRtlBuddyError` if the file is missing — same shape as `cdc_annotations`.
- Regenerated `docs/reference/cli.md` to keep the CI drift check happy.

Closes #156.

## Test plan

- [x] `uv run ruff check && uv run ruff format --check`
- [x] `uv run pytest` (795 passed, 7 skipped)
- [x] `uv run python scripts/gen_cli_reference.py --check`
- [ ] Manual smoke: `rtl-buddy-cdc lint ... --emit-reset-domain-map r.json && rb hier <top> --format json --cdc-annotations c.json --rdc-annotations r.json` — confirm `view.json` overlays_present contains `["clock", "reset"]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)