### PR TITLE
feat(hub): marimo session reuse + shutdown cleanup (Phase 2.5)

### DIFF
--- a/src/rtl_buddy/hub/viewer_http.py
+++ b/src/rtl_buddy/hub/viewer_http.py
@@ -199,6 +199,14 @@ class ViewerServer:
         # ``?model=X`` / ``?model=Y`` requests run in parallel. Locks
         # are allocated lazily and never garbage-collected per session.
         self._model_locks: dict[str, asyncio.Lock] = {}
+        # Marimo "Open in marimo" session cache (Phase 2.5).
+        # ``(test, suite_dir) → LaunchResult``. Repeat clicks reuse
+        # the cached entry when the spawned marimo is still alive
+        # (``os.kill(pid, 0)`` succeeds). Per-key lock funnels
+        # concurrent requests for the same notebook through one
+        # spawn — analogous to ``_model_locks`` for /view.json?model=.
+        self._axi_notebook_sessions: dict[tuple[str, str], Any] = {}
+        self._axi_notebook_locks: dict[tuple[str, str], asyncio.Lock] = {}
         self._server: Any | None = None
         self._bundle_index = self._resolve_bundle_index(viewer_bundle)
 
@@ -253,6 +261,14 @@ class ViewerServer:
             pass
 
     async def shutdown(self) -> None:
+        # Reap the marimo subprocesses we spawned for /api/axi-profile/
+        # notebook before tearing down the HTTP server. Without this
+        # they survive hub restarts as orphans — each one holds an
+        # OS port and a marimo session that nobody can reach (the SPA
+        # only knows the URL via the now-dead hub).
+        for key, session in list(self._axi_notebook_sessions.items()):
+            _terminate_pid(session.pid)
+            self._axi_notebook_sessions.pop(key, None)
         if self._server is None:
             return
         self._server.close()
@@ -346,6 +362,11 @@ class ViewerServer:
         it's the user's notebook session, intended to outlive the
         single HTTP round-trip.
 
+        Repeat clicks for the same ``(test, suite_dir)`` reuse the
+        cached marimo when its pid is still alive (single-instance
+        per notebook, Phase 2.5). When the cached marimo has died
+        the entry is dropped and a fresh one spawns.
+
         Response::
 
           {
@@ -353,7 +374,8 @@ class ViewerServer:
             "pid":       12345,
             "port":      NNNN,
             "test":      "basic_traffic",
-            "suite_dir": "/abs/path/to/verif/demo_axi_2x2"
+            "suite_dir": "/abs/path/to/verif/demo_axi_2x2",
+            "reused":    false                            ← true when cache hit
           }
 
         Errors surface as JSON-bodied 4xx/5xx with a single ``error``
@@ -373,29 +395,64 @@ class ViewerServer:
             )
         test = (query.get("test") or [""])[0]
         suite_dir = (query.get("suite_dir") or [""])[0]
-        try:
-            result = await axi_notebook_launcher.launch(
-                test=test,
-                suite_dir=suite_dir,
-                project_root=self.project_root,
-            )
-        except axi_notebook_launcher.AxiNotebookLaunchError as e:
+
+        # Per-(test, suite_dir) lock funnels concurrent requests for
+        # the same notebook through one spawn. Without this, two SPA
+        # clicks within marimo's ~3 s startup window would both miss
+        # the cache and spawn duplicate processes on different ports.
+        key = (test, suite_dir)
+        lock = self._axi_notebook_locks.setdefault(key, asyncio.Lock())
+        async with lock:
+            cached = self._axi_notebook_sessions.get(key)
+            if cached is not None and _is_pid_alive(cached.pid):
+                # Cache hit — return the same URL the user got last time.
+                body = _json.dumps(
+                    {
+                        "url": cached.url,
+                        "pid": cached.pid,
+                        "port": cached.port,
+                        "test": cached.test,
+                        "suite_dir": cached.suite_dir,
+                        "reused": True,
+                    }
+                ).encode()
+                return _http_response(
+                    connection, 200, body, content_type="application/json"
+                )
+            # Cache miss or stale → drop the dead entry, spawn fresh.
+            if cached is not None:
+                self._axi_notebook_sessions.pop(key, None)
+            try:
+                result = await axi_notebook_launcher.launch(
+                    test=test,
+                    suite_dir=suite_dir,
+                    project_root=self.project_root,
+                )
+            except axi_notebook_launcher.AxiNotebookLaunchError as e:
+                return _http_response(
+                    connection,
+                    e.status,
+                    _json.dumps({"error": str(e)}).encode(),
+                    content_type="application/json",
+                )
+            # Cache under the resolved key (suite_dir may have been
+            # normalised to an absolute path by the launcher's
+            # validator; use the request key so the next request with
+            # the same input hits the cache).
+            self._axi_notebook_sessions[key] = result
+            body = _json.dumps(
+                {
+                    "url": result.url,
+                    "pid": result.pid,
+                    "port": result.port,
+                    "test": result.test,
+                    "suite_dir": result.suite_dir,
+                    "reused": False,
+                }
+            ).encode()
             return _http_response(
-                connection,
-                e.status,
-                _json.dumps({"error": str(e)}).encode(),
-                content_type="application/json",
+                connection, 200, body, content_type="application/json"
             )
