### PR TITLE
feat(hub): --axi-perf-from threads axi-perf annotations into view.json builds (Phase 2.5)

### DIFF
--- a/src/rtl_buddy/hub/cli.py
+++ b/src/rtl_buddy/hub/cli.py
@@ -155,6 +155,22 @@ def cmd_start(
             ),
         ),
     ] = None,
+    axi_perf_from: Annotated[
+        Path | None,
+        typer.Option(
+            "--axi-perf-from",
+            help=(
+                "Path to an axi-perf.json (output of `rb axi-profile run`). "
+                "The hub bakes its per-bundle/interconnect throughput overlay "
+                "into every generated view.json AND records the source's "
+                "test/suite_dir so the SPA's 'Open in marimo' button skips "
+                "its prompt. Use the canonical "
+                "<suite>/artefacts/axi/<test>/axi-perf.json layout so the "
+                "test/suite_dir derivation lands. Only used with "
+                "--serve-viewer."
+            ),
+        ),
+    ] = None,
 ) -> None:
     """Bind, write ``hub.json``, run the server loop.
 
@@ -221,6 +237,15 @@ def cmd_start(
     # before the asyncio loop starts so a missing model or a tool
     # failure surfaces synchronously with a clear error, not as a
     # 404 the user discovers in the browser later.
+    # Up-front existence check on --axi-perf-from so the user gets a
+    # clear error before the hub binds its sockets, not later on the
+    # first SPA refresh.
+    if axi_perf_from is not None and not axi_perf_from.is_file():
+        emit_console_text(
+            f"--axi-perf-from: file not found: {axi_perf_from}", style="red"
+        )
+        raise typer.Exit(code=2)
+
     view_json_override: Path | None = None
     if model is not None:
         _models_yaml, loader = hub_model_discovery.resolve_model(
@@ -228,7 +253,9 @@ def cmd_start(
         )
         model_cfg = loader.get_model(model)
         view_json_override = hub_view_builder.build_view_json(
-            project_root=project_root, model_cfg=model_cfg
+            project_root=project_root,
+            model_cfg=model_cfg,
+            axi_perf_source=axi_perf_from,
         )
         emit_console_text(
             f"rb hub: generated view.json for {model!r} at {view_json_override}",
@@ -246,6 +273,7 @@ def cmd_start(
         serve_viewer=serve_viewer,
         viewer_bundle=str(viewer_bundle) if viewer_bundle else "",
         model=model or "",
+        axi_perf_from=str(axi_perf_from) if axi_perf_from else "",
     )
     raise typer.Exit(
         code=hub_loop.serve(
@@ -256,6 +284,7 @@ def cmd_start(
             view_json_override=view_json_override,
             initial_model=model,
             models_file_pin=models_file,
+            axi_perf_source=axi_perf_from,
         )
     )
 

--- a/src/rtl_buddy/hub/loop.py
+++ b/src/rtl_buddy/hub/loop.py
@@ -126,6 +126,7 @@ async def _run(
     view_json_override: Path | None = None,
     initial_model: str | None = None,
     models_file_pin: Path | None = None,
+    axi_perf_source: Path | None = None,
 ) -> int:
     if view_json_override is not None:
         # ``rb hub start --model`` already resolved + generated the
@@ -170,6 +171,7 @@ async def _run(
             project_root=project_root,
             initial_model=initial_model,
             models_file_pin=models_file_pin,
+            axi_perf_source=axi_perf_source,
             hub_server=server,
         )
         _vhost, vport = await _start_listener(
@@ -263,6 +265,7 @@ def serve(
     view_json_override: Path | None = None,
     initial_model: str | None = None,
     models_file_pin: Path | None = None,
+    axi_perf_source: Path | None = None,
 ) -> int:
     """Run the hub event loop until exit. Returns the process exit code.
 
