### PR TITLE
feat(tool-check): rb tool-check subcommand + declarative tool manifest

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -61,6 +61,7 @@ Usage: rtl-buddy [OPTIONS] COMMAND [ARGS]...
 │ cdc-regression     run CDC lint regression                                           │
 │ fpv                run formal property verification                                  │
 │ fpv-regression     run FPV regression                                                │
+│ tool-check         check installed tool dependencies and subcommand readiness        │
 │ axi-profile        profile AXI interconnect performance via rtl-buddy-axi-profiler   │
 │ hub                manage the rtl-buddy-hub daemon                                   │
 │ skill              manage the rtl_buddy agent skill                                  │
@@ -454,5 +455,31 @@ Usage: rtl-buddy fpv-regression [OPTIONS]
 │                                [default: (Use ./fpv_regression.yaml if present)]     │
 │ --reg-level   -l      INTEGER  FPV regression level to stop at [default: 0]          │
 │ --help                         Show this message and exit.                           │
+╰──────────────────────────────────────────────────────────────────────────────────────╯
+```
+
+## tool-check
+
+```text
+Usage: rtl-buddy tool-check [OPTIONS]                                                  
+                                                                                        
+ check installed tool dependencies and subcommand readiness                             
+                                                                                        
+╭─ Options ────────────────────────────────────────────────────────────────────────────╮
+│ --format                                       TEXT  text | json [default: text]     │
+│ --required-for                                 TEXT  check only what `rb             │
+│                                                      <subcommand>` needs             │
+│ --explain                                      TEXT  show install instructions for a │
+│                                                      single tool and exit            │
+│ --strict                                             exit non-zero if any required   │
+│                                                      tool is missing/outdated        │
+│ --include-optional    --no-include-optional          include optional tools          │
+│                                                      (default: yes)                  │
+│                                                      [default: include-optional]     │
+│ --probe-versions      --no-probe-versions            run `<tool> --version` to       │
+│                                                      capture installed version       │
+│                                                      (default: yes)                  │
+│                                                      [default: probe-versions]       │
+│ --help                                               Show this message and exit.     │
 ╰──────────────────────────────────────────────────────────────────────────────────────╯
 ```

--- a/scripts/gen_cli_reference.py
+++ b/scripts/gen_cli_reference.py
@@ -31,6 +31,7 @@ SUBCOMMANDS = [
     "cdc-regression",
     "fpv",
     "fpv-regression",
+    "tool-check",
 ]
 
 HEADER = """\

--- a/src/rtl_buddy/config/root.py
+++ b/src/rtl_buddy/config/root.py
@@ -33,6 +33,7 @@ from .power import PowerToolConfig, PowerToolConfigFile
 from .cdc import CdcToolConfig, CdcToolConfigFile
 from .fpv import FpvToolConfig, FpvToolConfigFile
 from .systemc import SystemCConfig, SystemCConfigFile
+from .tools import ToolVersionConfig, ToolVersionConfigFile
 from ..errors import FatalRtlBuddyError
 from ..logging_utils import log_event
 
@@ -136,6 +137,7 @@ class RootConfigFile:
         rename="cfg-synth-efforts", default_factory=list
     )
     systemc: SystemCConfigFile | None = field(rename="cfg-systemc", default=None)
+    tools: list[ToolVersionConfigFile] = field(rename="cfg-tools", default_factory=list)
 
 
 class RootConfig:
@@ -188,6 +190,7 @@ class RootConfig:
         self.fpv_tool_cfgs: dict = {}
         self.synth_effort_cfgs: dict = {}
         self.systemc_cfg: SystemCConfig | None = None
+        self.tool_version_cfgs: dict[str, ToolVersionConfig] = {}
         self.platform_cfg = None
         self.reg_cfg = None  # initialise later when get_rtl_reg_cfg is called
 
@@ -286,6 +289,11 @@ class RootConfig:
             # SystemC config (optional, single block)
             if data.systemc is not None:
                 self.systemc_cfg = data.systemc.initialise()
+
+            # cfg-tools min-version overrides (optional)
+            self.tool_version_cfgs = {
+                cfg.name: ToolVersionConfig.from_file(cfg) for cfg in data.tools
+            }
 
             # Initialise regression config
             self.cfg_rtl_reg = data.cfg_rtl_reg
@@ -608,6 +616,10 @@ class RootConfig:
                 f"synthesis effort '{name}' not found in cfg-synth-efforts"
             )
         return cfg
+
+    def get_tool_version_cfg(self, name: str) -> ToolVersionConfig | None:
+        """Get optional ``cfg-tools`` min-version pin for the given tool name."""
+        return self.tool_version_cfgs.get(name)
 
     def get_systemc_cfg(self) -> SystemCConfig | None:
         """

--- a/src/rtl_buddy/config/tools.py
+++ b/src/rtl_buddy/config/tools.py
@@ -1,0 +1,31 @@
+"""Optional ``cfg-tools`` block in ``root_config.yaml``.
+
+Each entry pairs a tool manifest name (e.g. ``verible``, ``yosys``, ``surfer``)
+with a project-pinned minimum version. ``rb tool-check`` overlays these on top
+of the in-source defaults in :mod:`rtl_buddy.tool_manifest`, so a project can
+demand a newer baseline than what rtl_buddy ships with — without forking the
+manifest.
+
+The block is intentionally optional and additive. Projects that don't pin
+versions get the manifest defaults.
+"""
+
+from dataclasses import dataclass
+
+from serde import field, serde
+
+
+@serde
+class ToolVersionConfigFile:
+    name: str
+    min_version: str | None = field(rename="min-version", default=None)
+
+
+@dataclass
+class ToolVersionConfig:
+    name: str
+    min_version: str | None = None
+
+    @classmethod
+    def from_file(cls, cfg: ToolVersionConfigFile) -> "ToolVersionConfig":
+        return cls(name=cfg.name, min_version=cfg.min_version)

--- a/src/rtl_buddy/rtl_buddy.py
+++ b/src/rtl_buddy/rtl_buddy.py
@@ -220,6 +220,10 @@ class RtlBuddy:
         self.app.add_typer(
             self.spec_app, name="spec", help="spec traceability commands"
         )
+        self.app.command(
+            "tool-check",
+            help="check installed tool dependencies and subcommand readiness",
+        )(self.do_cmd_tool_check)
 
         if "." not in os.environ["PATH"].split(os.pathsep):
             os.environ["PATH"] = "." + os.pathsep + os.environ["PATH"]
@@ -317,7 +321,7 @@ class RtlBuddy:
 
         self.machine = machine
 
-        if ctx.invoked_subcommand in {"skill", "docs", "spec", "hub"}:
+        if ctx.invoked_subcommand in {"skill", "docs", "spec", "hub", "tool-check"}:
             return
 
         setup_logging(debug=debug, verbose=verbose, color=color, machine=machine)
@@ -3046,6 +3050,139 @@ class RtlBuddy:
         )
         exit_code = ver.do_cmd(cmd=cmd, verible_args=verible_args)
         raise typer.Exit(exit_code)
+
+    def do_cmd_tool_check(
+        self,
+        fmt: Annotated[
+            str,
+            typer.Option(
+                "--format",
+                help="text | json",
+                case_sensitive=False,
+            ),
+        ] = "text",
+        required_for: Annotated[
+            str | None,
+            typer.Option(
+                "--required-for",
+                help="check only what `rb <subcommand>` needs",
+            ),
+        ] = None,
+        explain_tool: Annotated[
+            str | None,
+            typer.Option(
+                "--explain",
+                help="show install instructions for a single tool and exit",
+            ),
+        ] = None,
+        strict: Annotated[
+            bool,
+            typer.Option(
+                "--strict",
+                help="exit non-zero if any required tool is missing/outdated",
+            ),
+        ] = False,
+        include_optional: Annotated[
+            bool,
+            typer.Option(
+                "--include-optional/--no-include-optional",
+                help="include optional tools (default: yes)",
+            ),
+        ] = True,
+        probe_versions: Annotated[
+            bool,
+            typer.Option(
+                "--probe-versions/--no-probe-versions",
+                help="run `<tool> --version` to capture installed version "
+                "(default: yes)",
+            ),
+        ] = True,
+    ):
+        """
+        Detect installed tool dependencies and report subcommand readiness.
+        """
+        from . import tool_manifest as tm
+        from .config.root import _discover_root_cfg
+
+        setup_logging(debug=False, verbose=False, color=True, machine=self.machine)
+
+        # Opportunistic root_config discovery. tool-check must work outside a
+        # project, so we suppress the "not found" error log entirely.
+        root_cfg = None
+        root_logger = logging.getLogger("rtl_buddy.config.root")
+        prev_level = root_logger.level
+        root_logger.setLevel(logging.CRITICAL)
+        try:
+            if _discover_root_cfg() is not None:
+                root_cfg = RootConfig(name=self.name + "/tool-check/root_config")
+        except FatalRtlBuddyError:
+            root_cfg = None
+        finally:
+            root_logger.setLevel(prev_level)
+
+        specs = tm.get_manifest(root_cfg)
+        project_root = (
+            Path(root_cfg.get_project_rootdir()) if root_cfg is not None else None
+        )
+
+        if explain_tool is not None:
+            spec = next((s for s in specs if s.name == explain_tool), None)
+            if spec is None:
+                emit_console_text(
+                    f"tool-check: unknown tool '{explain_tool}'. "
+                    f"Known: {', '.join(s.name for s in specs)}",
+                    style="red",
+                    stream="stderr",
+                )
+                raise typer.Exit(1)
+            status = tm.check_tool(
+                spec, project_root=project_root, probe_versions=probe_versions
+            )
+            # Plain stdout — Rich's word-wrap would mangle paths.
+            print(tm.explain(spec, status))
+            raise typer.Exit(0)
+
+        statuses = tm.check_all(
+            specs,
+            project_root=project_root,
+            probe_versions=probe_versions,
+            include_optional=include_optional,
+        )
+        subcommands = tm.subcommand_readiness(statuses, specs)
+
+        if required_for is not None:
+            if required_for not in subcommands:
+                emit_console_text(
+                    f"tool-check: subcommand '{required_for}' has no "
+                    f"declared tool dependencies",
+                    style="yellow",
+                )
+                raise typer.Exit(0)
+            subcommands = {required_for: subcommands[required_for]}
+            wanted = set(subcommands[required_for]["tools"])
+            statuses = [s for s in statuses if s.name in wanted]
+
+        reported_exit_code = tm.compute_exit_code(
+            statuses,
+            required_for=required_for,
+            subcommands=tm.subcommand_readiness(statuses, specs),
+        )
+
+        # Use raw stdout — Rich's word-wrap would mangle JSON and break the
+        # alignment of the tool table.
+        if fmt.lower() == "json":
+            print(tm.render_json(statuses, subcommands, exit_code=reported_exit_code))
+        else:
+            print(
+                tm.render_text(statuses, subcommands, include_optional=include_optional)
+            )
+
+        # --required-for always enforces (exit 2 on miss); --strict enforces
+        # the global "any required tool missing" check (exit 1). Without
+        # either flag the command is purely informational.
+        if required_for is not None or strict:
+            raise typer.Exit(reported_exit_code)
+        raise typer.Exit(0)
 
     def show_git_rev(self):
         status_result = subprocess.run(

--- a/src/rtl_buddy/tool_manifest.py
+++ b/src/rtl_buddy/tool_manifest.py
@@ -1,0 +1,1163 @@
+"""Declarative tool manifest for ``rb tool-check``.
+
+This module is the single source of truth for "which external tools does
+``rtl_buddy`` rely on, where do we look for them, and what versions do we
+expect."  The :data:`MANIFEST` list is consumed by:
+
+* ``rb tool-check`` — to report install status.
+* per-tool subcommand wrappers — via :func:`require` to surface a uniform
+  "tool missing" error message.
+* future docs / setup-script generation.
+
+The manifest is reconciled against a project's ``root_config.yaml`` when
+one is available: ``cfg-verible``, ``cfg-surfer``, ``cfg-synth-tools``,
+``cfg-pnr-tools``, ``cfg-power-tools``, ``cfg-cdc-tools``, and
+``cfg-fpv-tools`` may pin the executable used at runtime, and the
+optional ``cfg-tools`` block lets a project pin a stricter
+``min-version`` than what rtl_buddy ships with.
+
+Versions are not part of the manifest API — they are an output of
+:func:`check_tool` after probing.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import shutil
+import subprocess
+from dataclasses import dataclass, field
+from importlib import metadata as importlib_metadata
+from pathlib import Path
+from typing import Iterable
+
+from .errors import FatalRtlBuddyError
+from .logging_utils import log_event
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Detectors
+
+
+@dataclass
+class DetectionResult:
+    """Outcome of a single detector.
+
+    Attributes:
+      found: True if the detector located something usable.
+      path: Filesystem path (binary or vendor dir entry). ``None`` for
+        python packages.
+      kind: One of ``"path"``, ``"vendor"``, ``"python"``. Used for the
+        display string (``(python)`` vs. a path) and for downstream
+        diagnostics.
+      version: Pre-resolved version string (only python-package
+        detectors fill this; binary detectors leave version probing to
+        :func:`probe_version`).
+    """
+
+    found: bool
+    path: str | None = None
+    kind: str = "path"
+    version: str | None = None
+
+
+class Detector:
+    """Strategy for locating one of a tool's binaries / packages."""
+
+    def detect(
+        self, spec: "ToolSpec", project_root: Path | None
+    ) -> DetectionResult:  # pragma: no cover - abstract
+        raise NotImplementedError
+
+
+@dataclass
+class PathDetector(Detector):
+    """Look up a tool's binaries on ``$PATH`` via :func:`shutil.which`."""
+
+    def detect(self, spec: "ToolSpec", project_root: Path | None) -> DetectionResult:
+        for binary in spec.binaries:
+            resolved = shutil.which(binary)
+            if resolved:
+                return DetectionResult(found=True, path=resolved, kind="path")
+        return DetectionResult(found=False, kind="path")
+
+
+@dataclass
+class VendorDetector(Detector):
+    """Look up a tool inside a project-relative or absolute vendor directory.
+
+    The directory pattern mirrors what setup scripts write
+    (e.g. ``vendor/surfer/bin/surfer``, ``tools/verible/macos/active/bin``).
+    Either an absolute path (already resolved by ``RootConfig``) or one
+    relative to ``project_root`` is accepted.
+    """
+
+    rel_path: str
+
+    def detect(self, spec: "ToolSpec", project_root: Path | None) -> DetectionResult:
+        base = Path(self.rel_path)
+        if not base.is_absolute():
+            if project_root is None:
+                return DetectionResult(found=False, kind="vendor")
+            base = (project_root / self.rel_path).resolve()
+        for binary in spec.binaries:
+            candidate = base / binary if base.is_dir() else base
+            if candidate.is_file() and os.access(candidate, os.X_OK):
+                return DetectionResult(found=True, path=str(candidate), kind="vendor")
+        return DetectionResult(found=False, kind="vendor")
+
+
+@dataclass
+class AbsolutePathDetector(Detector):
+    """Detect a tool installed at a fully-qualified absolute path.
+
+    Used when ``RootConfig`` already resolved a path for us (e.g. the
+    ``cfg-surfer`` entry overrides PATH with an absolute Surfer binary).
+    If the path points at a directory we look for ``spec.binaries[0]``
+    inside it; otherwise we treat the path as the binary itself.
+    """
+
+    abs_path: str
+
+    def detect(self, spec: "ToolSpec", project_root: Path | None) -> DetectionResult:
+        p = Path(self.abs_path)
+        if p.is_dir():
+            for binary in spec.binaries:
+                candidate = p / binary
+                if candidate.is_file() and os.access(candidate, os.X_OK):
+                    return DetectionResult(
+                        found=True, path=str(candidate), kind="vendor"
+                    )
+        elif p.is_file() and os.access(p, os.X_OK):
+            return DetectionResult(found=True, path=str(p), kind="vendor")
+        return DetectionResult(found=False, kind="vendor")
+
+
+@dataclass
+class PythonPackageDetector(Detector):
+    """Detect an installed Python package via ``importlib.metadata``."""
+
+    package: str
+
+    def detect(self, spec: "ToolSpec", project_root: Path | None) -> DetectionResult:
+        try:
+            ver = importlib_metadata.version(self.package)
+        except importlib_metadata.PackageNotFoundError:
+            return DetectionResult(found=False, kind="python")
+        return DetectionResult(found=True, path=None, kind="python", version=ver)
+
+
+@dataclass
+class PythonSiblingDetector(Detector):
+    """Detect a python-sibling tool by *both* PyPI metadata and PATH.
+
+    Python siblings (``rtl-buddy-view``, ``rtl-buddy-cdc``,
+    ``rtl-buddy-axi-profiler``) ship a wheel plus a script entry-point.
+    Reporting "kind=python" alone hides where the binary actually lives;
+    reporting PATH alone hides the version. This detector returns both
+    when both are present, so the table shows ``version + path`` for the
+    common "fully installed" case.
+    """
+
+    package: str
+
+    def detect(self, spec: "ToolSpec", project_root: Path | None) -> DetectionResult:
+        try:
+            version = importlib_metadata.version(self.package)
+        except importlib_metadata.PackageNotFoundError:
+            version = None
+        binary_path: str | None = None
+        for binary in spec.binaries:
+            resolved = shutil.which(binary)
+            if resolved:
+                binary_path = resolved
+                break
+        if version is None and binary_path is None:
+            return DetectionResult(found=False, kind="python")
+        # Prefer "path" kind when the binary is on PATH so the table shows
+        # the absolute path; fall back to "python" when only the wheel is
+        # installed (uncommon, but possible with `pip install --no-scripts`).
+        kind = "path" if binary_path else "python"
+        return DetectionResult(found=True, path=binary_path, kind=kind, version=version)
+
+
+# ---------------------------------------------------------------------------
+# ToolSpec
+
+
+@dataclass
+class ToolSpec:
+    """Declarative description of a single tool dependency.
+
+    Attributes:
+      name: Canonical key (used for ``--explain``, JSON output, and
+        ``require()``).
+      binaries: Binary names to look for. The first one found wins. For
+        Python packages this is typically a single human-readable name
+        (e.g. ``("pyslang",)``) used only for display.
+      version_cmd: Argv prefix that, when run, prints a version. ``None``
+        skips probing for this tool.
+      version_regex: Pattern applied to combined stdout+stderr of
+        ``version_cmd``. The first match wins.
+      minimum_version: Lower-bound version string. ``None`` means "any
+        version is acceptable as long as the tool is present."
+      detection: Ordered detectors. First ``found=True`` wins.
+      install_hint: Per-platform install instructions for ``--explain``.
+      used_by: Subcommands that this tool participates in. Drives the
+        "Subcommand readiness" section of the report.
+      optional: ``True`` means missing this tool does not gate
+        subcommand readiness.
+      description: Short one-liner shown by ``--explain``.
+      notes: Free-form additional context for ``--explain``.
+    """
+
+    name: str
+    binaries: tuple[str, ...]
+    version_cmd: tuple[str, ...] | None
+    version_regex: str | None
+    minimum_version: str | None
+    detection: tuple[Detector, ...]
+    install_hint: dict[str, str] = field(default_factory=dict)
+    used_by: tuple[str, ...] = ()
+    optional: bool = False
+    description: str = ""
+    notes: str = ""
+
+
+@dataclass
+class ToolStatus:
+    """Result of evaluating a single :class:`ToolSpec` against the env."""
+
+    name: str
+    status: str  # "ok" | "missing" | "outdated"
+    version: str | None
+    path: str | None
+    optional: bool
+    minimum_version: str | None
+    kind: str | None  # "path" | "vendor" | "python" | None
+    used_by: tuple[str, ...]
+
+
+# ---------------------------------------------------------------------------
+# Built-in manifest
+
+
+def _builtin_manifest() -> list[ToolSpec]:
+    return [
+        ToolSpec(
+            name="verible",
+            binaries=(
+                "verible-verilog-syntax",
+                "verible-verilog-lint",
+                "verible-verilog-format",
+            ),
+            version_cmd=("verible-verilog-syntax", "--version"),
+            version_regex=r"v\d+\.\d+-\d+",
+            minimum_version=None,
+            detection=(PathDetector(),),
+            install_hint={
+                "macos": "brew install verible",
+                "linux": "download release tarball from "
+                "https://github.com/chipsalliance/verible/releases",
+                "vendor": "extract into tools/verible/<os>/active/bin",
+            },
+            used_by=("hier", "verible"),
+            optional=False,
+            description="Verilog/SystemVerilog parser, linter, formatter",
+        ),
+        ToolSpec(
+            name="yosys",
+            binaries=("yosys",),
+            version_cmd=("yosys", "-V"),
+            version_regex=r"Yosys\s+([\w.+\-]+)",
+            minimum_version=None,
+            detection=(PathDetector(),),
+            install_hint={
+                "macos": "brew install yosys",
+                "linux": "apt install yosys (Debian) or build from "
+                "https://github.com/YosysHQ/yosys",
+                "source": "https://github.com/rtl-buddy/yosys",
+            },
+            used_by=("synth", "synth-regression", "cdc", "cdc-regression"),
+            optional=False,
+            description="Yosys open-source synthesis framework",
+        ),
+        ToolSpec(
+            name="verilator",
+            binaries=("verilator",),
+            version_cmd=("verilator", "--version"),
+            version_regex=r"Verilator\s+([\d.]+)",
+            minimum_version=None,
+            detection=(PathDetector(),),
+            install_hint={
+                "macos": "brew install verilator",
+                "linux": "apt install verilator (Ubuntu 22.04+: ≥ 5.0)",
+                "source": "https://verilator.org/guide/latest/install.html",
+            },
+            used_by=("test", "randtest", "regression"),
+            optional=False,
+            description="Verilog/SystemVerilog simulator (used in --binary mode)",
+            notes="rtl_buddy invokes Verilator in --binary mode; older 4.x "
+            "will fail compile.",
+        ),
+        ToolSpec(
+            name="surfer",
+            binaries=("surfer",),
+            version_cmd=("surfer", "--version"),
+            version_regex=r"surfer\s+([\d.]+(?:[-+][\w.]+)?)",
+            minimum_version=None,
+            detection=(PathDetector(),),
+            install_hint={
+                "source": "https://github.com/rtl-buddy/surfer (branch rtl-buddy)",
+                "build": "cd ../surfer && cargo build --release",
+            },
+            used_by=("wave", "wave-fpv", "hub"),
+            optional=False,
+            description="Web-native waveform viewer",
+        ),
+        ToolSpec(
+            name="gtkwave",
+            binaries=("gtkwave",),
+            version_cmd=("gtkwave", "--version"),
+            version_regex=r"GTKWave Analyzer\s+v?([\d.]+)",
+            minimum_version=None,
+            detection=(PathDetector(),),
+            install_hint={
+                "macos": "brew install --cask gtkwave",
+                "linux": "apt install gtkwave",
+            },
+            used_by=("wave-fpv",),
+            optional=True,
+            description="Legacy waveform viewer (fallback for rb wave-fpv)",
+        ),
+        ToolSpec(
+            name="graphviz",
+            binaries=("dot",),
+            version_cmd=("dot", "-V"),
+            version_regex=r"version\s+([\d.]+)",
+            minimum_version=None,
+            detection=(PathDetector(),),
+            install_hint={
+                "macos": "brew install graphviz",
+                "linux": "apt install graphviz",
+            },
+            used_by=("hier",),
+            optional=True,
+            description="Graphviz layout engine — renders rb hier --format dot to SVG/PNG",
+        ),
+        ToolSpec(
+            name="openroad",
+            binaries=("openroad",),
+            version_cmd=("openroad", "-version"),
+            version_regex=r"([\d.]+(?:-[\w.]+)?)",
+            minimum_version=None,
+            detection=(PathDetector(),),
+            install_hint={
+                "source": "https://github.com/The-OpenROAD-Project/OpenROAD",
+                "macos": "brew install --cask openroad (community tap)",
+            },
+            used_by=("pnr", "power", "power-regression", "synth"),
+            optional=True,
+            description="OpenROAD place-and-route + STA engine",
+        ),
+        ToolSpec(
+            name="klayout",
+            binaries=("klayout",),
+            version_cmd=("klayout", "-v"),
+            version_regex=r"KLayout\s+([\d.]+)",
+            minimum_version=None,
+            detection=(PathDetector(),),
+            install_hint={
+                "macos": "brew install --cask klayout",
+                "linux": "apt install klayout (Debian) or download from "
+                "https://www.klayout.de",
+            },
+            used_by=("pnr",),
+            optional=True,
+            description="GDS viewer (optional, used by rb pnr to render layout)",
+        ),
+        ToolSpec(
+            name="sby",
+            binaries=("sby",),
+            version_cmd=("sby", "--version"),
+            version_regex=r"sby\s+([\w.+\-]+)",
+            minimum_version=None,
+            detection=(PathDetector(),),
+            install_hint={
+                "source": "https://github.com/YosysHQ/sby",
+                "linux": "apt install yosys-sby (Debian)",
+            },
+            used_by=("fpv", "fpv-regression"),
+            optional=True,
+            description="SymbiYosys formal property verification driver",
+        ),
+        ToolSpec(
+            name="git",
+            binaries=("git",),
+            version_cmd=("git", "--version"),
+            version_regex=r"git version\s+([\d.]+)",
+            minimum_version=None,
+            detection=(PathDetector(),),
+            install_hint={
+                "macos": "brew install git (or use Xcode CLT)",
+                "linux": "apt install git",
+            },
+            used_by=(
+                "test",
+                "regression",
+                "synth",
+                "synth-regression",
+                "cdc",
+                "cdc-regression",
+                "fpv",
+                "fpv-regression",
+                "wave",
+                "hier",
+            ),
+            optional=False,
+            description="Required for revision banners and regression reporting",
+        ),
+        ToolSpec(
+            name="lcov",
+            binaries=("genhtml",),
+            version_cmd=("genhtml", "--version"),
+            version_regex=r"genhtml:\s+LCOV version\s+([\d.]+)",
+            minimum_version=None,
+            detection=(PathDetector(),),
+            install_hint={
+                "macos": "brew install lcov",
+                "linux": "apt install lcov",
+            },
+            used_by=("test", "regression"),
+            optional=True,
+            description="genhtml — coverage HTML reports for Verilator runs",
+        ),
+        ToolSpec(
+            name="info-process",
+            binaries=("info-process",),
+            # No --version flag in upstream info-process; skip the probe to
+            # avoid printing whatever is on the first line of --help.
+            version_cmd=None,
+            version_regex=None,
+            minimum_version=None,
+            detection=(PathDetector(),),
+            install_hint={
+                "linux": "build from "
+                "https://github.com/antmicro/coverview (info-process tool)",
+            },
+            used_by=("test", "regression"),
+            optional=True,
+            description="LCOV info-process — coverage merging for Coverview",
+        ),
+        ToolSpec(
+            name="marimo",
+            binaries=("marimo",),
+            version_cmd=("marimo", "--version"),
+            version_regex=r"([\d.]+)",
+            minimum_version=None,
+            detection=(PathDetector(),),
+            install_hint={
+                "any": "uv tool install marimo  (or pipx install marimo)",
+            },
+            used_by=("axi-profile",),
+            optional=True,
+            description="Marimo notebook launcher — used by rb axi-profile notebook",
+        ),
+        # ----- python siblings -----
+        ToolSpec(
+            name="rtl-buddy-view",
+            binaries=("rtl-buddy-view",),
+            version_cmd=None,
+            version_regex=None,
+            minimum_version=None,
+            detection=(PythonSiblingDetector("rtl-buddy-view"),),
+            install_hint={
+                "any": "uv tool install rtl-buddy-view  (or pip install rtl-buddy-view)",
+            },
+            used_by=("hier", "hub"),
+            optional=False,
+            description="Hierarchy viewer + JSON exporter for rtl_buddy",
+        ),
+        ToolSpec(
+            name="rtl-buddy-cdc",
+            binaries=("rtl-buddy-cdc",),
+            version_cmd=None,
+            version_regex=None,
+            minimum_version=None,
+            detection=(PythonSiblingDetector("rtl-buddy-cdc"),),
+            install_hint={
+                "any": "uv tool install rtl-buddy-cdc  (or pip install rtl-buddy-cdc)",
+            },
+            used_by=("cdc", "cdc-regression", "hub"),
+            optional=False,
+            description="CDC lint analyzer used by rb cdc",
+        ),
+        ToolSpec(
+            name="rtl-buddy-axi-profiler",
+            binaries=("axi-profiler",),
+            version_cmd=None,
+            version_regex=None,
+            minimum_version=None,
+            detection=(PythonSiblingDetector("rtl-buddy-axi-profiler"),),
+            install_hint={
+                "any": "uv tool install rtl-buddy-axi-profiler",
+            },
+            used_by=("axi-profile",),
+            optional=False,
+            description="AXI interconnect profiler used by rb axi-profile",
+        ),
+        # ----- python extras -----
+        ToolSpec(
+            name="pyslang",
+            binaries=("pyslang",),
+            version_cmd=None,
+            version_regex=None,
+            minimum_version=None,
+            detection=(PythonPackageDetector("pyslang"),),
+            install_hint={
+                "any": "uv pip install pyslang  (only needed for --frontend slang)",
+            },
+            used_by=("hier", "synth", "cdc"),
+            optional=True,
+            description="Python slang frontend — alternative parser for rb hier / synth / cdc",
+        ),
+        ToolSpec(
+            name="cocotb",
+            binaries=("cocotb",),
+            version_cmd=None,
+            version_regex=None,
+            minimum_version=None,
+            detection=(PythonPackageDetector("cocotb"),),
+            install_hint={
+                "any": "uv pip install cocotb  (only needed for cocotb-runner tests)",
+            },
+            used_by=("test", "regression"),
+            optional=True,
+            description="cocotb Python testbench runner",
+        ),
+        # ----- FPV solver engines (driven by sby) -----
+        # Mirrors tools/fpv_solver_pin._PROBES — that module is the runtime
+        # source of truth, this list keeps tool-check in sync. All optional:
+        # rb fpv only needs the solvers listed in the active engines: line of
+        # the user's fpv.yaml. Projects can pin exact versions through
+        # cfg-fpv-tools[*].opts.solver-versions, which _reconcile_with_root_cfg
+        # surfaces as minimum_version below.
+        *_fpv_solver_specs(),
+    ]
+
+
+def _fpv_solver_specs() -> list[ToolSpec]:
+    """Build solver ToolSpecs from the runtime probe table.
+
+    Importing :data:`fpv_solver_pin._PROBES` directly means tool-check and
+    the runtime pin check share the same binary / regex pair — adding a
+    solver in one place updates the other.
+    """
+    from .tools.fpv_solver_pin import _PROBES
+
+    specs: list[ToolSpec] = []
+    for name, (binary, args, pattern) in _PROBES.items():
+        specs.append(
+            ToolSpec(
+                name=name,
+                binaries=(binary,),
+                version_cmd=(binary, *args),
+                version_regex=pattern,
+                minimum_version=None,
+                detection=(PathDetector(),),
+                install_hint=_FPV_SOLVER_INSTALL_HINTS.get(name, {}),
+                used_by=("fpv", "fpv-regression"),
+                optional=True,
+                description=_FPV_SOLVER_DESCRIPTIONS.get(name, f"FPV solver: {name}"),
+                notes=(
+                    "Pinned exactly via cfg-fpv-tools.opts.solver-versions at "
+                    "runtime (`rb fpv` hard-fails on mismatch). tool-check "
+                    "uses a ≥ comparison against any project pin."
+                ),
+            )
+        )
+    return specs
+
+
+_FPV_SOLVER_INSTALL_HINTS: dict[str, dict[str, str]] = {
+    "yices": {
+        "macos": "brew install SRI-CSL/sri-csl/yices2",
+        "linux": "apt install yices2 (Debian) or build from "
+        "https://github.com/SRI-CSL/yices2",
+    },
+    "z3": {
+        "macos": "brew install z3",
+        "linux": "apt install z3",
+    },
+    "boolector": {
+        "source": "https://github.com/Boolector/boolector",
+        "macos": "brew install boolector",
+    },
+    "bitwuzla": {
+        "source": "https://github.com/bitwuzla/bitwuzla",
+    },
+    "btormc": {
+        "source": "https://github.com/Boolector/boolector "
+        "(builds btormc alongside boolector)",
+    },
+    "abc": {
+        "any": "ships with yosys as `yosys-abc` — installing yosys is enough",
+    },
+}
+
+_FPV_SOLVER_DESCRIPTIONS: dict[str, str] = {
+    "yices": "Yices SMT solver — default smtbmc engine",
+    "z3": "Z3 SMT solver",
+    "boolector": "Boolector BV/QF_AUFBV solver",
+    "bitwuzla": "Bitwuzla SMT solver (successor to Boolector)",
+    "btormc": "BtorMC bounded model checker (btor2 backend)",
+    "abc": "Yosys-ABC — combinational/sequential synthesis + BMC engine",
+}
+
+
+# ---------------------------------------------------------------------------
+# Reconciliation with root_config.yaml
+
+
+def _reconcile_with_root_cfg(specs: list[ToolSpec], root_cfg) -> list[ToolSpec]:
+    """Apply root-config overrides to manifest defaults.
+
+    Four kinds of override are honored:
+
+    * ``cfg-verible`` — the active platform's verible directory is added
+      to the verible spec's detector chain as the *preferred* lookup,
+      with PATH retained as the fallback.
+    * ``cfg-surfer`` — the ``surfer-default`` entry's resolved path is
+      added to the surfer spec's detector chain in the same way.
+    * ``cfg-tools`` — overrides ``minimum_version`` for any matching
+      tool. Project pins always win over manifest defaults.
+    * ``cfg-fpv-tools[*].opts.solver-versions`` — pins a project-wide
+      version for each FPV solver. Runtime semantics is exact-equality
+      (``rb fpv`` hard-fails on mismatch via
+      :func:`fpv_solver_pin.check_solver_pins`); tool-check surfaces the
+      pin as ``minimum_version`` so users see a single "outdated"
+      indication for solvers that don't match.
+    """
+    if root_cfg is None:
+        return specs
+
+    by_name = {s.name: s for s in specs}
+
+    # Verible vendor path
+    try:
+        verible_cfg = root_cfg.get_verible_cfg()
+    except Exception:
+        verible_cfg = None
+    if verible_cfg is not None and verible_cfg.path:
+        spec = by_name["verible"]
+        by_name["verible"] = _replace(
+            spec,
+            detection=(AbsolutePathDetector(verible_cfg.path), *spec.detection),
+        )
+
+    # Surfer override path
+    try:
+        surfer_cfg = root_cfg.get_surfer_cfg()
+    except Exception:
+        surfer_cfg = None
+    if surfer_cfg is not None:
+        try:
+            surfer_path = surfer_cfg.get_surfer_exe()
+        except Exception:
+            surfer_path = None
+        if surfer_path and surfer_path != surfer_cfg.path:
+            # An absolute path was resolved — prepend an AbsolutePathDetector
+            spec = by_name["surfer"]
+            by_name["surfer"] = _replace(
+                spec,
+                detection=(AbsolutePathDetector(surfer_path), *spec.detection),
+            )
+
+    # cfg-tools min-version pins
+    for name, ver_cfg in getattr(root_cfg, "tool_version_cfgs", {}).items():
+        if name not in by_name:
+            log_event(
+                logger,
+                logging.DEBUG,
+                "tool_manifest.unknown_pin",
+                name=name,
+                min_version=ver_cfg.min_version,
+            )
+            continue
+        if ver_cfg.min_version:
+            by_name[name] = _replace(by_name[name], minimum_version=ver_cfg.min_version)
+
+    # cfg-fpv-tools[*].opts.solver-versions pins. Multiple fpv-tool
+    # entries can each pin different solvers; later entries win for the
+    # same solver — matches dict-merge semantics.
+    fpv_pins: dict[str, str] = {}
+    for tool_cfg in getattr(root_cfg, "fpv_tool_cfgs", {}).values():
+        opts = tool_cfg.get_opts()
+        for solver, version in opts.solver_versions.items():
+            fpv_pins[solver] = version
+    for solver, version in fpv_pins.items():
+        if solver not in by_name:
+            log_event(
+                logger,
+                logging.DEBUG,
+                "tool_manifest.unknown_solver_pin",
+                solver=solver,
+                pinned=version,
+            )
+            continue
+        by_name[solver] = _replace(by_name[solver], minimum_version=version)
+
+    return list(by_name.values())
+
+
+def _replace(spec: ToolSpec, **changes) -> ToolSpec:
+    """:func:`dataclasses.replace` without importing it everywhere."""
+    from dataclasses import replace
+
+    return replace(spec, **changes)
+
+
+def get_manifest(root_cfg=None) -> list[ToolSpec]:
+    """Return the full tool manifest, optionally reconciled with ``root_cfg``."""
+    return _reconcile_with_root_cfg(_builtin_manifest(), root_cfg)
+
+
+# ---------------------------------------------------------------------------
+# Version handling
+
+
+_VERSION_TOKEN_RE = re.compile(r"\d+")
+
+
+def _version_tuple(value: str) -> tuple[int, ...]:
+    """Extract a tuple of ints from a version-looking string.
+
+    ``v0.0-3724`` → ``(0, 0, 3724)``. Non-numeric tokens are ignored.
+    Returns ``()`` if no digits found — used as a sentinel for
+    incomparable strings.
+    """
+    return tuple(int(t) for t in _VERSION_TOKEN_RE.findall(value))
+
+
+def _version_satisfies(actual: str | None, minimum: str | None) -> bool:
+    """Tolerant ``actual >= minimum`` check.
+
+    Strategy: extract integer tuples from each, lexicographically
+    compare. If either side has no extractable digits, we err on the
+    side of "satisfies" — the tool is present, after all, and a stricter
+    comparator should be opt-in.
+    """
+    if minimum is None:
+        return True
+    if actual is None:
+        # No version captured but a minimum was requested — can't prove
+        # satisfaction. Treat as outdated so the user investigates.
+        return False
+    a, m = _version_tuple(actual), _version_tuple(minimum)
+    if not a or not m:
+        return True
+    return a >= m
+
+
+# ---------------------------------------------------------------------------
+# Version cache (~/.cache/rtl_buddy/tool_versions.json)
+
+
+def _cache_path() -> Path:
+    base = os.environ.get("XDG_CACHE_HOME") or os.path.expanduser("~/.cache")
+    return Path(base) / "rtl_buddy" / "tool_versions.json"
+
+
+def _load_cache() -> dict:
+    path = _cache_path()
+    if not path.is_file():
+        return {}
+    try:
+        return json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def _save_cache(cache: dict) -> None:
+    path = _cache_path()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(cache, indent=2, sort_keys=True))
+    except OSError:
+        log_event(
+            logger,
+            logging.DEBUG,
+            "tool_manifest.cache_write_failed",
+            path=str(path),
+        )
+
+
+def probe_version(
+    spec: ToolSpec, binary_path: str | None, cache: dict | None = None
+) -> str | None:
+    """Run ``spec.version_cmd`` and return the parsed version string.
+
+    ``binary_path`` is substituted as ``argv[0]`` when set so vendor
+    binaries are probed instead of whatever PATH would resolve. Results
+    are cached keyed by ``(binary_path, mtime)`` in
+    ``~/.cache/rtl_buddy/tool_versions.json`` so repeated calls don't
+    re-fork.
+    """
+    if spec.version_cmd is None or spec.version_regex is None:
+        return None
+
+    cmd = list(spec.version_cmd)
+    if binary_path:
+        cmd[0] = binary_path
+
+    cache_key = None
+    if cache is not None and binary_path:
+        try:
+            mtime = os.path.getmtime(binary_path)
+            cache_key = f"{binary_path}@{int(mtime)}"
+            if cache_key in cache:
+                cached = cache[cache_key]
+                if cached.get("regex") == spec.version_regex:
+                    return cached.get("version")
+        except OSError:
+            cache_key = None
+
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return None
+
+    blob = (result.stdout or "") + "\n" + (result.stderr or "")
+    match = re.search(spec.version_regex, blob)
+    version = None
+    if match:
+        # Prefer first capture group if present, else full match.
+        version = match.group(1) if match.groups() else match.group(0)
+
+    if cache is not None and cache_key is not None:
+        cache[cache_key] = {"regex": spec.version_regex, "version": version}
+
+    return version
+
+
+# ---------------------------------------------------------------------------
+# Detection + status
+
+
+def detect_tool(spec: ToolSpec, project_root: Path | None = None) -> DetectionResult:
+    """Run detectors in order, returning the first hit (or last miss)."""
+    last = DetectionResult(found=False)
+    for det in spec.detection:
+        result = det.detect(spec, project_root)
+        if result.found:
+            return result
+        last = result
+    return last
+
+
+def check_tool(
+    spec: ToolSpec,
+    *,
+    project_root: Path | None = None,
+    probe_versions: bool = True,
+    cache: dict | None = None,
+) -> ToolStatus:
+    """Resolve detection + optional version probe for one ToolSpec."""
+    det = detect_tool(spec, project_root=project_root)
+
+    if not det.found:
+        return ToolStatus(
+            name=spec.name,
+            status="missing",
+            version=None,
+            path=None,
+            optional=spec.optional,
+            minimum_version=spec.minimum_version,
+            kind=None,
+            used_by=spec.used_by,
+        )
+
+    version = det.version
+    if version is None and probe_versions and det.kind != "python":
+        version = probe_version(spec, det.path, cache=cache)
+
+    status = "ok"
+    if not _version_satisfies(version, spec.minimum_version):
+        status = "outdated"
+
+    return ToolStatus(
+        name=spec.name,
+        status=status,
+        version=version,
+        path=det.path,
+        optional=spec.optional,
+        minimum_version=spec.minimum_version,
+        kind=det.kind,
+        used_by=spec.used_by,
+    )
+
+
+def check_all(
+    specs: Iterable[ToolSpec],
+    *,
+    project_root: Path | None = None,
+    probe_versions: bool = True,
+    include_optional: bool = True,
+) -> list[ToolStatus]:
+    cache = _load_cache() if probe_versions else None
+    statuses: list[ToolStatus] = []
+    for spec in specs:
+        if not include_optional and spec.optional:
+            continue
+        statuses.append(
+            check_tool(
+                spec,
+                project_root=project_root,
+                probe_versions=probe_versions,
+                cache=cache,
+            )
+        )
+    if cache is not None:
+        _save_cache(cache)
+    return statuses
+
+
+def subcommand_readiness(
+    statuses: list[ToolStatus],
+    specs: Iterable[ToolSpec],
+) -> dict[str, dict]:
+    """Group tool statuses by the subcommands they gate.
+
+    Each subcommand entry has:
+        ``status`` — overall ``ok`` / ``outdated`` / ``missing``
+        ``missing`` — list of required tools that are absent
+        ``outdated`` — list of required tools that are too old
+        ``optional_feature`` — True iff *all* gating tools are optional
+            (i.e. the subcommand only runs when the user opts in)
+    """
+    by_name = {s.name: s for s in statuses}
+
+    subcommands: dict[str, dict] = {}
+    for spec in specs:
+        for sub in spec.used_by:
+            slot = subcommands.setdefault(
+                sub,
+                {
+                    "missing": [],
+                    "outdated": [],
+                    "tools": [],
+                    "optional_only": True,
+                },
+            )
+            slot["tools"].append(spec.name)
+            if not spec.optional:
+                slot["optional_only"] = False
+            st = by_name.get(spec.name)
+            if st is None:
+                continue
+            if st.status == "missing" and not spec.optional:
+                slot["missing"].append(spec.name)
+            elif st.status == "outdated" and not spec.optional:
+                slot["outdated"].append(spec.name)
+
+    out: dict[str, dict] = {}
+    for sub, slot in sorted(subcommands.items()):
+        status = "ok"
+        if slot["missing"]:
+            status = "missing"
+        elif slot["outdated"]:
+            status = "outdated"
+        out[sub] = {
+            "status": status,
+            "missing": slot["missing"],
+            "outdated": slot["outdated"],
+            "tools": slot["tools"],
+            "optional_feature": slot["optional_only"],
+        }
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Public helpers used by subcommand wrappers
+
+
+def require(name: str, root_cfg=None) -> ToolStatus:
+    """Assert that ``name`` is installed (and not outdated), else raise.
+
+    Subcommand entry points may call this to surface a uniform
+    "missing tool" error pointing the user at ``rb tool-check --explain``.
+    """
+    spec = next((s for s in get_manifest(root_cfg) if s.name == name), None)
+    if spec is None:
+        raise FatalRtlBuddyError(f"tool_manifest: unknown tool '{name}'")
+    status = check_tool(spec)
+    if status.status == "missing":
+        raise FatalRtlBuddyError(
+            f"{name} not found — run `rb tool-check --explain {name}` "
+            "for install instructions"
+        )
+    if status.status == "outdated":
+        raise FatalRtlBuddyError(
+            f"{name} {status.version} is older than the required minimum "
+            f"{spec.minimum_version} — run `rb tool-check --explain {name}` "
+            "for upgrade instructions"
+        )
+    return status
+
+
+def explain(spec: ToolSpec, status: ToolStatus | None = None) -> str:
+    """Render a multi-line, human-readable description for ``--explain``."""
+    lines: list[str] = []
+    headline = spec.name
+    if spec.description:
+        headline = f"{headline} — {spec.description}"
+    lines.append(headline)
+    if status is not None:
+        lines.append(f"  Status:  {status.status}")
+        if status.version:
+            lines.append(f"  Version: {status.version}")
+        if status.path:
+            lines.append(f"  Path:    {status.path}")
+    if spec.used_by:
+        lines.append(f"  Used by: {', '.join(f'rb {s}' for s in spec.used_by)}")
+    if spec.install_hint:
+        lines.append("  Install:")
+        for platform, hint in spec.install_hint.items():
+            lines.append(f"    {platform:8s} {hint}")
+    if spec.minimum_version:
+        lines.append(f"  Minimum version: {spec.minimum_version}")
+    if spec.optional:
+        lines.append("  Optional: yes (subcommands using it are opt-in)")
+    if spec.notes:
+        lines.append(f"  Notes: {spec.notes}")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+
+
+def _status_glyph(status: str) -> str:
+    # ASCII only — see issue #204: must stay grep-friendly for CI logs.
+    return status
+
+
+def render_text(
+    statuses: list[ToolStatus],
+    subcommands: dict[str, dict],
+    *,
+    include_optional: bool = True,
+) -> str:
+    ok = sum(1 for s in statuses if s.status == "ok")
+    missing = sum(1 for s in statuses if s.status == "missing" and not s.optional)
+    outdated = sum(1 for s in statuses if s.status == "outdated" and not s.optional)
+    header = f"Tools ({ok} ok, {missing} missing, {outdated} outdated)\n" + ("-" * 70)
+
+    name_w = max(20, max((len(s.name) for s in statuses), default=0) + 2)
+    rows: list[str] = []
+    rows.append(f"{'Tool':<{name_w}}{'Status':12}{'Version':14}Path")
+    for st in statuses:
+        path_display = st.path or "—"
+        if st.kind == "python":
+            path_display = "(python)"
+        version = st.version or "—"
+        suffix = "  (optional)" if st.optional else ""
+        if st.status == "outdated" and st.minimum_version:
+            suffix = f"  (need ≥ {st.minimum_version})" + suffix
+        rows.append(
+            f"{st.name:<{name_w}}{_status_glyph(st.status):12}{version:14}"
+            f"{path_display}{suffix}"
+        )
+
+    sub_lines: list[str] = []
+    sub_lines.append("\nSubcommand readiness")
+    sub_lines.append("-" * 70)
+    for sub, info in subcommands.items():
+        gloss_parts = []
+        if info["missing"]:
+            gloss_parts.append(f"needs: {', '.join(info['missing'])}")
+        if info["outdated"]:
+            gloss_parts.append(f"outdated: {', '.join(info['outdated'])}")
+        if not gloss_parts:
+            gloss_parts.append(", ".join(info["tools"]) or "no external deps")
+        opt = "  (optional feature)" if info["optional_feature"] else ""
+        sub_lines.append(
+            f"  {_status_glyph(info['status']):9} rb {sub:20} ({gloss_parts[0]}){opt}"
+        )
+
+    hint = "\nHint: `rb tool-check --explain <tool>` for install instructions."
+    return "\n".join([header, *rows, *sub_lines, hint])
+
+
+def render_json(
+    statuses: list[ToolStatus],
+    subcommands: dict[str, dict],
+    *,
+    exit_code: int,
+) -> str:
+    tools_out: dict[str, dict] = {}
+    for st in statuses:
+        entry: dict = {
+            "status": st.status,
+            "version": st.version,
+            "path": st.path,
+            "optional": st.optional,
+        }
+        if st.minimum_version:
+            entry["minimum_version"] = st.minimum_version
+        tools_out[st.name] = entry
+
+    subs_out: dict[str, dict] = {}
+    for sub, info in subcommands.items():
+        entry = {
+            "status": info["status"],
+            "missing": info["missing"],
+            "outdated": info["outdated"],
+        }
+        if info["optional_feature"]:
+            entry["optional_feature"] = True
+        subs_out[sub] = entry
+
+    return json.dumps(
+        {"tools": tools_out, "subcommands": subs_out, "exit_code": exit_code},
+        indent=2,
+        sort_keys=False,
+    )
+
+
+def compute_exit_code(
+    statuses: list[ToolStatus],
+    *,
+    required_for: str | None = None,
+    subcommands: dict[str, dict] | None = None,
+) -> int:
+    """Map a checked manifest to a process exit code.
+
+    Mapping (per issue #204):
+        0 — all required tools present and up-to-date.
+        1 — at least one required tool missing/outdated.
+        2 — ``--required-for <sub>`` and that sub's deps are missing.
+    """
+    if required_for is not None and subcommands is not None:
+        info = subcommands.get(required_for)
+        if info is None:
+            return 1
+        if info["status"] != "ok":
+            return 2
+        return 0
+    for st in statuses:
+        if st.optional:
+            continue
+        if st.status != "ok":
+            return 1
+    return 0

--- a/tests/test_tool_manifest.py
+++ b/tests/test_tool_manifest.py
@@ -1,0 +1,587 @@
+"""Unit tests for :mod:`rtl_buddy.tool_manifest` and ``rb tool-check``."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+from rtl_buddy import tool_manifest as tm
+
+
+# ---------------------------------------------------------------------------
+# Version helpers
+
+
+def test_version_tuple_extracts_integers():
+    assert tm._version_tuple("v0.0-3724") == (0, 0, 3724)
+    assert tm._version_tuple("Yosys 0.40") == (0, 40)
+    assert tm._version_tuple("5.048") == (5, 48)
+    assert tm._version_tuple("no digits") == ()
+
+
+def test_version_satisfies():
+    # No minimum → always satisfies.
+    assert tm._version_satisfies("anything", None) is True
+    # Minimum but no detected version → cannot prove → outdated.
+    assert tm._version_satisfies(None, "1.0") is False
+    # Same / greater / lesser
+    assert tm._version_satisfies("v0.0-3724", "v0.0-3724") is True
+    assert tm._version_satisfies("v0.0-3800", "v0.0-3724") is True
+    assert tm._version_satisfies("v0.0-3600", "v0.0-3724") is False
+    # Non-digit minimum → bail out as satisfied (we can't compare).
+    assert tm._version_satisfies("1.0", "anything") is True
+
+
+# ---------------------------------------------------------------------------
+# Detectors
+
+
+@pytest.fixture
+def fake_bin(tmp_path: Path) -> Iterator[Path]:
+    """Drop an executable on PATH for the duration of the test."""
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    old_path = os.environ["PATH"]
+    os.environ["PATH"] = f"{bindir}{os.pathsep}{old_path}"
+    try:
+        yield bindir
+    finally:
+        os.environ["PATH"] = old_path
+
+
+def _make_exe(path: Path, body: str = "#!/bin/sh\necho stub\n") -> Path:
+    path.write_text(body)
+    path.chmod(0o755)
+    return path
+
+
+def test_path_detector_hits_on_path(fake_bin: Path):
+    _make_exe(fake_bin / "stub-tool")
+    spec = tm.ToolSpec(
+        name="stub",
+        binaries=("stub-tool",),
+        version_cmd=None,
+        version_regex=None,
+        minimum_version=None,
+        detection=(tm.PathDetector(),),
+    )
+    result = tm.detect_tool(spec)
+    assert result.found is True
+    assert result.path is not None
+    assert result.path.endswith("stub-tool")
+
+
+def test_path_detector_misses_when_absent():
+    spec = tm.ToolSpec(
+        name="never",
+        binaries=("definitely-not-a-real-binary-xyz",),
+        version_cmd=None,
+        version_regex=None,
+        minimum_version=None,
+        detection=(tm.PathDetector(),),
+    )
+    assert tm.detect_tool(spec).found is False
+
+
+def test_vendor_detector_hits(tmp_path: Path):
+    vendor_bin = tmp_path / "vendor" / "stub" / "bin"
+    vendor_bin.mkdir(parents=True)
+    _make_exe(vendor_bin / "stub-tool")
+    spec = tm.ToolSpec(
+        name="stub",
+        binaries=("stub-tool",),
+        version_cmd=None,
+        version_regex=None,
+        minimum_version=None,
+        detection=(tm.VendorDetector(rel_path="vendor/stub/bin"),),
+    )
+    result = tm.detect_tool(spec, project_root=tmp_path)
+    assert result.found is True
+    assert result.kind == "vendor"
+
+
+def test_absolute_path_detector_hits(tmp_path: Path):
+    target_dir = tmp_path / "vbn" / "bin"
+    target_dir.mkdir(parents=True)
+    _make_exe(target_dir / "verible-verilog-syntax")
+    spec = tm.ToolSpec(
+        name="verible",
+        binaries=("verible-verilog-syntax",),
+        version_cmd=None,
+        version_regex=None,
+        minimum_version=None,
+        detection=(tm.AbsolutePathDetector(abs_path=str(target_dir)),),
+    )
+    result = tm.detect_tool(spec)
+    assert result.found is True
+    assert result.kind == "vendor"
+    assert "verible-verilog-syntax" in (result.path or "")
+
+
+def test_python_package_detector_hits_on_pytest():
+    # pytest is a hard dev dependency — guaranteed present here.
+    spec = tm.ToolSpec(
+        name="pytest",
+        binaries=("pytest",),
+        version_cmd=None,
+        version_regex=None,
+        minimum_version=None,
+        detection=(tm.PythonPackageDetector("pytest"),),
+    )
+    result = tm.detect_tool(spec)
+    assert result.found is True
+    assert result.kind == "python"
+    assert result.version  # importlib.metadata always returns something
+
+
+def test_python_sibling_detector_returns_both_version_and_path(fake_bin: Path):
+    """When a python sibling is installed AND on PATH, show both.
+
+    Uses ``pytest`` as the test subject — its package is installed (it's
+    running this test) and its script entry-point is on PATH. We add the
+    fake_bin shim only to confirm the detector's binary-lookup path runs.
+    """
+    spec = tm.ToolSpec(
+        name="pytest",
+        binaries=("pytest",),
+        version_cmd=None,
+        version_regex=None,
+        minimum_version=None,
+        detection=(tm.PythonSiblingDetector("pytest"),),
+    )
+    result = tm.detect_tool(spec)
+    assert result.found is True
+    # Version comes from importlib.metadata.
+    assert result.version
+    # Path comes from shutil.which — pytest installs a console entry-point.
+    assert result.path
+    assert result.path.endswith("pytest")
+    # kind is "path" when the binary is on PATH (so the table shows the
+    # absolute path instead of "(python)").
+    assert result.kind == "path"
+
+
+def test_python_sibling_detector_misses_when_neither_present(tmp_path: Path):
+    spec = tm.ToolSpec(
+        name="fake",
+        binaries=("nonexistent-cmd-zzz",),
+        version_cmd=None,
+        version_regex=None,
+        minimum_version=None,
+        detection=(tm.PythonSiblingDetector("nonexistent-package-zzz"),),
+    )
+    assert tm.detect_tool(spec).found is False
+
+
+def test_python_package_detector_misses_on_unknown():
+    spec = tm.ToolSpec(
+        name="fake",
+        binaries=("fake",),
+        version_cmd=None,
+        version_regex=None,
+        minimum_version=None,
+        detection=(tm.PythonPackageDetector("definitely-not-installed-xyz-pkg"),),
+    )
+    assert tm.detect_tool(spec).found is False
+
+
+# ---------------------------------------------------------------------------
+# Version probe
+
+
+def test_probe_version_parses_output(fake_bin: Path):
+    bin_path = _make_exe(
+        fake_bin / "stubver",
+        body="#!/bin/sh\necho 'stubver v0.0-3724'\n",
+    )
+    spec = tm.ToolSpec(
+        name="stub",
+        binaries=("stubver",),
+        version_cmd=("stubver", "--version"),
+        version_regex=r"v\d+\.\d+-\d+",
+        minimum_version=None,
+        detection=(tm.PathDetector(),),
+    )
+    version = tm.probe_version(spec, str(bin_path), cache={})
+    assert version == "v0.0-3724"
+
+
+def test_probe_version_uses_capture_group_when_present(fake_bin: Path):
+    bin_path = _make_exe(
+        fake_bin / "stubver2",
+        body="#!/bin/sh\necho 'Yosys 0.40 stable'\n",
+    )
+    spec = tm.ToolSpec(
+        name="stub",
+        binaries=("stubver2",),
+        version_cmd=("stubver2", "-V"),
+        version_regex=r"Yosys\s+([\d.]+)",
+        minimum_version=None,
+        detection=(tm.PathDetector(),),
+    )
+    assert tm.probe_version(spec, str(bin_path), cache={}) == "0.40"
+
+
+def test_probe_version_returns_none_when_unparsable(fake_bin: Path):
+    bin_path = _make_exe(
+        fake_bin / "noversion",
+        body="#!/bin/sh\necho 'no clue what version'\n",
+    )
+    spec = tm.ToolSpec(
+        name="stub",
+        binaries=("noversion",),
+        version_cmd=("noversion", "--version"),
+        version_regex=r"v\d+\.\d+-\d+",
+        minimum_version=None,
+        detection=(tm.PathDetector(),),
+    )
+    assert tm.probe_version(spec, str(bin_path), cache={}) is None
+
+
+def test_probe_version_cache_hit(fake_bin: Path):
+    bin_path = _make_exe(
+        fake_bin / "cachedver",
+        body="#!/bin/sh\necho 'IGNORE THIS' >&2\nexit 0\n",
+    )
+    spec = tm.ToolSpec(
+        name="stub",
+        binaries=("cachedver",),
+        version_cmd=("cachedver", "--version"),
+        version_regex=r"(\d+\.\d+)",
+        minimum_version=None,
+        detection=(tm.PathDetector(),),
+    )
+    mtime = int(os.path.getmtime(bin_path))
+    cache = {
+        f"{bin_path}@{mtime}": {
+            "regex": spec.version_regex,
+            "version": "1.2",
+        }
+    }
+    # Cache key matches → returns cached value WITHOUT executing the script
+    # (the script would yield None since stdout/stderr have no digits).
+    assert tm.probe_version(spec, str(bin_path), cache=cache) == "1.2"
+
+
+# ---------------------------------------------------------------------------
+# check_tool / check_all / subcommand_readiness
+
+
+def test_check_tool_ok(fake_bin: Path):
+    _make_exe(
+        fake_bin / "okt",
+        body="#!/bin/sh\necho 'okt 2.0'\n",
+    )
+    spec = tm.ToolSpec(
+        name="okt",
+        binaries=("okt",),
+        version_cmd=("okt", "--version"),
+        version_regex=r"okt\s+([\d.]+)",
+        minimum_version="1.0",
+        detection=(tm.PathDetector(),),
+    )
+    status = tm.check_tool(spec, probe_versions=True, cache={})
+    assert status.status == "ok"
+    assert status.version == "2.0"
+
+
+def test_check_tool_outdated(fake_bin: Path):
+    _make_exe(
+        fake_bin / "oldt",
+        body="#!/bin/sh\necho 'oldt 1.0'\n",
+    )
+    spec = tm.ToolSpec(
+        name="oldt",
+        binaries=("oldt",),
+        version_cmd=("oldt", "--version"),
+        version_regex=r"oldt\s+([\d.]+)",
+        minimum_version="9.0",
+        detection=(tm.PathDetector(),),
+    )
+    status = tm.check_tool(spec, probe_versions=True, cache={})
+    assert status.status == "outdated"
+    assert status.version == "1.0"
+    assert status.minimum_version == "9.0"
+
+
+def test_check_tool_missing():
+    spec = tm.ToolSpec(
+        name="ghost",
+        binaries=("ghost-binary-that-doesnt-exist",),
+        version_cmd=None,
+        version_regex=None,
+        minimum_version=None,
+        detection=(tm.PathDetector(),),
+        optional=True,
+    )
+    status = tm.check_tool(spec)
+    assert status.status == "missing"
+    assert status.path is None
+
+
+def test_subcommand_readiness_aggregates():
+    spec_required = tm.ToolSpec(
+        name="missing-required",
+        binaries=("never",),
+        version_cmd=None,
+        version_regex=None,
+        minimum_version=None,
+        detection=(tm.PathDetector(),),
+        used_by=("test", "hier"),
+        optional=False,
+    )
+    spec_optional = tm.ToolSpec(
+        name="missing-optional",
+        binaries=("never2",),
+        version_cmd=None,
+        version_regex=None,
+        minimum_version=None,
+        detection=(tm.PathDetector(),),
+        used_by=("test",),
+        optional=True,
+    )
+    specs = [spec_required, spec_optional]
+    statuses = tm.check_all(specs, probe_versions=False)
+    readiness = tm.subcommand_readiness(statuses, specs)
+    assert readiness["test"]["status"] == "missing"
+    assert "missing-required" in readiness["test"]["missing"]
+    # Optional misses do not flip status.
+    assert "missing-optional" not in readiness["test"]["missing"]
+    # hier only depends on the required tool — also missing.
+    assert readiness["hier"]["status"] == "missing"
+
+
+# ---------------------------------------------------------------------------
+# Manifest reconciliation with root_config.yaml
+
+
+def _write_minimal_root_config(target: Path, *, extra: str = "") -> None:
+    """Drop a usable root_config.yaml + regression.yaml at ``target``."""
+    target.mkdir(parents=True, exist_ok=True)
+    (target / "root_config.yaml").write_text(
+        """\
+rtl-buddy-filetype: project_root_config
+
+cfg-platforms:
+  - os: "test-host"
+    unames: ["Darwin", "Linux"]
+    builder: "stub"
+    verible: "stub-verible"
+
+cfg-rtl-builder:
+  - name: "stub"
+    builder: "echo"
+    builder-simv: "obj_dir/simv"
+    sim-rand-seed: 1
+    sim-rand-seed-prefix: "+seed="
+    builder-opts:
+      debug:
+        compile-time: "--no-op"
+        run-time: "--no-op"
+
+cfg-verible:
+  - name: "stub-verible"
+    path: "/usr/bin"
+    extra_args: {}
+
+cfg-rtl-reg:
+  reg-cfg-path: "regression.yaml"
+"""
+        + extra
+    )
+    (target / "regression.yaml").write_text(
+        "rtl-buddy-filetype: reg_config\ntest-configs: []\n"
+    )
+
+
+def test_root_cfg_tools_min_version_overrides_manifest(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    _write_minimal_root_config(
+        tmp_path,
+        extra=(
+            "\ncfg-tools:\n"
+            "  - name: verible\n"
+            '    min-version: "v9.9-9999"\n'
+            "  - name: yosys\n"
+            '    min-version: "99.0"\n'
+        ),
+    )
+    monkeypatch.chdir(tmp_path)
+
+    from rtl_buddy.config.root import RootConfig
+
+    rc = RootConfig(name="test")
+    specs = tm.get_manifest(rc)
+    by_name = {s.name: s for s in specs}
+    assert by_name["verible"].minimum_version == "v9.9-9999"
+    assert by_name["yosys"].minimum_version == "99.0"
+    # Unaffected tools keep their manifest default (None for now).
+    assert by_name["surfer"].minimum_version is None
+
+
+def test_fpv_solvers_present_in_manifest():
+    """Every solver tracked by fpv_solver_pin must have a manifest entry.
+
+    Catches drift between the runtime pin probe and the tool-check view —
+    adding a solver in one place must add it in both.
+    """
+    from rtl_buddy.tools.fpv_solver_pin import _PROBES
+
+    names = {s.name for s in tm.get_manifest()}
+    for solver in _PROBES:
+        assert solver in names, f"FPV solver '{solver}' missing from manifest"
+
+
+def test_fpv_solver_pin_reconciliation(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """cfg-fpv-tools.opts.solver-versions must surface as minimum_version."""
+    _write_minimal_root_config(
+        tmp_path,
+        extra=(
+            "\ncfg-fpv-tools:\n"
+            '  - name: "sby"\n'
+            '    tool: "sby"\n'
+            "    opts:\n"
+            "      solver-versions:\n"
+            '        yices: "99.0.0"\n'
+            '        z3: "99.0"\n'
+        ),
+    )
+    monkeypatch.chdir(tmp_path)
+
+    from rtl_buddy.config.root import RootConfig
+
+    rc = RootConfig(name="test")
+    specs = tm.get_manifest(rc)
+    by_name = {s.name: s for s in specs}
+    assert by_name["yices"].minimum_version == "99.0.0"
+    assert by_name["z3"].minimum_version == "99.0"
+    # Unpinned solvers keep their default (None).
+    assert by_name["boolector"].minimum_version is None
+
+
+def test_root_cfg_unknown_pin_is_ignored(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    _write_minimal_root_config(
+        tmp_path,
+        extra=('\ncfg-tools:\n  - name: not-a-real-tool\n    min-version: "99.0"\n'),
+    )
+    monkeypatch.chdir(tmp_path)
+
+    from rtl_buddy.config.root import RootConfig
+
+    rc = RootConfig(name="test")
+    # Should not raise — unknown pins are logged at DEBUG and skipped.
+    specs = tm.get_manifest(rc)
+    assert any(s.name == "verible" for s in specs)
+
+
+# ---------------------------------------------------------------------------
+# CLI integration
+
+
+def _run_rb(*args: str, cwd: Path | None = None) -> subprocess.CompletedProcess:
+    cmd = [sys.executable, "-m", "rtl_buddy", *args]
+    return subprocess.run(cmd, capture_output=True, text=True, cwd=cwd, check=False)
+
+
+def test_cli_tool_check_runs_outside_project(tmp_path: Path):
+    """tool-check must not require a root_config.yaml."""
+    result = _run_rb("tool-check", "--no-probe-versions", cwd=tmp_path)
+    assert result.returncode == 0
+    assert "Tools (" in result.stdout
+    assert "Subcommand readiness" in result.stdout
+
+
+def test_cli_tool_check_json(tmp_path: Path):
+    result = _run_rb(
+        "tool-check", "--format", "json", "--no-probe-versions", cwd=tmp_path
+    )
+    assert result.returncode == 0
+    payload = json.loads(result.stdout)
+    assert "tools" in payload and "subcommands" in payload
+    assert "exit_code" in payload
+    # Manifest is non-empty.
+    assert len(payload["tools"]) > 0
+
+
+def test_cli_tool_check_explain(tmp_path: Path):
+    result = _run_rb("tool-check", "--explain", "verible", cwd=tmp_path)
+    assert result.returncode == 0
+    assert "verible" in result.stdout
+    assert "Install" in result.stdout
+
+
+def test_cli_tool_check_explain_unknown_exits_1(tmp_path: Path):
+    result = _run_rb("tool-check", "--explain", "does-not-exist", cwd=tmp_path)
+    assert result.returncode == 1
+
+
+def test_cli_tool_check_required_for_present(tmp_path: Path):
+    # `tool-check` itself has no deps in the manifest; pick a sub that
+    # depends only on a tool we are confident is installed (pytest is
+    # always present here).
+    # Use the manifest to find a likely-satisfied subcommand: pick the
+    # first one whose required tools are all present.
+    statuses = tm.check_all(
+        tm.get_manifest(), probe_versions=False, include_optional=True
+    )
+    readiness = tm.subcommand_readiness(statuses, tm.get_manifest())
+    ok_sub = next(
+        (sub for sub, info in readiness.items() if info["status"] == "ok"),
+        None,
+    )
+    if ok_sub is None:
+        pytest.skip("no subcommand has all required tools installed")
+
+    result = _run_rb("tool-check", "--required-for", ok_sub, cwd=tmp_path)
+    assert result.returncode == 0
+
+
+def test_cli_tool_check_required_for_missing_exits_2(tmp_path: Path):
+    """--required-for must exit 2 if any required tool is missing."""
+    # axi-profile depends on rtl-buddy-axi-profiler, which we don't install
+    # in the rtl_buddy CI venv. If for some reason it *is* present, skip.
+    if shutil.which("axi-profiler") is not None:
+        pytest.skip("axi-profiler is installed; cannot exercise miss path")
+    try:
+        from importlib import metadata as md
+
+        md.version("rtl-buddy-axi-profiler")
+        pytest.skip("rtl-buddy-axi-profiler is installed; cannot exercise miss path")
+    except md.PackageNotFoundError:
+        pass
+
+    result = _run_rb("tool-check", "--required-for", "axi-profile", cwd=tmp_path)
+    assert result.returncode == 2
+
+
+def test_cli_tool_check_strict_exits_1_on_miss(tmp_path: Path):
+    """--strict must exit 1 if any required tool is missing."""
+    # As above — axi-profiler is the most reliably missing tool in CI.
+    if shutil.which("axi-profiler") is not None:
+        pytest.skip("axi-profiler is installed; cannot exercise miss path")
+    try:
+        from importlib import metadata as md
+
+        md.version("rtl-buddy-axi-profiler")
+        pytest.skip("rtl-buddy-axi-profiler is installed; cannot exercise miss path")
+    except md.PackageNotFoundError:
+        pass
+
+    result = _run_rb("tool-check", "--strict", "--no-probe-versions", cwd=tmp_path)
+    assert result.returncode == 1
+
+
+def test_cli_tool_check_default_exit_is_0(tmp_path: Path):
+    """Default behavior: no --strict, no --required-for → exit 0 always."""
+    result = _run_rb("tool-check", "--no-probe-versions", cwd=tmp_path)
+    assert result.returncode == 0


### PR DESCRIPTION
## Summary

- Adds `rb tool-check` — a status report covering every external binary, python sibling, and python extra that `rtl_buddy` calls into. Closes #204.
- Introduces a declarative manifest at `src/rtl_buddy/tool_manifest.py` that is also wired as a single source-of-truth for future docs / setup-script integration via `tool_manifest.require(name, root_cfg)`.
- Reconciles with `root_config.yaml`: vendor paths from `cfg-verible` / `cfg-surfer`, project `min-version:` pins from the new `cfg-tools` block, and FPV solver pins from `cfg-fpv-tools[*].opts.solver-versions` (matching the existing `fpv_solver_pin.check_solver_pins` runtime semantics).

## Catalogue (24 tools)

| Kind | Tools |
|---|---|
| External binary (required) | verible, yosys, verilator, surfer, git |
| External binary (optional) | gtkwave, graphviz/dot, openroad, klayout, sby, lcov, info-process, marimo |
| Python sibling | rtl-buddy-view, rtl-buddy-cdc, rtl-buddy-axi-profiler |
| Python extra | pyslang, cocotb |
| FPV solver engines (optional) | yices, z3, boolector, bitwuzla, btormc, abc |

Solver entries are built dynamically from `tools/fpv_solver_pin._PROBES` so the runtime pin check and the tool-check view share one binary/regex pair — adding a solver in one place updates the other.

## CLI surface

```
rb tool-check
       [--format text|json]
       [--required-for <subcommand>]
       [--explain <tool>]
       [--strict]
       [--include-optional/--no-include-optional]
       [--probe-versions/--no-probe-versions]