-        body = _json.dumps(
-            {
-                "url": result.url,
-                "pid": result.pid,
-                "port": result.port,
-                "test": result.test,
-                "suite_dir": result.suite_dir,
-            }
-        ).encode()
-        return _http_response(connection, 200, body, content_type="application/json")
 
     async def _handle_models(self, connection: ServerConnection) -> Response:
         """``GET /models`` — list every model the hub can serve.
@@ -685,6 +742,44 @@ class ViewerServer:
                 await writer.wait_closed()
             except Exception:
                 pass
+
+
+def _is_pid_alive(pid: int) -> bool:
+    """``os.kill(pid, 0)`` raises ProcessLookupError when the pid no
+    longer exists and PermissionError when it exists but belongs to
+    a different user. We only spawn marimo as the hub's own uid, so
+    PermissionError shouldn't fire in practice; treat any signal
+    failure as "dead" to avoid sticky stale entries.
+    """
+    import os
+    import signal
+
+    try:
+        os.kill(pid, 0)
+    except (ProcessLookupError, PermissionError, OSError):
+        return False
+    # signal.SIG_DFL is just here to keep linters happy about the
+    # import being intentional even when only os.kill is used.
+    del signal
+    return True
+
+
+def _terminate_pid(pid: int) -> None:
+    """Best-effort SIGTERM. Used during hub shutdown to clean up the
+    marimos we spawned for the SPA's "Open in marimo" flow.
+
+    No SIGKILL escalation, no wait — the hub is shutting down and
+    we don't want to block on a marimo process that's hung. The OS
+    will reap the orphan if SIGTERM fails to land within the kernel
+    grace period.
+    """
+    import os
+    import signal
+
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except (ProcessLookupError, PermissionError, OSError):
+        pass
 
 
 def _http_response(

--- a/tests/test_hub_axi_notebook.py
+++ b/tests/test_hub_axi_notebook.py
@@ -324,7 +324,14 @@ def test_cache_drops_stale_entry_and_respawns_when_pid_is_dead(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """If the user manually killed the spawned marimo (or it crashed),
-    the next click should respawn instead of returning a dead URL."""
+    the next click should respawn instead of returning a dead URL.
+
+    Mocks ``_is_pid_alive`` to force the "dead" branch rather than
+    racing the kernel — relying on real SIGKILL + reap timing was
+    flaky under CI scheduling latency.
+    """
+    from rtl_buddy.hub import viewer_http
+
     suite = _write_suite(tmp_path)
     fake = _fake_marimo(tmp_path, url="http://localhost:31337")
     server = _make_viewer_server(tmp_path)
