### PR TITLE
feat(verible): rb verible filelist generates verible.filelist from models.yaml

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -47,7 +47,6 @@ Usage: rtl-buddy [OPTIONS] COMMAND [ARGS]...
 │ regression         run rtl regression                                                │
 │ filelist           generate filelists using models.yaml                              │
 │ hier               render module hierarchy via rtl-buddy-view                        │
-│ verible            run verible cmd                                                   │
 │ wave               open waveform viewer for a test                                   │
 │ wave-fpv           open SymbiYosys counterexample VCD for a failed FPV verification  │
 │ wave-install-nvim  install nvim plugin for rb wave annotation                        │
@@ -62,6 +61,7 @@ Usage: rtl-buddy [OPTIONS] COMMAND [ARGS]...
 │ fpv                run formal property verification                                  │
 │ fpv-regression     run FPV regression                                                │
 │ axi-profile        profile AXI interconnect performance via rtl-buddy-axi-profiler   │
+│ verible            verible commands                                                  │
 │ hub                manage the rtl-buddy-hub daemon                                   │
 │ skill              manage the rtl_buddy agent skill                                  │
 │ docs               browse bundled documentation                                      │
@@ -235,16 +235,20 @@ Usage: rtl-buddy axi-profile [OPTIONS] COMMAND [ARGS]...
 ## verible
 
 ```text
-Usage: rtl-buddy verible [OPTIONS] CMD [VERIBLE_ARGS]...                               
+Usage: rtl-buddy verible [OPTIONS] COMMAND [ARGS]...                                   
                                                                                         
- run verible cmd                                                                        
+ verible commands                                                                       
                                                                                         
-╭─ Arguments ──────────────────────────────────────────────────────────────────────────╮
-│ *    cmd               TEXT               Verible cmd [required]                     │
-│      verible_args      [VERIBLE_ARGS]...                                             │
-╰──────────────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ────────────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                          │
+╰──────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────────────╮
+│ lint          run verible-verilog-lint                                               │
+│ syntax        run verible-verilog-syntax                                             │
+│ format        run verible-verilog-format                                             │
+│ preprocessor  run verible-verilog-preprocessor                                       │
+│ filelist      generate verible.filelist from models.yaml so verible-verilog-ls can   │
+│               resolve cross-file symbols                                             │
 ╰──────────────────────────────────────────────────────────────────────────────────────╯
 ```
 

--- a/src/rtl_buddy/rtl_buddy.py
+++ b/src/rtl_buddy/rtl_buddy.py
@@ -17,7 +17,7 @@ import click
 from .config import RegConfig, RootConfig, SuiteConfig, TestConfig
 from .config.cdc import CdcRegConfig, CdcSuiteConfig
 from .config.fpv import FpvRegConfig, FpvSuiteConfig
-from .config.model import ModelConfigLoader
+from .config.model import ModelConfig, ModelConfigLoader
 from .config.pnr import PnrSuiteConfig
 from .config.power import PowerRegConfig, PowerSuiteConfig
 from .config.synth import SynthRegConfig, SynthSuiteConfig
@@ -160,7 +160,27 @@ class RtlBuddy:
             name="axi-profile",
             help=("profile AXI interconnect performance via rtl-buddy-axi-profiler"),
         )
-        self.app.command("verible", help="run verible cmd")(self.do_verible)
+        self.verible_app = typer.Typer(
+            help="verible tooling and filelist generation", no_args_is_help=True
+        )
+        self.verible_app.command("lint", help="run verible-verilog-lint")(
+            self.do_verible_lint
+        )
+        self.verible_app.command("syntax", help="run verible-verilog-syntax")(
+            self.do_verible_syntax
+        )
+        self.verible_app.command("format", help="run verible-verilog-format")(
+            self.do_verible_format
+        )
+        self.verible_app.command(
+            "preprocessor", help="run verible-verilog-preprocessor"
+        )(self.do_verible_preprocessor)
+        self.verible_app.command(
+            "filelist",
+            help="generate verible.filelist from models.yaml so verible-verilog-ls "
+            "can resolve cross-file symbols",
+        )(self.do_verible_filelist)
+        self.app.add_typer(self.verible_app, name="verible", help="verible commands")
         self.app.command("wave", help="open waveform viewer for a test")(
             self.do_cmd_wave
         )