@@ -278,6 +281,12 @@ def serve(
     ``models_file_pin`` records ``--models-file PATH``: when set, both
     ``GET /models`` and ``GET /view.json?model=`` honour the pin and
     refuse model names that aren't in that file.
+
+    ``axi_perf_source`` records ``--axi-perf-from PATH``: forwarded
+    to every ``view_builder.build_view_json`` call so the generated
+    view.json carries the axi-perf overlay + source metadata the
+    SPA's "Open in marimo" button reads. Phase 2.5 of the marimo
+    umbrella.
     """
 
     try:
@@ -290,6 +299,7 @@ def serve(
                 view_json_override=view_json_override,
                 initial_model=initial_model,
                 models_file_pin=models_file_pin,
+                axi_perf_source=axi_perf_source,
             )
         )
     except _PortInUseError as exc:

--- a/src/rtl_buddy/hub/view_builder.py
+++ b/src/rtl_buddy/hub/view_builder.py
@@ -60,6 +60,7 @@ def build_view_json(
     *,
     project_root: Path,
     model_cfg: ModelConfig,
+    axi_perf_source: Path | None = None,
 ) -> Path:
     """Generate view.json for ``model_cfg`` at the stable cache path
     and return it. Raises ``FatalRtlBuddyError`` when the
@@ -72,6 +73,14 @@ def build_view_json(
     ``--cdc-annotations`` to rtl-buddy-view. The SPA's clock overlay
     toggle then has data to render against. Models without ``cdc:``
     fall through to the no-overlay path unchanged.
+
+    When ``axi_perf_source`` is supplied (via the hub's
+    ``--axi-perf-from`` start-up flag), the builder also passes
+    ``--overlay axi-perf=<path>`` so rtl-buddy-view bakes the
+    throughput overlay AND records the test/suite_dir metadata that
+    the SPA's "Open in marimo" button reads to skip its prompt
+    (Phase 2.5 of the marimo umbrella). When not supplied, the
+    no-overlay path runs unchanged.
     """
 
     # Build the domain map FIRST so a misconfigured cdc: back-pointer
@@ -96,6 +105,7 @@ def build_view_json(
         model=model_cfg.name,
         path=str(out_path),
         cdc_annotations=str(domain_map) if domain_map else "",
+        axi_perf=str(axi_perf_source) if axi_perf_source else "",
     )
     runner = RtlBuddyView(
         name=f"hub/view/{model_cfg.name}",
@@ -105,6 +115,7 @@ def build_view_json(
         output=str(out_path),
         executable=viewer_exe,
         cdc_annotations=str(domain_map) if domain_map else None,
+        axi_perf_annotations=str(axi_perf_source) if axi_perf_source else None,
     )
     rc = runner.run()
     if rc != 0 or not out_path.is_file():

--- a/src/rtl_buddy/hub/viewer_http.py
+++ b/src/rtl_buddy/hub/viewer_http.py
@@ -174,6 +174,7 @@ class ViewerServer:
         project_root: Path | None = None,
         initial_model: str | None = None,
         models_file_pin: Path | None = None,
+        axi_perf_source: Path | None = None,
         hub_server: Any | None = None,
     ) -> None:
         self.hub_host = hub_host
@@ -188,6 +189,13 @@ class ViewerServer:
         self.project_root = project_root
         self.active_model = initial_model
         self.models_file_pin = models_file_pin
+        # Optional axi-perf.json the hub bakes into every model's
+        # generated view.json (Phase 2.5 of the marimo umbrella).
+        # ``rb hub start --axi-perf-from PATH`` populates this; the
+        # path is forwarded to rtl-buddy-view via the
+        # ``--overlay axi-perf=…`` form so the SPA's "Open in
+        # marimo" button gets the test/suite_dir metadata for free.
+        self.axi_perf_source = axi_perf_source
         self.hub_server = hub_server
         # Mirror the active model onto HubState so the ``state_snapshot``
         # request type can return it without reaching back into the HTTP
@@ -577,6 +585,7 @@ class ViewerServer:
                     view_builder.build_view_json,
                     project_root=self.project_root,
                     model_cfg=model_cfg,
+                    axi_perf_source=self.axi_perf_source,
                 )
             except FatalRtlBuddyError as exc:
                 log_event(

--- a/src/rtl_buddy/tools/hier_rtl_buddy_view.py
+++ b/src/rtl_buddy/tools/hier_rtl_buddy_view.py
@@ -47,6 +47,7 @@ class RtlBuddyView:
         frontend: str | None = None,
         cdc_annotations: str | None = None,
         rdc_annotations: str | None = None,
+        axi_perf_annotations: str | None = None,
         clock_legend: bool = False,
         executable: str = "rtl-buddy-view",
     ):
@@ -57,6 +58,14 @@ class RtlBuddyView:
         self.frontend = frontend
         self.cdc_annotations = cdc_annotations
         self.rdc_annotations = rdc_annotations
+        # Path to an ``axi-perf.json`` (the ``rb axi-profile run``
+        # output for a given test). When set, rtl-buddy-view bakes
+        # the per-bundle/interconnect throughput overlay AND emits a
+        # top-level ``axi_perf.{source,test,suite_dir}`` block that
+        # the SPA's "Open in marimo" button uses to skip its prompt
+        # (Phase 2.5 of the marimo umbrella). Passed via the new
+        # ``--overlay axi-perf=PATH`` form.
+        self.axi_perf_annotations = axi_perf_annotations
         self.clock_legend = clock_legend
         self.executable = executable
 
@@ -102,6 +111,8 @@ class RtlBuddyView:
             cmd += ["--cdc-annotations", self.cdc_annotations]
         if self.rdc_annotations is not None:
             cmd += ["--rdc-annotations", self.rdc_annotations]
+        if self.axi_perf_annotations is not None:
+            cmd += ["--overlay", f"axi-perf={self.axi_perf_annotations}"]
         if self.clock_legend:
             cmd += ["--clock-legend"]
         return cmd
@@ -130,6 +141,13 @@ class RtlBuddyView:
         ):
             raise FatalRtlBuddyError(
                 f"hier: cdc-annotations file not found: {self.cdc_annotations}"
+            )
+        if self.axi_perf_annotations is not None and not os.path.isfile(
+            self.axi_perf_annotations
+        ):
+            raise FatalRtlBuddyError(
+                f"hier: axi-perf annotations file not found: "
+                f"{self.axi_perf_annotations}"
             )
 
         if self.rdc_annotations is not None and not os.path.isfile(

--- a/tests/test_hier.py
+++ b/tests/test_hier.py
@@ -115,6 +115,63 @@ def test_wrapper_forwards_optional_flags(tmp_path: Path):
     assert "--clock-legend" in argv
 
 
+def test_wrapper_forwards_axi_perf_annotations_as_overlay(tmp_path: Path):
+    """The hub uses --axi-perf-from to bake throughput overlays into
+    every model's generated view.json. Locks the new --overlay
+    axi-perf=PATH passthrough (Phase 2.5 of the marimo umbrella)."""
+    src = tmp_path / "src" / "example.sv"
+    src.parent.mkdir()
+    src.write_text("module example; endmodule\n")
+    model = ModelConfig(
+        name="example",
+        filelist=[str(src)],
+        path=str(tmp_path / "models.yaml"),
+    )
+    axi_perf = tmp_path / "axi-perf.json"
+    axi_perf.write_text("{}")
+    script, record = _make_fake_view(tmp_path)
+
+    view = RtlBuddyView(
+        name="t",
+        model_cfg=model,
+        suite_dir=str(tmp_path),
+        axi_perf_annotations=str(axi_perf),
+        executable=str(script),
+    )
+    assert view.run() == 0
+    argv = json.loads(record.read_text())
+    assert "--overlay" in argv
+    assert f"axi-perf={axi_perf}" in argv
+
+
+def test_wrapper_rejects_missing_axi_perf_annotations(tmp_path: Path):
+    """File-existence check fires before the viewer is spawned so the
+    user gets a clean error, not a viewer-side overlay-load
+    backtrace."""
+    from rtl_buddy.errors import FatalRtlBuddyError
+
+    src = tmp_path / "src" / "example.sv"
+    src.parent.mkdir()
+    src.write_text("module example; endmodule\n")
+    model = ModelConfig(
+        name="example",
+        filelist=[str(src)],
+        path=str(tmp_path / "models.yaml"),
+    )
+    script, _ = _make_fake_view(tmp_path)
+
+    view = RtlBuddyView(
+        name="t",
+        model_cfg=model,
+        suite_dir=str(tmp_path),
+        axi_perf_annotations=str(tmp_path / "missing.json"),
+        executable=str(script),
+    )
+    with pytest.raises(FatalRtlBuddyError) as exc:
+        view.run()
+    assert "axi-perf" in str(exc.value)
+
+
 def test_wrapper_propagates_viewer_exit_code(tmp_path: Path):
     src = tmp_path / "src" / "example.sv"
     src.parent.mkdir()

--- a/tests/test_hub_viewer_http.py
+++ b/tests/test_hub_viewer_http.py
@@ -669,7 +669,7 @@ async def test_view_json_query_param_flips_active_model_and_broadcasts(
 
     captured_view = tmp_path / ".rtl-buddy" / "cache" / "view-demo.json"
 
-    def fake_build_view_json(*, project_root, model_cfg):
+    def fake_build_view_json(*, project_root, model_cfg, axi_perf_source=None):
         captured_view.parent.mkdir(parents=True, exist_ok=True)
         captured_view.write_text('{"schema_version":"1.0","top":"demo"}')
         return captured_view
@@ -726,7 +726,7 @@ async def test_view_json_no_query_serves_active_model(
 
     cache_path = tmp_path / ".rtl-buddy" / "cache" / "view-demo.json"
 
-    def fake_build_view_json(*, project_root, model_cfg):
+    def fake_build_view_json(*, project_root, model_cfg, axi_perf_source=None):
         cache_path.parent.mkdir(parents=True, exist_ok=True)
         cache_path.write_text('{"top":"demo"}')
         return cache_path
@@ -757,7 +757,7 @@ async def test_concurrent_same_model_requests_serialise(
     call_count = {"n": 0}
     cache_path = tmp_path / ".rtl-buddy" / "cache" / "view-demo.json"
 
-    def fake_build(*, project_root, model_cfg):
+    def fake_build(*, project_root, model_cfg, axi_perf_source=None):
         call_count["n"] += 1
         # Block long enough that the second request piles up behind
         # the lock, then release.


### PR DESCRIPTION
## Summary

Closes the last gap in Phase 2.5 of the marimo umbrella ([axi-profiler #16](https://github.com/rtl-buddy/rtl-buddy-axi-profiler/issues/16)): users on \`rb hub start --serve-viewer\` now get the "Open in marimo" auto-detect end-to-end, without having to manually invoke \`rtl-buddy-view --overlay axi-perf=…\` to seed the view.json.

## Usage

\`\`\`bash
rb hub start --serve-viewer --model demo \\
    --axi-perf-from verif/demo_axi_2x2/artefacts/axi/basic_traffic/axi-perf.json
\`\`\`

## Plumbing

The path threads through the existing model-aware view.json generation pipeline:

\`\`\`
rb hub start (cli.py)
 └─ hub_loop.serve(axi_perf_source=…)
     └─ ViewerServer(axi_perf_source=…)
         └─ /view.json?model= handler
             └─ view_builder.build_view_json(axi_perf_source=…)
                 └─ RtlBuddyView(axi_perf_annotations=…)
                     └─ rtl-buddy-view --overlay axi-perf=PATH
\`\`\`

\`rtl-buddy-view\` (since [view #93](https://github.com/rtl-buddy/rtl-buddy-view/pull/93)) emits the axi-perf throughput overlay PLUS a top-level \`axi_perf.{source,test,suite_dir}\` block. The SPA's "Open in marimo" button ([view #91](https://github.com/rtl-buddy/rtl-buddy-view/pull/91)) reads that block to skip the test/suite_dir prompt.

## Wrapper change

\`RtlBuddyView\` gains \`axi_perf_annotations\` kwarg → emits \`--overlay axi-perf=PATH\` in the spawned argv. File-existence check at \`run()\` time raises \`FatalRtlBuddyError\` with a clear "axi-perf annotations file not found" message.

## CLI ergonomics

- File-existence check fires **before** the hub binds its sockets, so a typoed path surfaces as a clean stderr error + exit code 2, not a later 500 on the first SPA refresh.
- Help text documents the canonical \`<suite>/artefacts/axi/<test>/axi-perf.json\` layout — using it lets rtl-buddy-view's derivation land the test/suite_dir fields cleanly.

## Test plan

- [x] **2 new** in \`tests/test_hier.py\`:
  - \`test_wrapper_forwards_axi_perf_annotations_as_overlay\` — locks the \`--overlay axi-perf=PATH\` argv shape
  - \`test_wrapper_rejects_missing_axi_perf_annotations\` — file-existence check fires + clean error
- [x] 3 existing \`test_hub_viewer_http\` tests' \`fake_build_view_json\` stubs gain the new kwarg
- [x] 815 / 815 + 10 skipped pytest; ruff (check + format) clean
- [ ] CI green

## Stacking

Based on \`feat/hub-axi-notebook-session-reuse\` ([rtl_buddy #195](https://github.com/rtl-buddy/rtl_buddy/pull/195)) — both are hub-side Phase 2.5 work. **Rebase when #195 lands** so the stack flattens.

## End-to-end Phase 2 + 2.5 now

With this PR + #195 + [view #93](https://github.com/rtl-buddy/rtl-buddy-view/pull/93):

1. \`rb hub start --serve-viewer --model X --axi-perf-from PATH\`
2. SPA loads view.json that carries \`axi_perf.{source, test, suite_dir}\`
3. User clicks "Open in marimo ↗" — no prompt
4. Hub spawns \`rb axi-profile notebook test --headless --port auto\` (or reuses an existing session)
5. SPA opens the URL in a new tab
6. Hub shutdown SIGTERMs the spawned marimos

Phase 2 work is feature-complete after this lands.