```

Exit codes: `0` default (report-only) or under `--strict` when all required tools are present; `1` under `--strict` on any required miss; `2` under `--required-for <sub>` when that subcommand's deps are missing. The JSON output also embeds the would-be exit code so CI can read it either way.

## Implementation notes

- `PythonSiblingDetector` returns both wheel version and binary path so the table shows `0.1.0 /…/.venv/bin/rtl-buddy-view` instead of just `(python)`.
- Version probing is cached in `~/.cache/rtl_buddy/tool_versions.json` keyed by binary mtime so repeated invocations don't re-fork.
- `rb tool-check` works outside a project — `root_config.yaml` discovery is opportunistic and silent.
- ASCII status strings (`ok` / `missing` / `outdated`) instead of Unicode glyphs for grep-friendly CI logs.

## Test plan

- [x] `uv run pytest` — 824 passed, 7 skipped (30 new tests in `tests/test_tool_manifest.py`)
- [x] `uv run ruff check` + `uv run ruff format --check`
- [x] `uv run python scripts/gen_cli_reference.py --check` — `docs/reference/cli.md` regenerated and in sync
- [x] Manual: `rb tool-check`, `rb tool-check --format json`, `rb tool-check --explain verible`, `rb tool-check --required-for hier`, `rb tool-check --strict` exercised against rtl-buddy-ai-project (20 ok / 1 missing) and outside any project
- [x] Manual: `cfg-tools` min-version pin + `cfg-fpv-tools.opts.solver-versions` reconciliation verified end-to-end (yices/z3 pinned to bogus versions surfaces as `outdated`)
- [ ] Reviewer to spot-check that the manifest covers their local tool list (`rb tool-check` against a project on their machine)

## Follow-ups (out of scope for this PR)

- Wire `tool_manifest.require()` into the existing subcommand wrappers so the "tool not found" UX is centralized (v2 in the issue).
- `scripts/gen_tools_reference.py` to emit the install matrix to `docs/reference/tools.md` (v3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)