@@ -3083,13 +3103,12 @@ class RtlBuddy:
     def do_gen_vlog_run_script(self):
         assert False, "not yet impl"
 
-    def do_verible(
-        self,
-        cmd: Annotated[str, typer.Argument(help="Verible cmd")],
-        verible_args: Annotated[list[str], typer.Argument(...)] = [],
-    ):
-        """
-        run verible cmd
+    def _run_verible_passthrough(self, cmd: str, verible_args: list[str]):
+        """Shared dispatch for the verible passthrough subcommands.
+
+        Resolves the configured verible executable via root_config and
+        invokes it with the trailing ``verible_args``. Always exits via
+        ``typer.Exit`` so the binary's return code propagates.
         """
         verible_cfg = self.root_cfg.platform_cfg.get_verible()
         if not verible_cfg.available:
@@ -3104,8 +3123,112 @@ class RtlBuddy:
             command=cmd,
             argv=" ".join(verible_args),
         )
-        exit_code = ver.do_cmd(cmd=cmd, verible_args=verible_args)
-        raise typer.Exit(exit_code)
+        raise typer.Exit(ver.do_cmd(cmd=cmd, verible_args=verible_args))
+
+    def do_verible_lint(
+        self,
+        verible_args: Annotated[list[str], typer.Argument(...)] = [],
+    ):
+        """run verible-verilog-lint"""
+        self._run_verible_passthrough("lint", verible_args)
+
+    def do_verible_syntax(
+        self,
+        verible_args: Annotated[list[str], typer.Argument(...)] = [],
+    ):
+        """run verible-verilog-syntax"""
+        self._run_verible_passthrough("syntax", verible_args)
+
+    def do_verible_format(
+        self,
+        verible_args: Annotated[list[str], typer.Argument(...)] = [],
+    ):
+        """run verible-verilog-format"""
+        self._run_verible_passthrough("format", verible_args)
+
+    def do_verible_preprocessor(
+        self,
+        verible_args: Annotated[list[str], typer.Argument(...)] = [],
+    ):
+        """run verible-verilog-preprocessor"""
+        self._run_verible_passthrough("preprocessor", verible_args)
+
+    def do_verible_filelist(
+        self,
+        models: Annotated[
+            list[str],
+            typer.Option(
+                "--model",
+                help=(
+                    "Model name(s) to include. May be repeated. Default: "
+                    "union of every model declared in any models.yaml under "
+                    "the project root."
+                ),
+            ),
+        ] = [],
+        output: Annotated[
+            str | None,
+            typer.Option(
+                "-o",
+                "--output",
+                help=(
+                    "Output path. Defaults to <project_root>/verible.filelist "
+                    "so verible-verilog-ls auto-discovers it."
+                ),
+            ),
+        ] = None,
+    ):
+        """
+        generate verible.filelist from models.yaml so verible-verilog-ls can
+        resolve cross-file symbols (go-to-definition, hover, references)
+        """
+        project_root = self.root_cfg.get_project_rootdir()
+        if output is None:
+            output = os.path.join(project_root, "verible.filelist")
+
+        all_entries = discover_model_configs(project_root)
+        if not all_entries:
+            log_event(
+                logger,
+                logging.ERROR,
+                "verible_filelist.no_models_discovered",
+                project_root=project_root,
+            )
+            raise FatalRtlBuddyError(f"no models.yaml files found under {project_root}")
+
+        if models:
+            by_name: dict[str, ModelConfig] = {}
+            for _, model in all_entries:
+                # First-found wins on duplicate names across files. Within a
+                # single models.yaml, ModelConfigLoader already rejects dupes.
+                by_name.setdefault(model.name, model)
+            missing = [name for name in models if name not in by_name]
+            if missing:
+                log_event(
+                    logger,
+                    logging.ERROR,
+                    "verible_filelist.unknown_models",
+                    models=missing,
+                    available=sorted(by_name),
+                )
+                raise FatalRtlBuddyError(f"unknown model(s): {', '.join(missing)}")
+            selected = [by_name[name] for name in models]
+        else:
+            selected = [model for _, model in all_entries]
+
+        log_event(
+            logger,
+            logging.INFO,
+            "command.verible_filelist",
+            models=[m.name for m in selected],
+            output=output,
+        )
+        vlog_fl = VlogFilelist(
+            name=self.name + "/verible_filelist",
+            model_cfg=None,
+            output_path=output,
+        )
+        vlog_fl.write_verible_filelist(selected, output_filepath=output)
 
     def show_git_rev(self):
         status_result = subprocess.run(

--- a/src/rtl_buddy/tools/vlog_filelist.py
+++ b/src/rtl_buddy/tools/vlog_filelist.py
@@ -24,6 +24,9 @@ class VlogFilelist:
     def __init__(self, name, model_cfg, output_path):
         self.name = name
         self.output_path = output_path
+        # model_cfg may be None for callers that drive a multi-model
+        # generation flow (e.g. write_verible_filelist) and supply
+        # the models per call.
         self.model_cfg = model_cfg
 
     def _fail(self, event, message, **fields):
@@ -222,4 +225,65 @@ class VlogFilelist:
             log_event(
                 logger, logging.INFO, "filelist.write_done", output=output_filepath
             )
+        return
+
+    def write_verible_filelist(self, model_cfgs, output_filepath=None):
+        """Generate a verible.filelist from one or more ModelConfigs.
+
+        Verible-verilog-ls parses the filelist via
+        ``verilog-filelist.cc::AppendFileListFromContent`` which honours
+        only bare source-file paths and ``+incdir+`` / ``+define+``
+        directives — any other ``+``/``-`` line is silently ignored.
+        We strip ``-v`` / ``-y`` / ``+libext+`` here so the on-disk
+        filelist only carries lines that affect the LSP's symbol scope.
+        ``-F`` chains are always unrolled so the output is a flat list
+        the LSP can consume without further indirection.
+        """
+        if output_filepath is None:
+            output_filepath = self.output_path
+        log_event(
+            logger,
+            logging.DEBUG,
+            "verible_filelist.write_start",
+            output=output_filepath,
+            models=[m.name for m in model_cfgs],
+        )
+
+        if not model_cfgs:
+            self._fail(
+                "verible_filelist.no_models",
+                "no models supplied for verible filelist generation",
+            )
+
+        entries = []
+        for cfg in model_cfgs:
+            entries.extend(
+                self._extract(
+                    cfg.get_filelist(),
+                    unroll=True,
+                    fpath=os.path.abspath(cfg.get_model_path()),
+                )
+            )
+
+        filtered = [
+            (path, opt) for path, opt in entries if opt is None or opt == "+incdir+"
+        ]
+        lines = self._process(
+            filtered,
+            output_dir=os.path.dirname(output_filepath) or ".",
+            flatten=False,
+            strip=False,
+            deduplicate=True,
+        )
+
+        with open(output_filepath, "w") as f:
+            f.write("// rtl-buddy generated verible filelist\n")
+            f.writelines(lines)
+        log_event(
+            logger,
+            logging.INFO,
+            "verible_filelist.write_done",
+            output=output_filepath,
+            entries=len(lines),
+        )
         return

--- a/tests/test_verible_filelist.py
+++ b/tests/test_verible_filelist.py
@@ -1,0 +1,182 @@
+"""Tests for ``rb verible filelist`` and the underlying generator.
+
+Covers:
+- Multi-model union (default): aggregates every model under the project root.
+- ``--model`` filter: emits only the selected models' transitive sources.
+- ``-o`` override: writes to a non-default path.
+- Verible filelist format: bare source paths + ``+incdir+`` only; ``-y``/``-v``
+  and ``+libext+`` are dropped because verible-verilog-ls silently ignores
+  them (see verible's ``verilog-filelist.cc::AppendFileListFromContent``).
+- ``-F`` chains are flattened so the LSP doesn't need to follow indirection.
+- Duplicate paths across models are deduplicated.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from rtl_buddy.config.model import ModelConfig
+from rtl_buddy.errors import FilelistError
+from rtl_buddy.rtl_buddy import RtlBuddy
+from rtl_buddy.tools.vlog_filelist import VlogFilelist
+
+
+def _runner() -> tuple[CliRunner, RtlBuddy]:
+    return CliRunner(), RtlBuddy(name="test_verible_filelist")
+
+
+# --- VlogFilelist.write_verible_filelist (unit) ---------------------------
+
+
+def test_verible_filelist_drops_unsupported_directives(tmp_path: Path):
+    """``-v`` / ``-y`` / ``+libext+`` get filtered out; only paths and
+    ``+incdir+`` survive, matching what verible-verilog-ls actually parses."""
+    src = tmp_path / "src" / "a.sv"
+    src.parent.mkdir()
+    src.write_text("module a; endmodule\n")
+    libdir = tmp_path / "lib"
+    libdir.mkdir()
+    incdir = tmp_path / "include"
+    incdir.mkdir()
+    libfile = libdir / "b.sv"
+    libfile.write_text("module b; endmodule\n")
+
+    model = ModelConfig(
+        name="m",
+        filelist=[
+            "src/a.sv",
+            "-y lib/",
+            "+incdir+include",
+            "+libext+.sv+.v",
+            "-v lib/b.sv",
+        ],
+        path=str(tmp_path / "models.yaml"),
+    )
+
+    out = tmp_path / "verible.filelist"
+    fl = VlogFilelist(name="t", model_cfg=None, output_path=str(out))
+    fl.write_verible_filelist([model])
+
+    text = out.read_text()
+    assert "src/a.sv" in text
+    assert "+incdir+include" in text
+    # Filtered:
+    assert "-y" not in text
+    assert "-v" not in text
+    assert "+libext+" not in text
+
+
+def test_verible_filelist_unrolls_dash_F_chains(tmp_path: Path):
+    """``-F sub.f`` references are inlined so the LSP only sees flat paths."""
+    src = tmp_path / "src" / "x.sv"
+    src.parent.mkdir()
+    src.write_text("module x; endmodule\n")
+    other = tmp_path / "src" / "y.sv"
+    other.write_text("module y; endmodule\n")
+
+    sub_f = tmp_path / "src" / "sub.f"
+    sub_f.write_text("y.sv\n")
+
+    model = ModelConfig(
+        name="m",
+        filelist=["src/x.sv", "-F src/sub.f"],
+        path=str(tmp_path / "models.yaml"),
+    )
+
+    out = tmp_path / "verible.filelist"
+    fl = VlogFilelist(name="t", model_cfg=None, output_path=str(out))
+    fl.write_verible_filelist([model])
+
+    text = out.read_text()
+    assert "src/x.sv" in text
+    assert "src/y.sv" in text
+    # The inlined .f reference itself must not appear as a -F line.
+    assert "-F" not in text
+
+
+def test_verible_filelist_deduplicates_across_models(tmp_path: Path):
+    """When two models share a common source, it appears once in the output."""
+    shared = tmp_path / "src" / "shared.sv"
+    shared.parent.mkdir()
+    shared.write_text("module shared; endmodule\n")
+    only_a = tmp_path / "src" / "a_only.sv"
+    only_a.write_text("module a_only; endmodule\n")
+    only_b = tmp_path / "src" / "b_only.sv"
+    only_b.write_text("module b_only; endmodule\n")
+
+    model_a = ModelConfig(
+        name="a",
+        filelist=["src/shared.sv", "src/a_only.sv"],
+        path=str(tmp_path / "models.yaml"),
+    )
+    model_b = ModelConfig(
+        name="b",
+        filelist=["src/shared.sv", "src/b_only.sv"],
+        path=str(tmp_path / "models.yaml"),
+    )
+
+    out = tmp_path / "verible.filelist"
+    fl = VlogFilelist(name="t", model_cfg=None, output_path=str(out))
+    fl.write_verible_filelist([model_a, model_b])
+
+    lines = [
+        ln for ln in out.read_text().splitlines() if ln and not ln.startswith("//")
+    ]
+    assert lines.count("src/shared.sv") == 1
+    assert "src/a_only.sv" in lines
+    assert "src/b_only.sv" in lines
+
+
+def test_verible_filelist_empty_model_list_errors(tmp_path: Path):
+    fl = VlogFilelist(name="t", model_cfg=None, output_path=str(tmp_path / "out.f"))
+    with pytest.raises(FilelistError):
+        fl.write_verible_filelist([])
+
+
+# --- rb verible filelist (integration through Typer) ---------------------
+
+
+def test_rb_verible_filelist_default_writes_at_project_root(minimal_project: Path):
+    """Default ``rb verible filelist`` writes ``<project_root>/verible.filelist``
+    with every model's sources unioned. Mirrors the LSP auto-discovery layout."""
+    runner, rb = _runner()
+    result = runner.invoke(rb.app, ["verible", "filelist"])
+    assert result.exit_code == 0, result.output
+    out = minimal_project / "verible.filelist"
+    assert out.is_file()
+    text = out.read_text()
+    assert "rtl-buddy generated verible filelist" in text
+    # The fixture has a single model ("example") with src/example.sv.
+    assert "src/example.sv" in text
+
+
+def test_rb_verible_filelist_model_filter(minimal_project: Path):
+    """``--model NAME`` restricts the output to the named model only."""
+    runner, rb = _runner()
+    result = runner.invoke(rb.app, ["verible", "filelist", "--model", "example"])
+    assert result.exit_code == 0, result.output
+    text = (minimal_project / "verible.filelist").read_text()
+    assert "src/example.sv" in text
+
+
+def test_rb_verible_filelist_unknown_model_exits_nonzero(minimal_project: Path):
+    runner, rb = _runner()
+    result = runner.invoke(
+        rb.app, ["verible", "filelist", "--model", "not_a_real_model"]
+    )
+    assert result.exit_code != 0
+
+
+def test_rb_verible_filelist_output_override(minimal_project: Path, tmp_path: Path):
+    """``-o PATH`` writes to a non-default location and skips the default
+    ``<project_root>/verible.filelist`` path entirely."""
+    runner, rb = _runner()
+    custom = minimal_project / "custom_dir" / "my.filelist"
+    custom.parent.mkdir()
+    result = runner.invoke(rb.app, ["verible", "filelist", "-o", str(custom)])
+    assert result.exit_code == 0, result.output
+    assert custom.is_file()
+    assert not (minimal_project / "verible.filelist").exists()


### PR DESCRIPTION
Closes #148.

## Summary

- `rb verible filelist [--model NAME ...] [-o PATH]` writes a `verible.filelist` so `verible-verilog-ls` can resolve cross-file symbols (go-to-definition, hover, references) without users hand-rolling a `find ... > verible.filelist` step that goes stale on every new file.
- Default writes `<project_root>/verible.filelist` (the path verible-verilog-ls auto-discovers); no `--model` ⇒ union of every model under the project, one or more `--model` ⇒ just those models' transitive sources.
- Output is filtered to bare paths + `+incdir+` because verible's parser (`verilog-filelist.cc::AppendFileListFromContent`) silently drops other directives — keeping `-v`/`-y`/`+libext+` in the file would just be misleading noise.
- Implementation reuses `VlogFilelist` so SV/SVH discovery, `-F` flattening, and include resolution match every other rtl-buddy filelist consumer.
- Converts `rb verible` into a Typer sub-app so the existing `syntax`/`lint`/`format`/`preprocessor` passthroughs sit alongside the new `filelist` subcommand. `rb verible syntax foo.sv` etc. continue to work unchanged.

## Out of scope (per issue)

- `--watch` / `--check-staleness` (stretch goal in #148); manual one-shot covers the immediate pain.
- `.verilator_root` / Slang project files and editor-side LSP config.

## Test plan

- [x] `uv run pytest` — 818 existing tests + 8 new ones all pass
- [x] `uv run ruff check` / `ruff format --check` clean
- [x] `python scripts/gen_cli_reference.py --check` passes (docs/reference/cli.md regenerated)
- [x] Live validation against `rtl-buddy-ai-project`:
  - `python -m rtl_buddy verible filelist` writes `verible.filelist` at the project root
  - File contains `design/common/ip_cdc_handshake.sv` — the exact path the issue's repro flow needs for `<C-]>` to jump from `ip_demo_tiny_npu.sv`
  - `--model ip_demo_tiny_npu` produces a 20-line subset matching the demo's transitive sources

🤖 Generated with [Claude Code](https://claude.com/claude-code)