### PR TITLE
feat(hub): route wave_set_scope through surfer's set_scope command

### DIFF
--- a/src/rtl_buddy/hub/send.py
+++ b/src/rtl_buddy/hub/send.py
@@ -348,7 +348,7 @@ def cmd_wave_cursor(
 
 @send_app.command(
     "wave-scope",
-    help="Ask the wave peer (surfer) to switch its scope (maps to WCP add_scope in v1).",
+    help="Ask the wave peer (surfer) to switch its active scope without populating the variable panel (maps to WCP set_scope).",
 )
 def cmd_wave_scope(
     wave_scope: Annotated[str, typer.Argument(help="surfer/VCD scope")],

--- a/src/rtl_buddy/tools/wave_hub_bridge.py
+++ b/src/rtl_buddy/tools/wave_hub_bridge.py
@@ -513,31 +513,28 @@ class WaveHubBridge:
         scope = payload.get("wave_scope")
         if not isinstance(scope, str) or not scope:
             return self._reply_bad_request(env, "missing wave_scope")
-        # §9.3 documents `set_scope` as a fork addition; surfer's current
-        # close match is `add_scope` (which also adds variables). Until the
-        # fork ships `set_scope`, use `add_scope` and document the gap.
+        # surfer's `set_scope` (rtl-buddy fork PR #6) navigates the active
+        # scope without mutating the displayed item list — the right
+        # semantics for "follow source-focus" tinting. We reply
+        # optimistically here matching the set_cursor / set_viewport_to
+        # pattern (no add_* ids to surface); unknown-scope errors are
+        # logged on surfer but not propagated back to the requesting peer.
         self._send_to_surfer(
-            {"type": "command", "command": "add_scope", "scope": scope}
+            {"type": "command", "command": "set_scope", "scope": scope}
         )
-        resp = self._listener.await_response("add_scope", timeout=2.0)
-        reply_payload = self._build_add_reply(resp, ok_fallback=True)
-        self._reply_response(env, type_=env.type, payload=reply_payload)
+        self._reply_response(env, type_=env.type, payload={"ok": True})
 
     @staticmethod
-    def _build_add_reply(resp: dict | None, *, ok_fallback: bool = False) -> dict:
+    def _build_add_reply(resp: dict | None) -> dict:
         """Translate surfer's WCP add_* response into the hub reply payload.
 
         ``not_found`` is surfaced only when present and non-empty so older
-        surfer binaries (no not_found field) keep the legacy shape. The
-        ``ok`` field is set when ``ok_fallback`` is True, matching the
-        previous wave_set_scope reply contract for clients that ignore ids.
+        surfer binaries (no not_found field) keep the legacy shape.
         """
         if resp is None:
-            return {"ok": True, "ids": []} if ok_fallback else {"ids": []}
+            return {"ids": []}
         ids = resp.get("ids") if isinstance(resp.get("ids"), list) else []
         out: dict[str, Any] = {"ids": ids}
-        if ok_fallback:
-            out["ok"] = True
         not_found = resp.get("not_found")
         if isinstance(not_found, list) and not_found:
             out["not_found"] = [s for s in not_found if isinstance(s, str)]

--- a/tests/test_wave_hub_bridge.py
+++ b/tests/test_wave_hub_bridge.py
@@ -428,19 +428,17 @@ def test_wave_add_variables_forwards_ids_and_not_found(hub_in_thread: _HubInThre
         bridge.stop()
 
 
-def test_wave_set_scope_forwards_not_found(hub_in_thread: _HubInThread):
-    """add_scope with an unknown scope: surfer returns ids=[] +
-    not_found=[scope]; the bridge forwards both alongside the ok flag."""
+def test_wave_set_scope_unknown_scope_still_acks_optimistically(
+    hub_in_thread: _HubInThread,
+):
+    """surfer's `set_scope` (rtl-buddy fork) acks on success and emits a
+    structured error on unknown-scope, but the bridge replies
+    optimistically with {"ok": True} regardless and does not wait for the
+    surfer-side error. Trade-off: typo detection is lost on the peer
+    side, matching the precedent for set_cursor / set_viewport_to which
+    also reply optimistically with no error propagation."""
     host, port = hub_in_thread.server.host, hub_in_thread.server.port  # type: ignore[union-attr]
     listener = _FakeListener()
-    listener.next_responses["add_scope"] = [
-        {
-            "type": "response",
-            "command": "add_scope",
-            "ids": [],
-            "not_found": ["tb.dut.does_not_exist"],
-        }
-    ]
     bridge = WaveHubBridge.connect((host, port), listener=listener)
     bridge.start()
     view_sock = _connect_observer(hub_in_thread, Origin.VIEW)
@@ -455,11 +453,7 @@ def test_wave_set_scope_forwards_not_found(hub_in_thread: _HubInThread):
         view_sock.sendall(encode(req).encode("utf-8") + b"\n")
         resp = _recv_line(view_sock)
         assert resp.kind is Kind.RESPONSE
-        assert resp.payload == {
-            "ok": True,
-            "ids": [],
-            "not_found": ["tb.dut.does_not_exist"],
-        }
+        assert resp.payload == {"ok": True}
     finally:
         view_sock.close()
         bridge.stop()
@@ -609,10 +603,13 @@ def test_wave_zoom_to_fit_translates_to_wcp_command(hub_in_thread: _HubInThread)
         bridge.stop()
 
 
-def test_wave_set_scope_translates_to_add_scope_until_fork(
+def test_wave_set_scope_translates_to_wcp_set_scope(
     hub_in_thread: _HubInThread,
 ):
-    """Per §9.3, surfer's fork will add `set_scope`; until then, `add_scope`."""
+    """`wave_set_scope { wave_scope }` → WCP `set_scope { scope }` (surfer
+    rtl-buddy fork PR #6). The bridge no longer falls back to add_scope,
+    so the surfer variable panel is left alone on cross-view scope
+    navigation."""
 
     host, port = hub_in_thread.server.host, hub_in_thread.server.port  # type: ignore[union-attr]
     listener = _FakeListener()
@@ -630,10 +627,10 @@ def test_wave_set_scope_translates_to_add_scope_until_fork(
         view_sock.sendall(encode(req).encode("utf-8") + b"\n")
         resp = _recv_line(view_sock)
         assert resp.kind is Kind.RESPONSE
-        # Reply also carries the (here-empty) ids list from surfer's add_scope
-        # response so callers can distinguish "no response" from "scope had
-        # nothing to add". not_found is omitted when empty.
-        assert resp.payload == {"ok": True, "ids": []}
+        # Optimistic reply: just {"ok": True}. set_scope doesn't return
+        # ids (no items added) and the bridge doesn't await surfer's ack
+        # to keep the reply path symmetrical with set_cursor / set_viewport.
+        assert resp.payload == {"ok": True}
 
         deadline = time.monotonic() + 1.0
         while time.monotonic() < deadline and not listener.sent:
@@ -641,7 +638,7 @@ def test_wave_set_scope_translates_to_add_scope_until_fork(
         assert listener.sent == [
             {
                 "type": "command",
-                "command": "add_scope",
+                "command": "set_scope",
                 "scope": "tb.dut.u_fifo",
             }
         ]


### PR DESCRIPTION
## Summary

Surfer PR [rtl-buddy/surfer#6](https://github.com/rtl-buddy/surfer/pull/6) merged on the \`rtl-buddy\` branch and added \`WcpCommand::set_scope { scope }\` — navigates surfer's active scope without populating the displayed item list. This PR routes \`wave_set_scope\` envelopes through the new command instead of the \`add_scope\` fallback.

## Why

The bridge previously fell back to \`add_scope\` because surfer had no scope-navigation primitive that left the variable panel alone. That fallback had the documented side effect of populating the variable panel on every cross-view scope navigation — exactly the spam pattern the protocol spec (\`docs/hub-protocol.md\` §9.3) was designed to avoid.

| | before | after |
|---|---|---|
| WCP command | \`add_scope { scope }\` | \`set_scope { scope }\` |
| Side effect | populates variable panel | none — pure navigation |
| Reply shape | \`{ ok, ids, not_found? }\` | \`{ ok: true }\` |
| Await pattern | waits for surfer response | optimistic (no await) |

## Reply shape change

The reply payload for \`wave_set_scope\` simplifies to \`{\"ok\": True}\`. \`ids\` is gone (no items are added) and \`not_found\` is gone (the bridge no longer awaits surfer's response). This matches the precedent set by \`wave_set_cursor\` / \`wave_set_viewport\` which also reply optimistically with no error propagation.

Trade-off: typo detection on the peer side is lost — if a peer sends \`wave_set_scope { wave_scope: \"tb.dut.bogus\" }\`, surfer logs the error locally but the peer gets a happy \`{\"ok\": True}\` back. Same pattern as the cursor / viewport commands. If this matters down the line, the right fix is plumbing error frames through the listener's await machinery (not specific to scope nav).

## Test plan

- [x] \`uv run pytest tests/test_wave_hub_bridge.py\` — 23 passed
- [x] \`uv run pytest tests/\` (skipping pre-existing \`test_vendored_schema_matches_source_when_view_repo_present\` drift) — 810 passed, 9 skipped
- [x] \`uv run ruff check\` + \`uv run ruff format --check\` clean

## Cleanup

\`_build_add_reply\` lost its now-unused \`ok_fallback\` parameter (only the old set_scope path used it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)