### PR TITLE
feat(hub): wave_values_changed producer on cursor_moved

### DIFF
--- a/src/rtl_buddy/hub/schema/hub-protocol-v1.json
+++ b/src/rtl_buddy/hub/schema/hub-protocol-v1.json
@@ -108,6 +108,41 @@
       }
     },
     {
+      "if": { "properties": { "type": { "const": "wave_values_changed" } }, "required": ["type"] },
+      "then": {
+        "properties": {
+          "kind": { "const": "event" },
+          "payload": {
+            "type": "object",
+            "required": ["t_fs", "values"],
+            "additionalProperties": false,
+            "description": "Broadcast by the hub when surfer reports new values for the variables it's tracking — typically as a side-effect of cursor movement. Carries the timestamp at which the values were sampled plus one entry per (wave_scope, signal). Consumers merge into a last-known-value map; absent signals retain their previous value (no clear-on-omit semantics).",
+            "properties": {
+              "t_fs": {
+                "type": "string",
+                "pattern": "^-?[0-9]+$",
+                "description": "Sampling time in femtoseconds, decimal string (same encoding as cursor_time_changed)."
+              },
+              "values": {
+                "type": "array",
+                "description": "Per-signal value samples at t_fs. An empty array is legal (e.g. the cursor moved into a region the hub doesn't have variables tracked for) and clears nothing.",
+                "items": {
+                  "type": "object",
+                  "required": ["wave_scope", "signal", "value"],
+                  "additionalProperties": false,
+                  "properties": {
+                    "wave_scope": { "type": "string", "minLength": 1, "description": "Surfer-side scope path, dotted (e.g. `tb.dut.fifo`)." },
+                    "signal":     { "type": "string", "minLength": 1, "description": "Bare signal name within wave_scope (no scope prefix)." },
+                    "value":      { "type": "string", "description": "SV literal — e.g. `1'b1`, `32'hDEAD_BEEF`, `1'bx`. Producers should emit the same encoding the Phase 8 offline overlay uses so the renderer can format both identically." }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
       "if": { "properties": { "type": { "const": "source_focused" } }, "required": ["type"] },
       "then": {
         "properties": {

--- a/src/rtl_buddy/hub/server.py
+++ b/src/rtl_buddy/hub/server.py
@@ -71,6 +71,7 @@ STATE_EVENT_TYPES: frozenset[str] = frozenset(
         "scope_changed",
         "source_focused",
         "diagnostics_set",
+        "wave_values_changed",
     }
 )
 """Event ``type`` strings that broadcast to all clients except origin.

--- a/src/rtl_buddy/tools/wave_hub_bridge.py
+++ b/src/rtl_buddy/tools/wave_hub_bridge.py
@@ -68,7 +68,15 @@ WAVE_CAPABILITIES: tuple[str, ...] = (
     "signal_selected",
     "cursor_time_changed",
     "scope_changed",
+    "wave_values_changed",
 )
+
+# Maximum wall-time the bridge will wait on a query_variable_values
+# response before giving up on a cursor-driven sample. Short by design
+# — surfer's WCP is in-process and a query against a handful of
+# variables typically returns in <10 ms; anything longer than this and
+# the user has scrubbed past the sample point anyway.
+QUERY_TIMEOUT_SECONDS = 1.0
 
 
 class WaveHubBridgeError(Exception):
@@ -155,6 +163,17 @@ class WaveHubBridge:
         self._stop = threading.Event()
         self._send_lock = threading.Lock()
         self._reader_thread: threading.Thread | None = None
+        # Hierarchy strings the user has asked surfer to track via
+        # ``wave_add_variables``. ``query_variable_values`` only returns
+        # data for variables whose signal payload has been loaded — which
+        # the add_variables flow guarantees. The set is the
+        # working-cache for cursor-driven re-sampling.
+        self._tracked_variables: list[str] = []
+        # Single-in-flight gate for cursor-driven queries. Cursor
+        # scrubbing fires at ~60 Hz; one outstanding round-trip is enough
+        # to keep the viewer painted, and dropping the rest avoids
+        # piling up queries surfer can't process faster than they arrive.
+        self._query_in_flight = threading.Lock()
 
     # ------------------------------------------------------------------
     # connection
@@ -293,12 +312,37 @@ class WaveHubBridge:
                 type=envelope.type,
                 error=str(exc),
             )
+        # Cursor-driven wave-values producer. Runs AFTER the
+        # cursor_time_changed broadcast so peers always see the cursor
+        # advance before the new values land — without this ordering,
+        # a fast worker thread can race ahead and emit
+        # wave_values_changed first, which looks wrong in event logs
+        # even though the viewer's merge semantics are identical.
+        if event_name == "cursor_moved":
+            ts = msg.get("timestamp")
+            if (
+                isinstance(ts, int)
+                and self._tracked_variables
+                and self._query_in_flight.acquire(blocking=False)
+            ):
+                t = threading.Thread(
+                    target=self._produce_wave_values,
+                    args=(ts,),
+                    name="wave-hub-bridge-values",
+                    daemon=True,
+                )
+                t.start()
 
     def _wcp_to_hub_event(self, event_name: str, msg: dict) -> Envelope | None:
         if event_name == "cursor_moved":
             ts = msg.get("timestamp")
             if not isinstance(ts, int):
                 return None
+            # NB: the cursor-driven ``wave_values_changed`` producer is
+            # kicked off in :meth:`on_wcp_event` AFTER the
+            # ``cursor_time_changed`` envelope has been sent, so peers
+            # see cursor-move-then-values rather than the other way
+            # around. See the matching block there.
             return Envelope(
                 origin=Origin.WAVE,
                 kind=Kind.EVENT,
@@ -432,6 +476,23 @@ class WaveHubBridge:
         # the bridge has run for years without this round-trip.
         resp = self._listener.await_response("add_variables", timeout=2.0)
         reply_payload = self._build_add_reply(resp)
+        # Update the tracked-variables cache so cursor-driven
+        # ``wave_values_changed`` queries (below) target the set the
+        # user actually cares about. Track only the variables surfer
+        # resolved — querying for paths that came back in ``not_found``
+        # would just waste a round-trip.
+        not_found_set = set()
+        if isinstance(resp, dict):
+            nf = resp.get("not_found")
+            if isinstance(nf, list):
+                not_found_set = {s for s in nf if isinstance(s, str)}
+        resolved = [v for v in variables if v not in not_found_set]
+        if resolved:
+            existing = set(self._tracked_variables)
+            for v in resolved:
+                if v not in existing:
+                    self._tracked_variables.append(v)
+                    existing.add(v)
         self._reply_response(env, type_=env.type, payload=reply_payload)
 
     def _handle_set_cursor(self, env: Envelope) -> None:
@@ -523,6 +584,126 @@ class WaveHubBridge:
             {"type": "command", "command": "set_scope", "scope": scope}
         )
         self._reply_response(env, type_=env.type, payload={"ok": True})
+
+    def _produce_wave_values(self, native_timestamp: int) -> None:
+        """Sample every tracked variable at the cursor and broadcast.
+
+        Runs on a daemon thread; the in-flight gate is released before
+        return so the next cursor_moved can spawn its own worker.
+        """
+
+        try:
+            variables = list(self._tracked_variables)
+            if not variables:
+                return
+            self._send_to_surfer(
+                {
+                    "type": "command",
+                    "command": "query_variable_values",
+                    "variables": variables,
+                    # No timestamp → surfer samples at its current
+                    # cursor. The cursor_moved event we're responding
+                    # to means CursorSet has already landed, so this
+                    # matches the event's timestamp by construction
+                    # and avoids re-sending the value the bridge just
+                    # received in the event payload.
+                }
+            )
+            resp = self._listener.await_response(
+                "query_variable_values", timeout=QUERY_TIMEOUT_SECONDS
+            )
+            if resp is None:
+                # Either surfer didn't reply in time or the WCP socket
+                # dropped. Either way we just skip this sample; the
+                # next cursor_moved will retry.
+                log_event(
+                    logger,
+                    logging.DEBUG,
+                    "wave.hub.query_timeout",
+                    variables=len(variables),
+                )
+                return
+            envelope = self._wave_values_envelope(resp, native_timestamp)
+            if envelope is None:
+                return
+            try:
+                self._send_envelope(envelope)
+            except (OSError, HubProtocolError) as exc:
+                log_event(
+                    logger,
+                    logging.WARNING,
+                    "wave.hub.send_failed",
+                    type=envelope.type,
+                    error=str(exc),
+                )
+        except Exception:
+            logger.exception("wave.hub.produce_wave_values_failed")
+        finally:
+            self._query_in_flight.release()
+
+    def _wave_values_envelope(
+        self, resp: dict, fallback_native_ts: int
+    ) -> Envelope | None:
+        """Translate a surfer ``query_variable_values`` response into the
+        hub's ``wave_values_changed`` event envelope.
+
+        ``fallback_native_ts`` is the native-tick timestamp from the
+        cursor_moved event that triggered this query — used when the
+        response doesn't carry a parsable ``timestamp`` (defensive; the
+        new surfer command always sets one).
+        """
+
+        # surfer serializes the response timestamp as a decimal string
+        # (see surfer-wcp proto.rs). The cursor_moved event uses an
+        # integer in native ticks. The hub-side ``t_fs`` envelope wants
+        # a decimal string in *fs* — so we have to convert through
+        # surfer's tick → fs mapping, which the bridge doesn't track
+        # explicitly. Instead, reuse the cursor_moved event's timestamp
+        # (already in surfer-native ticks) since the new surfer command
+        # samples at-cursor and the two values agree by construction.
+        # If a future caller passes an explicit ``timestamp`` to the
+        # query, we re-derive from the response.
+        ts_raw = resp.get("timestamp")
+        native_ts: int
+        if isinstance(ts_raw, str):
+            try:
+                native_ts = int(ts_raw)
+            except ValueError:
+                native_ts = fallback_native_ts
+        elif isinstance(ts_raw, int):
+            native_ts = ts_raw
+        else:
+            native_ts = fallback_native_ts
+
+        rows = resp.get("values")
+        if not isinstance(rows, list):
+            return None
+        values: list[dict[str, str]] = []
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            variable = row.get("variable")
+            value = row.get("value")
+            if not isinstance(variable, str) or "." not in variable:
+                continue
+            if not isinstance(value, str):
+                # value is null when the variable has no transition
+                # before the sample point. Drop from the broadcast so
+                # the viewer's "absent signals retain prior values"
+                # semantics keep painting whatever was last known.
+                continue
+            scope, _, signal = variable.rpartition(".")
+            if not scope or not signal:
+                continue
+            values.append({"wave_scope": scope, "signal": signal, "value": value})
+
+        return Envelope(
+            origin=Origin.WAVE,
+            kind=Kind.EVENT,
+            type="wave_values_changed",
+            id=new_id(),
+            payload={"t_fs": str(native_ts), "values": values},
+        )
 
     @staticmethod
     def _build_add_reply(resp: dict | None) -> dict:

--- a/tests/test_hub_protocol.py
+++ b/tests/test_hub_protocol.py
@@ -289,6 +289,7 @@ def test_vendored_schema_has_expected_types():
         "wave_set_viewport",
         "wave_zoom_to_range",
         "wave_zoom_to_fit",
+        "wave_values_changed",
         "view_pan_to",
         "view_capture",
         "wave_set_viewport",

--- a/tests/test_wave_hub_bridge.py
+++ b/tests/test_wave_hub_bridge.py
@@ -652,6 +652,248 @@ def test_wave_set_scope_translates_to_wcp_set_scope(
 # ---------------------------------------------------------------------------
 
 
+def _send_wave_add(view_sock, variables: list[str]) -> Envelope:
+    req = Envelope(
+        origin=Origin.VIEW,
+        kind=Kind.REQUEST,
+        type="wave_add_variables",
+        id=new_id(),
+        payload={"variables": variables},
+    )
+    view_sock.sendall(encode(req).encode("utf-8") + b"\n")
+    return req
+
+
+def test_cursor_moved_broadcasts_wave_values_changed_for_tracked_vars(
+    hub_in_thread: _HubInThread,
+):
+    """End-to-end producer: viewer adds variables → cursor moves → bridge
+    queries surfer → ``wave_values_changed`` lands on the bus."""
+    host, port = hub_in_thread.server.host, hub_in_thread.server.port  # type: ignore[union-attr]
+    listener = _FakeListener()
+    # Stage surfer's add_variables response so the bridge can record the
+    # variables as ``tracked``. ids/not_found shape matches surfer's PR #3.
+    listener.next_responses["add_variables"] = [
+        {
+            "type": "response",
+            "command": "add_variables",
+            "ids": [10, 11],
+            "not_found": [],
+        }
+    ]
+    # Stage surfer's query_variable_values response so the cursor-driven
+    # query has something to translate. timestamp echoes back as a
+    # decimal string per surfer PR #7's wire shape.
+    listener.next_responses["query_variable_values"] = [
+        {
+            "type": "response",
+            "command": "query_variable_values",
+            "timestamp": "12500000",
+            "values": [
+                {"variable": "tb.dut.q", "value": "1"},
+                {"variable": "tb.dut.clk", "value": "0"},
+            ],
+            "not_found": [],
+        }
+    ]
+    bridge = WaveHubBridge.connect((host, port), listener=listener)
+    bridge.start()
+    view_sock = _connect_observer(hub_in_thread, Origin.VIEW)
+    try:
+        # Step 1: viewer adds variables. Wait for the reply so we know
+        # the bridge has finished updating its tracked-vars cache before
+        # we fire the cursor_moved.
+        req = _send_wave_add(view_sock, ["tb.dut.q", "tb.dut.clk"])
+        ack = _recv_line(view_sock)
+        assert ack.id == req.id
+
+        # Step 2: drive a cursor_moved through the WCP observer hook.
+        bridge.on_wcp_event(
+            "cursor_moved",
+            {"type": "event", "event": "cursor_moved", "timestamp": 12500000},
+        )
+
+        # First envelope on the bus: cursor_time_changed (synchronous
+        # translation on the listener thread).
+        env_cursor = _recv_line(view_sock)
+        assert env_cursor.type == "cursor_time_changed"
+        assert env_cursor.payload == {"t_fs": "12500000"}
+
+        # Second envelope: wave_values_changed, produced by the daemon
+        # thread that issued the query. The fake listener pops the
+        # staged response immediately, so this should arrive promptly.
+        env_values = _recv_line(view_sock)
+        assert env_values.type == "wave_values_changed"
+        assert env_values.origin is Origin.WAVE
+        assert env_values.payload["t_fs"] == "12500000"
+        values = env_values.payload["values"]
+        # Order matches surfer's response order (which mirrors the
+        # request, which is the order add_variables saw).
+        assert values == [
+            {"wave_scope": "tb.dut", "signal": "q", "value": "1"},
+            {"wave_scope": "tb.dut", "signal": "clk", "value": "0"},
+        ]
+
+        # And the bridge actually sent the query to surfer.
+        query_sent = next(
+            (
+                cmd
+                for cmd in listener.sent
+                if cmd.get("command") == "query_variable_values"
+            ),
+            None,
+        )
+        assert query_sent is not None
+        assert query_sent == {
+            "type": "command",
+            "command": "query_variable_values",
+            "variables": ["tb.dut.q", "tb.dut.clk"],
+        }
+    finally:
+        view_sock.close()
+        bridge.stop()
+
+
+def test_cursor_moved_without_tracked_variables_skips_query(
+    hub_in_thread: _HubInThread,
+):
+    """Until any wave_add_variables has happened, cursor moves don't
+    pay a WCP round-trip — there's nothing to sample."""
+    host, port = hub_in_thread.server.host, hub_in_thread.server.port  # type: ignore[union-attr]
+    listener = _FakeListener()
+    bridge = WaveHubBridge.connect((host, port), listener=listener)
+    view_sock = _connect_observer(hub_in_thread, Origin.VIEW)
+    try:
+        bridge.on_wcp_event(
+            "cursor_moved",
+            {"type": "event", "event": "cursor_moved", "timestamp": 9000},
+        )
+        # cursor_time_changed still lands (the user wants the cursor
+        # marker to track regardless of value plumbing).
+        env_cursor = _recv_line(view_sock)
+        assert env_cursor.type == "cursor_time_changed"
+        # But no query went to surfer — the listener's sent log is empty.
+        # Give any spurious worker thread time to act so we're not
+        # racing with it.
+        time.sleep(0.05)
+        assert listener.sent == []
+        # And the bus only ever saw the cursor_time_changed envelope
+        # (no wave_values_changed broadcast).
+        view_sock.settimeout(0.2)
+        with pytest.raises((TimeoutError, OSError, BlockingIOError)):
+            _recv_line(view_sock)
+    finally:
+        view_sock.close()
+        bridge.stop()
+
+
+def test_wave_values_changed_drops_null_values(hub_in_thread: _HubInThread):
+    """Per the surfer protocol, ``value: null`` means the variable
+    resolved but has no transition before the sample point. The bridge
+    must filter those out so the viewer's last-known-value cache
+    survives — otherwise a freshly-loaded design would clobber static
+    Phase-8 snapshots with empty strings."""
+    host, port = hub_in_thread.server.host, hub_in_thread.server.port  # type: ignore[union-attr]
+    listener = _FakeListener()
+    listener.next_responses["add_variables"] = [
+        {"type": "response", "command": "add_variables", "ids": [1, 2], "not_found": []}
+    ]
+    listener.next_responses["query_variable_values"] = [
+        {
+            "type": "response",
+            "command": "query_variable_values",
+            "timestamp": "100",
+            "values": [
+                {"variable": "tb.dut.q", "value": "1"},
+                {"variable": "tb.dut.preset", "value": None},
+            ],
+            "not_found": [],
+        }
+    ]
+    bridge = WaveHubBridge.connect((host, port), listener=listener)
+    bridge.start()
+    view_sock = _connect_observer(hub_in_thread, Origin.VIEW)
+    try:
+        req = _send_wave_add(view_sock, ["tb.dut.q", "tb.dut.preset"])
+        _ = _recv_line(view_sock)  # ack — id matches req
+        assert req.id  # silence linter on unused-binding
+
+        bridge.on_wcp_event(
+            "cursor_moved",
+            {"type": "event", "event": "cursor_moved", "timestamp": 100},
+        )
+        _ = _recv_line(view_sock)  # cursor_time_changed
+        env = _recv_line(view_sock)
+        assert env.type == "wave_values_changed"
+        # Only the populated row appears; preset (value=null) is gone.
+        assert env.payload["values"] == [
+            {"wave_scope": "tb.dut", "signal": "q", "value": "1"},
+        ]
+    finally:
+        view_sock.close()
+        bridge.stop()
+
+
+def test_add_variables_not_found_paths_are_not_tracked(
+    hub_in_thread: _HubInThread,
+):
+    """Variables that surfer reports in ``not_found`` shouldn't be added
+    to the tracked-variables cache — querying them on every cursor_moved
+    would just waste a round-trip producing no values."""
+    host, port = hub_in_thread.server.host, hub_in_thread.server.port  # type: ignore[union-attr]
+    listener = _FakeListener()
+    listener.next_responses["add_variables"] = [
+        {
+            "type": "response",
+            "command": "add_variables",
+            "ids": [3],
+            "not_found": ["tb.dut.bogus"],
+        }
+    ]
+    # If the bridge mistakenly tracked the bogus path, the cursor-driven
+    # query would include it. Stage a response that asserts on the
+    # variables list it's actually queried for.
+    listener.next_responses["query_variable_values"] = [
+        {
+            "type": "response",
+            "command": "query_variable_values",
+            "timestamp": "1",
+            "values": [{"variable": "tb.dut.real_signal", "value": "0"}],
+            "not_found": [],
+        }
+    ]
+    bridge = WaveHubBridge.connect((host, port), listener=listener)
+    bridge.start()
+    view_sock = _connect_observer(hub_in_thread, Origin.VIEW)
+    try:
+        req = _send_wave_add(view_sock, ["tb.dut.real_signal", "tb.dut.bogus"])
+        _ = _recv_line(view_sock)  # ack
+        assert req.id
+
+        bridge.on_wcp_event(
+            "cursor_moved",
+            {"type": "event", "event": "cursor_moved", "timestamp": 1},
+        )
+        _ = _recv_line(view_sock)  # cursor_time_changed
+        _ = _recv_line(view_sock)  # wave_values_changed
+
+        query_sent = next(
+            (
+                cmd
+                for cmd in listener.sent
+                if cmd.get("command") == "query_variable_values"
+            ),
+            None,
+        )
+        assert query_sent is not None
+        # The bogus path is gone — only the resolved variable made it
+        # into the cursor-driven query.
+        assert query_sent["variables"] == ["tb.dut.real_signal"]
+    finally:
+        view_sock.close()
+        bridge.stop()
+
+
 def test_stop_unregisters_from_hub(hub_in_thread: _HubInThread):
     host, port = hub_in_thread.server.host, hub_in_thread.server.port  # type: ignore[union-attr]
     listener = _FakeListener()

--- a/tests/test_wave_hub_bridge.py
+++ b/tests/test_wave_hub_bridge.py
@@ -279,6 +279,31 @@ def _recv_line(sock) -> Envelope:
     return decode(line)
 
 
+class _Recv:
+    """Buffered envelope receiver that preserves bytes past the first ``\\n``.
+
+    The plain ``_recv_line`` helper discards post-newline data — that's
+    safe when each test expects exactly one envelope per cursor_moved /
+    request, but the wave-values producer emits two envelopes
+    back-to-back per ``cursor_moved`` and TCP coalesces them into a
+    single recv on slower hosts (notably CI). This class keeps the
+    leftover bytes between reads so the second envelope isn't dropped.
+    """
+
+    def __init__(self, sock):
+        self._sock = sock
+        self._buf = b""
+
+    def next(self) -> Envelope:
+        while b"\n" not in self._buf:
+            chunk = self._sock.recv(4096)
+            if not chunk:
+                raise OSError("closed")
+            self._buf += chunk
+        line, _, self._buf = self._buf.partition(b"\n")
+        return decode(line)
+
+
 def test_cursor_moved_becomes_cursor_time_changed(hub_in_thread: _HubInThread):
     host, port = hub_in_thread.server.host, hub_in_thread.server.port  # type: ignore[union-attr]
     listener = _FakeListener()
@@ -699,12 +724,13 @@ def test_cursor_moved_broadcasts_wave_values_changed_for_tracked_vars(
     bridge = WaveHubBridge.connect((host, port), listener=listener)
     bridge.start()
     view_sock = _connect_observer(hub_in_thread, Origin.VIEW)
+    rx = _Recv(view_sock)
     try:
         # Step 1: viewer adds variables. Wait for the reply so we know
         # the bridge has finished updating its tracked-vars cache before
         # we fire the cursor_moved.
         req = _send_wave_add(view_sock, ["tb.dut.q", "tb.dut.clk"])
-        ack = _recv_line(view_sock)
+        ack = rx.next()
         assert ack.id == req.id
 
         # Step 2: drive a cursor_moved through the WCP observer hook.
@@ -715,14 +741,14 @@ def test_cursor_moved_broadcasts_wave_values_changed_for_tracked_vars(
 
         # First envelope on the bus: cursor_time_changed (synchronous
         # translation on the listener thread).
-        env_cursor = _recv_line(view_sock)
+        env_cursor = rx.next()
         assert env_cursor.type == "cursor_time_changed"
         assert env_cursor.payload == {"t_fs": "12500000"}
 
         # Second envelope: wave_values_changed, produced by the daemon
         # thread that issued the query. The fake listener pops the
         # staged response immediately, so this should arrive promptly.
-        env_values = _recv_line(view_sock)
+        env_values = rx.next()
         assert env_values.type == "wave_values_changed"
         assert env_values.origin is Origin.WAVE
         assert env_values.payload["t_fs"] == "12500000"
@@ -813,17 +839,18 @@ def test_wave_values_changed_drops_null_values(hub_in_thread: _HubInThread):
     bridge = WaveHubBridge.connect((host, port), listener=listener)
     bridge.start()
     view_sock = _connect_observer(hub_in_thread, Origin.VIEW)
+    rx = _Recv(view_sock)
     try:
         req = _send_wave_add(view_sock, ["tb.dut.q", "tb.dut.preset"])
-        _ = _recv_line(view_sock)  # ack — id matches req
+        _ = rx.next()  # ack — id matches req
         assert req.id  # silence linter on unused-binding
 
         bridge.on_wcp_event(
             "cursor_moved",
             {"type": "event", "event": "cursor_moved", "timestamp": 100},
         )
-        _ = _recv_line(view_sock)  # cursor_time_changed
-        env = _recv_line(view_sock)
+        _ = rx.next()  # cursor_time_changed
+        env = rx.next()
         assert env.type == "wave_values_changed"
         # Only the populated row appears; preset (value=null) is gone.
         assert env.payload["values"] == [
@@ -865,17 +892,18 @@ def test_add_variables_not_found_paths_are_not_tracked(
     bridge = WaveHubBridge.connect((host, port), listener=listener)
     bridge.start()
     view_sock = _connect_observer(hub_in_thread, Origin.VIEW)
+    rx = _Recv(view_sock)
     try:
         req = _send_wave_add(view_sock, ["tb.dut.real_signal", "tb.dut.bogus"])
-        _ = _recv_line(view_sock)  # ack
+        _ = rx.next()  # ack
         assert req.id
 
         bridge.on_wcp_event(
             "cursor_moved",
             {"type": "event", "event": "cursor_moved", "timestamp": 1},
         )
-        _ = _recv_line(view_sock)  # cursor_time_changed
-        _ = _recv_line(view_sock)  # wave_values_changed
+        _ = rx.next()  # cursor_time_changed
+        _ = rx.next()  # wave_values_changed
 
         query_sent = next(
             (


### PR DESCRIPTION
## Summary

Completes the producer half of [rtl-buddy-view#24](https://github.com/rtl-buddy/rtl-buddy-view/issues/24). With [surfer PR #7](https://github.com/rtl-buddy/surfer/pull/7) (`query_variable_values` WCP command) landed, the wave bridge can now sample the user's tracked variables on every surfer cursor move and broadcast the values to the bus.

## Producer flow

On each surfer `cursor_moved` event:

1. `cursor_time_changed` envelope goes out first so peers see the marker advance immediately.
2. If the user has tracked variables (added via `wave_add_variables`), a daemon worker thread sends `query_variable_values` to surfer and awaits the response. A single-in-flight lock drops overlapping queries during 60 Hz scrubs — one round-trip is enough; the next `cursor_moved` is ~16 ms away.
3. Worker translates the response into a `wave_values_changed` envelope (origin=`wave`) and broadcasts. Rows with `value: null` are filtered out so the viewer's last-known-value cache survives partial sample windows.

## Changes

- `hub/server.py`: add `wave_values_changed` to `STATE_EVENT_TYPES` so the hub routes it. `_update_state` intentionally ignores it — per-sample value snapshots belong in the viewer, not the hub state.
- `tools/wave_hub_bridge.py`: tracked-variables cache populated on `wave_add_variables`; paths in `not_found` are excluded so they don't pollute future queries. Producer + envelope translation.
- `hub/schema/hub-protocol-v1.json`: vendored copy synced with [rtl-buddy-view PR #94](https://github.com/rtl-buddy/rtl-buddy-view/pull/94)'s `wave_values_changed` event definition.

## Dependency

This PR depends on [surfer PR #7](https://github.com/rtl-buddy/surfer/pull/7) landing. Without it, the new `query_variable_values` command returns an error and the producer silently no-ops (logged at DEBUG). The viewer keeps painting cursor moves; only the wave-values badges stay stale.

## Test plan

- [x] Four new `test_wave_hub_bridge.py` cases: happy-path producer, no-tracked-variables skip, value=null filter, not_found exclusion from tracked set.
- [x] `uv run pytest -q` — 823 passed (+5 new from this PR + viewer-schema sync update; no regressions).
- [x] `uv run ruff check` / `ruff format --check` clean.
- [ ] End-to-end with a real surfer + rtl-buddy-view: blocked on surfer PR #7 landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)