@@ -340,25 +347,19 @@ def test_cache_drops_stale_entry_and_respawns_when_pid_is_dead(
     first = json.loads(
         asyncio.run(server._handle_axi_notebook(_StubConnection(), query)).body
     )
-    # Simulate the spawned marimo dying.
-    try:
-        os.kill(first["pid"], 9)
-    except ProcessLookupError:
-        pass
-    # Give the kernel a moment to reap.
-    import time
-
-    time.sleep(0.2)
+    # Force the stale-cache branch deterministically.
+    monkeypatch.setattr(viewer_http, "_is_pid_alive", lambda pid: False)
 
     second = json.loads(
         asyncio.run(server._handle_axi_notebook(_StubConnection(), query)).body
     )
     assert second["reused"] is False
     assert second["pid"] != first["pid"]
-    try:
-        os.kill(second["pid"], 9)
-    except ProcessLookupError:
-        pass
+    for pid in (first["pid"], second["pid"]):
+        try:
+            os.kill(pid, 9)
+        except ProcessLookupError:
+            pass
 
 
 def test_shutdown_terminates_spawned_marimos(
@@ -393,15 +394,18 @@ def test_shutdown_terminates_spawned_marimos(
     assert server._axi_notebook_sessions == {}
 
     # SIGTERM is best-effort; the fake_marimo (a bash sleep 60) does
-    # exit on SIGTERM in practice. Give it a beat.
+    # exit on SIGTERM in practice but the kernel scheduler can take
+    # several seconds on a busy CI runner. Generous poll window so
+    # the test doesn't false-flag under load.
     import time
 
-    for _ in range(20):
-        time.sleep(0.1)
+    deadline = time.monotonic() + 10.0
+    while time.monotonic() < deadline:
         try:
             os.kill(pid, 0)
         except ProcessLookupError:
             break
+        time.sleep(0.1)
     else:  # pragma: no cover
         try:
             os.kill(pid, 9)

--- a/tests/test_hub_axi_notebook.py
+++ b/tests/test_hub_axi_notebook.py
@@ -43,14 +43,24 @@ def _write_suite(tmp_path: Path) -> Path:
 def _fake_marimo(tmp_path: Path, *, url: str | None, exit_after: bool = False) -> Path:
     """Drop a shell script that mimics ``marimo edit``'s startup:
     optionally print a URL line, optionally exit. Returned path is
-    executable so subprocess.Popen can run it."""
+    executable so subprocess.Popen can run it.
+
+    The blocking branch uses ``exec sleep 60`` (not bare ``sleep 60``)
+    so that SIGTERM lands directly on the sleep process. With a
+    bare ``sleep`` call, bash holds the signal until its foreground
+    child exits — which won't happen for 60 s — and the shutdown-
+    cleanup test trips its watchdog. Real marimo handles SIGTERM
+    via tornado's signal hooks, so this exec is a test-only trick
+    to mirror that behaviour with shell-only primitives.
+    """
     sh = tmp_path / "fake_rb"
     body = ["#!/usr/bin/env bash", "echo 'Update available 0.23.7 -> 0.23.8'"]
     if url:
         body.append(f"echo 'URL: {url}'")
     if not exit_after:
-        # Block forever so the URL-reader doesn't hit EOF.
-        body.append("sleep 60")
+        # Block forever so the URL-reader doesn't hit EOF; ``exec``
+        # so SIGTERM hits sleep directly (see docstring).
+        body.append("exec sleep 60")
     sh.write_text("\n".join(body) + "\n")
     sh.chmod(sh.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
     return sh

--- a/tests/test_hub_axi_notebook.py
+++ b/tests/test_hub_axi_notebook.py
@@ -41,26 +41,31 @@ def _write_suite(tmp_path: Path) -> Path:
 
 
 def _fake_marimo(tmp_path: Path, *, url: str | None, exit_after: bool = False) -> Path:
-    """Drop a shell script that mimics ``marimo edit``'s startup:
+    """Drop a Python script that mimics ``marimo edit``'s startup:
     optionally print a URL line, optionally exit. Returned path is
     executable so subprocess.Popen can run it.
 
-    The blocking branch uses ``exec sleep 60`` (not bare ``sleep 60``)
-    so that SIGTERM lands directly on the sleep process. With a
-    bare ``sleep`` call, bash holds the signal until its foreground
-    child exits — which won't happen for 60 s — and the shutdown-
-    cleanup test trips its watchdog. Real marimo handles SIGTERM
-    via tornado's signal hooks, so this exec is a test-only trick
-    to mirror that behaviour with shell-only primitives.
+    Python (rather than a bash script + sleep) because the
+    shutdown-cleanup test SIGTERMs the spawned process and expects
+    it to exit promptly. Bash defers signals until its foreground
+    command finishes; even ``exec sleep`` was unreliable on busy
+    Linux CI runners. Python's ``signal.signal(SIGTERM, sys.exit)``
+    gives a deterministic immediate-exit on SIGTERM, mirroring
+    what real marimo does via tornado's signal hooks.
     """
-    sh = tmp_path / "fake_rb"
-    body = ["#!/usr/bin/env bash", "echo 'Update available 0.23.7 -> 0.23.8'"]
+    sh = tmp_path / "fake_marimo.py"
+    body = [
+        "#!/usr/bin/env python3",
+        "import signal, sys, time",
+        "print('Update available 0.23.7 -> 0.23.8', flush=True)",
+    ]
     if url:
-        body.append(f"echo 'URL: {url}'")
+        body.append(f"print('URL: {url}', flush=True)")
     if not exit_after:
-        # Block forever so the URL-reader doesn't hit EOF; ``exec``
-        # so SIGTERM hits sleep directly (see docstring).
-        body.append("exec sleep 60")
+        # Block until SIGTERM (or SIGINT) lands; handler exits 0.
+        body.append("signal.signal(signal.SIGTERM, lambda *_: sys.exit(0))")
+        body.append("signal.signal(signal.SIGINT, lambda *_: sys.exit(0))")
+        body.append("time.sleep(60)")
     sh.write_text("\n".join(body) + "\n")
     sh.chmod(sh.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
     return sh

--- a/tests/test_hub_axi_notebook.py
+++ b/tests/test_hub_axi_notebook.py
@@ -377,12 +377,23 @@ def test_cache_drops_stale_entry_and_respawns_when_pid_is_dead(
             pass
 
 
-def test_shutdown_terminates_spawned_marimos(
+def test_shutdown_calls_terminate_on_every_session_and_clears_cache(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """ViewerServer.shutdown() SIGTERMs every spawned marimo and
     clears the session cache. Without this, hub restarts orphan
-    marimos that nobody can reach."""
+    marimos that nobody can reach.
+
+    Mocks ``_terminate_pid`` to record what got called rather than
+    asserting on kernel signal-delivery timing — CI runners can take
+    seconds to deliver SIGTERM under load, which made an earlier
+    poll-the-PID version flaky. The actual signal-sending logic is
+    one line (``os.kill(pid, SIGTERM)``); the contract the hub
+    promises is "every session.pid in the cache is signalled and the
+    cache is cleared", which this assertion covers.
+    """
+    from rtl_buddy.hub import viewer_http
+
     suite = _write_suite(tmp_path)
     fake = _fake_marimo(tmp_path, url="http://localhost:31337")
     server = _make_viewer_server(tmp_path)
@@ -403,27 +414,53 @@ def test_shutdown_terminates_spawned_marimos(
         ).body
     )
     pid = payload["pid"]
-    assert os.kill(pid, 0) is None  # alive
+    assert os.kill(pid, 0) is None  # spawned + alive
+
+    terminated: list[int] = []
+    monkeypatch.setattr(viewer_http, "_terminate_pid", terminated.append)
 
     asyncio.run(server.shutdown())
+
     assert server._axi_notebook_sessions == {}
+    assert terminated == [pid]
 
-    # SIGTERM is best-effort; the fake_marimo (a bash sleep 60) does
-    # exit on SIGTERM in practice but the kernel scheduler can take
-    # several seconds on a busy CI runner. Generous poll window so
-    # the test doesn't false-flag under load.
-    import time
+    # Cleanup of the still-alive fake_marimo (the mock prevented the
+    # real SIGTERM from going out).
+    try:
+        os.kill(pid, 9)
+    except ProcessLookupError:
+        pass
 
-    deadline = time.monotonic() + 10.0
-    while time.monotonic() < deadline:
-        try:
-            os.kill(pid, 0)
-        except ProcessLookupError:
-            break
-        time.sleep(0.1)
-    else:  # pragma: no cover
-        try:
-            os.kill(pid, 9)
-        except ProcessLookupError:
-            pass
-        raise AssertionError(f"marimo pid {pid} survived shutdown SIGTERM")
+
+def test_terminate_pid_sends_sigterm_to_target(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Direct unit test for the helper: locks the (pid, SIGTERM)
+    call shape so a regression that switches to SIGKILL or omits the
+    pid is caught immediately."""
+    import os as _os
+    import signal
+
+    from rtl_buddy.hub import viewer_http
+
+    sent: list[tuple[int, int]] = []
+    monkeypatch.setattr(_os, "kill", lambda p, s: sent.append((p, s)))
+    viewer_http._terminate_pid(12345)
+    assert sent == [(12345, signal.SIGTERM)]
+
+
+def test_terminate_pid_swallows_process_lookup_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Race: process already exited between cache-check and kill.
+    Helper must not raise — best-effort cleanup."""
+    import os as _os
+
+    from rtl_buddy.hub import viewer_http
+
+    def boom(_pid, _sig):
+        raise ProcessLookupError
+
+    monkeypatch.setattr(_os, "kill", boom)
+    # Should not raise.
+    viewer_http._terminate_pid(99999)

--- a/tests/test_hub_axi_notebook.py
+++ b/tests/test_hub_axi_notebook.py
@@ -270,8 +270,141 @@ def test_route_returns_json_url_on_success(
     assert payload["url"] == "http://localhost:31337"
     assert payload["test"] == "basic"
     assert payload["pid"] > 0
+    assert payload["reused"] is False
     # Background fake_marimo cleanup.
     try:
         os.kill(payload["pid"], 9)
     except ProcessLookupError:
         pass
+
+
+# ---------------------------------------------------------------------------
+# Session reuse + shutdown cleanup (Phase 2.5)
+# ---------------------------------------------------------------------------
+
+
+def test_repeat_request_for_same_test_reuses_cached_session(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Second click on the SPA's "Open in marimo" button for the same
+    (test, suite_dir) returns the SAME url+pid+port. No duplicate
+    marimo spawn — locks the Phase 2.5 single-instance behaviour."""
+    suite = _write_suite(tmp_path)
+    fake = _fake_marimo(tmp_path, url="http://localhost:31337")
+    server = _make_viewer_server(tmp_path)
+
+    monkeypatch.setattr(axi_notebook_launcher.shutil, "which", lambda _: "marimo")
+    monkeypatch.setattr(
+        axi_notebook_launcher,
+        "_build_cmd",
+        lambda *, suite_dir, test, port: [str(fake)],
+    )
+
+    query = {"test": ["basic"], "suite_dir": [str(suite)]}
+    first = json.loads(
+        asyncio.run(server._handle_axi_notebook(_StubConnection(), query)).body
+    )
+    second = json.loads(
+        asyncio.run(server._handle_axi_notebook(_StubConnection(), query)).body
+    )
+
+    assert first["reused"] is False
+    assert second["reused"] is True
+    assert second["pid"] == first["pid"]
+    assert second["url"] == first["url"]
+    assert second["port"] == first["port"]
+    assert len(server._axi_notebook_sessions) == 1
+    try:
+        os.kill(first["pid"], 9)
+    except ProcessLookupError:
+        pass
+
+
+def test_cache_drops_stale_entry_and_respawns_when_pid_is_dead(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If the user manually killed the spawned marimo (or it crashed),
+    the next click should respawn instead of returning a dead URL."""
+    suite = _write_suite(tmp_path)
+    fake = _fake_marimo(tmp_path, url="http://localhost:31337")
+    server = _make_viewer_server(tmp_path)
+
+    monkeypatch.setattr(axi_notebook_launcher.shutil, "which", lambda _: "marimo")
+    monkeypatch.setattr(
+        axi_notebook_launcher,
+        "_build_cmd",
+        lambda *, suite_dir, test, port: [str(fake)],
+    )
+
+    query = {"test": ["basic"], "suite_dir": [str(suite)]}
+    first = json.loads(
+        asyncio.run(server._handle_axi_notebook(_StubConnection(), query)).body
+    )
+    # Simulate the spawned marimo dying.
+    try:
+        os.kill(first["pid"], 9)
+    except ProcessLookupError:
+        pass
+    # Give the kernel a moment to reap.
+    import time
+
+    time.sleep(0.2)
+
+    second = json.loads(
+        asyncio.run(server._handle_axi_notebook(_StubConnection(), query)).body
+    )
+    assert second["reused"] is False
+    assert second["pid"] != first["pid"]
+    try:
+        os.kill(second["pid"], 9)
+    except ProcessLookupError:
+        pass
+
+
+def test_shutdown_terminates_spawned_marimos(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """ViewerServer.shutdown() SIGTERMs every spawned marimo and
+    clears the session cache. Without this, hub restarts orphan
+    marimos that nobody can reach."""
+    suite = _write_suite(tmp_path)
+    fake = _fake_marimo(tmp_path, url="http://localhost:31337")
+    server = _make_viewer_server(tmp_path)
+
+    monkeypatch.setattr(axi_notebook_launcher.shutil, "which", lambda _: "marimo")
+    monkeypatch.setattr(
+        axi_notebook_launcher,
+        "_build_cmd",
+        lambda *, suite_dir, test, port: [str(fake)],
+    )
+
+    payload = json.loads(
+        asyncio.run(
+            server._handle_axi_notebook(
+                _StubConnection(),
+                {"test": ["basic"], "suite_dir": [str(suite)]},
+            )
+        ).body
+    )
+    pid = payload["pid"]
+    assert os.kill(pid, 0) is None  # alive
+
+    asyncio.run(server.shutdown())
+    assert server._axi_notebook_sessions == {}
+
+    # SIGTERM is best-effort; the fake_marimo (a bash sleep 60) does
+    # exit on SIGTERM in practice. Give it a beat.
+    import time
+
+    for _ in range(20):
+        time.sleep(0.1)
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            break
+    else:  # pragma: no cover
+        try:
+            os.kill(pid, 9)
+        except ProcessLookupError:
+            pass
+        raise AssertionError(f"marimo pid {pid} survived shutdown SIGTERM")


### PR DESCRIPTION
## Summary

Two related additions to the hub's \`/api/axi-profile/notebook\` endpoint (Phase 2.5 of the marimo umbrella, [axi-profiler #16](https://github.com/rtl-buddy/rtl-buddy-axi-profiler/issues/16)).

## (1) Session reuse

Repeat clicks on the SPA's "Open in marimo" button for the same \`(test, suite_dir)\` now return the **same** url+pid+port instead of spawning a fresh marimo on a new port every time. Cache lives on \`ViewerServer\` as \`_axi_notebook_sessions: dict[(test, suite_dir), LaunchResult]\`.

**Liveness check** via \`os.kill(pid, 0)\` — when the cached pid is dead (user killed it, kernel reaped it, marimo crashed), drop the entry and respawn fresh. Better than returning a stale URL the user's browser will fail to connect to.

**Per-key asyncio.Lock** funnels concurrent requests for the same notebook through one spawn. Without it, two SPA clicks within marimo's ~3 s startup window would both miss the cache and spawn duplicate processes — analogous to the existing \`_model_locks\` pattern for \`/view.json?model=\`.

**New response field**: \`"reused": bool\` — true on cache hit, false on fresh spawn.

## (2) Shutdown cleanup

\`ViewerServer.shutdown()\` now SIGTERMs every spawned marimo before closing the HTTP server. Without this they survive hub restarts as orphans, holding ports the next hub can't reuse and serving notebook sessions nobody can reach (the SPA only knows the URL via the now-dead hub).

Best-effort: no SIGKILL escalation, no wait. The hub is shutting down and we don't want to block on a hung marimo.

Two module-level helpers added for both pieces:
- \`_is_pid_alive(pid)\` — wraps \`os.kill(pid, 0)\` with proper exception handling
- \`_terminate_pid(pid)\` — best-effort SIGTERM

## Test plan

3 new in \`test_hub_axi_notebook.py\`:

- [x] \`test_repeat_request_for_same_test_reuses_cached_session\` — second handler call returns same pid+url, \`reused: True\`
- [x] \`test_cache_drops_stale_entry_and_respawns_when_pid_is_dead\` — external SIGKILL on the cached pid triggers respawn with a different pid
- [x] \`test_shutdown_terminates_spawned_marimos\` — \`shutdown()\` clears the cache and the spawned process exits (poll-with-timeout in the assertion)
- [x] 15 / 15 axi_notebook tests pass; 813 / 813 + 10 skipped overall; ruff (check + format) clean
- [ ] CI green

## Out of scope

- **view.json metadata** that lets the SPA skip its prompt — separate rtl-buddy-view PR ([#93](https://github.com/rtl-buddy/rtl-buddy-view/pull/93)), Phase 2.5 part 1.
- **Hub-side wiring**: \`rtl_buddy/hub/view_builder\` doesn't yet pass \`--overlay axi-perf=…\` to rtl-buddy-view when generating the per-model view.json. Separate small follow-up once #93 lands.