### PR TITLE
feat(hub): send time_unit=fs on WCP cursor/viewport commands

### DIFF
--- a/src/rtl_buddy/tools/wave_hub_bridge.py
+++ b/src/rtl_buddy/tools/wave_hub_bridge.py
@@ -444,7 +444,12 @@ class WaveHubBridge:
         except ValueError:
             return self._reply_bad_request(env, f"non-numeric t_fs: {t_fs!r}")
         self._send_to_surfer(
-            {"type": "command", "command": "set_cursor", "timestamp": ts}
+            {
+                "type": "command",
+                "command": "set_cursor",
+                "timestamp": ts,
+                "time_unit": "fs",
+            }
         )
         self._reply_response(env, type_=env.type, payload={"ok": True})
 
@@ -459,7 +464,12 @@ class WaveHubBridge:
         except ValueError:
             return self._reply_bad_request(env, f"non-numeric t_fs: {t_fs!r}")
         self._send_to_surfer(
-            {"type": "command", "command": "set_viewport_to", "timestamp": ts}
+            {
+                "type": "command",
+                "command": "set_viewport_to",
+                "timestamp": ts,
+                "time_unit": "fs",
+            }
         )
         self._reply_response(env, type_=env.type, payload={"ok": True})
 
@@ -483,6 +493,7 @@ class WaveHubBridge:
                 "command": "set_viewport_range",
                 "start": start_ts,
                 "end": end_ts,
+                "time_unit": "fs",
             }
         )
         self._reply_response(env, type_=env.type, payload={"ok": True})

--- a/tests/test_wave_hub_bridge.py
+++ b/tests/test_wave_hub_bridge.py
@@ -492,6 +492,7 @@ def test_wave_set_cursor_translates_to_wcp_command(hub_in_thread: _HubInThread):
                 "type": "command",
                 "command": "set_cursor",
                 "timestamp": 12500000,
+                "time_unit": "fs",
             }
         ]
     finally:
@@ -527,6 +528,7 @@ def test_wave_set_viewport_translates_to_wcp_command(hub_in_thread: _HubInThread
                 "type": "command",
                 "command": "set_viewport_to",
                 "timestamp": 200000,
+                "time_unit": "fs",
             }
         ]
     finally:
@@ -564,6 +566,7 @@ def test_wave_zoom_to_range_translates_to_wcp_command(hub_in_thread: _HubInThrea
                 "command": "set_viewport_range",
                 "start": 50000,
                 "end": 100000,
+                "time_unit": "fs",
             }
         ]
     finally:


### PR DESCRIPTION
## Summary

Surfer PR [rtl-buddy/surfer#5](https://github.com/rtl-buddy/surfer/pull/5) (merged) added an optional `time_unit` field to the WCP `set_cursor` / `set_viewport_to` / `set_viewport_range` commands. This PR stamps `time_unit: \"fs\"` on the WCP frames the bridge sends, so surfer rescales the integer to native ticks against the loaded waveform's timescale.

## Why

Before this change, the bridge took the hub envelope's `t_fs` / `start_fs` / `end_fs` payload, parsed it as an integer, and shipped it straight through as the WCP `timestamp` — which surfer interpreted in **native ticks**. On any FST with a finer-than-fs timescale (typical: 1ps, 10ps, 100ps) the cursor / viewport landed orders of magnitude off the requested femtosecond.

| handler | hub payload | WCP frame (before) | WCP frame (after) |
|---|---|---|---|
| `_handle_set_cursor` | `t_fs` | `set_cursor { timestamp }` | `set_cursor { timestamp, time_unit: \"fs\" }` |
| `_handle_set_viewport` | `t_fs` | `set_viewport_to { timestamp }` | `set_viewport_to { timestamp, time_unit: \"fs\" }` |
| `_handle_zoom_to_range` | `start_fs` / `end_fs` | `set_viewport_range { start, end }` | `set_viewport_range { start, end, time_unit: \"fs\" }` |

Surfer's conversion is integer math against the loaded waveform's \`TimeScale\` (exponent + multiplier); a 200000-fs request on a 1ps timescale now lands at native tick 200, not 200000.

## Test plan

- [x] \`uv run pytest tests/\` — 797 passed, 7 skipped, 1 deselected (\`test_vendored_schema_matches_source_when_view_repo_present\` is a pre-existing failure on main, unrelated)
- [x] \`uv run ruff check\` / \`uv run ruff format --check\` clean

## Compatibility

Backward-compatible at the WCP layer: the field is \`Option<WcpTimeUnit>\` in surfer, missing field = old native-ticks behavior. Any pre-PR-#5 surfer build will reject the unknown field at deserialization time — but since rtl-buddy ships its own surfer fork on the \`rtl-buddy\` branch and PR #5 is merged there, the field is supported by the only surfer the bridge talks to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)