### PR TITLE
feat(hub): event broker WS endpoint for SPA↔notebook sync (Phase 3)

### DIFF
--- a/src/rtl_buddy/hub/event_broker.py
+++ b/src/rtl_buddy/hub/event_broker.py
@@ -1,0 +1,123 @@
+"""In-memory pub/sub broker for SPA↔notebook state sync.
+
+Used by Phase 3 of the marimo umbrella (axi-profiler #16): the SPA's
+``AxiPerfView`` and a spawned marimo notebook each open a WebSocket
+to ``/api/events/sync``; clicking a bundle in the SPA reaches the
+notebook and brushing a time window in the notebook reaches the SPA.
+
+The broker treats every message as an opaque string. Topic routing
+and echo suppression (via a ``source`` field) live in the clients —
+the broker just relays each inbound message to every *other*
+connected client. Keeps the schema versionable without re-deploying
+the hub.
+
+Slow clients get bounded outbound queues: when full, the oldest
+queued message is dropped to make room. State-sync messages are
+throwaway — a stale ``selection`` is worthless once a fresh one has
+already arrived.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+
+from ..logging_utils import log_event
+
+logger = logging.getLogger(__name__)
+
+
+# Per-client outbound queue depth. 64 is enough to absorb a burst
+# from a chatty publisher without ballooning memory if a single slow
+# subscriber stalls.
+_CLIENT_QUEUE_MAX = 64
+
+
+@dataclass
+class BrokerClient:
+    """Handle the broker hands back to a connected WS handler.
+
+    The handler reads ``queue`` to forward messages downstream; the
+    broker writes to ``queue`` for every inbound from any peer.
+    """
+
+    queue: asyncio.Queue[str] = field(
+        default_factory=lambda: asyncio.Queue(maxsize=_CLIENT_QUEUE_MAX)
+    )
+    name: str = ""
+
+
+class EventBroker:
+    """Process-wide pub/sub fanout. Not thread-safe; single asyncio loop."""
+
+    def __init__(self) -> None:
+        self._clients: dict[int, BrokerClient] = {}
+        self._next_id: int = 0
+
+    def add_client(self, name: str = "") -> tuple[int, BrokerClient]:
+        client_id = self._next_id
+        self._next_id += 1
+        client = BrokerClient(name=name or f"c{client_id}")
+        self._clients[client_id] = client
+        log_event(
+            logger,
+            logging.DEBUG,
+            "hub.event_broker.client_added",
+            client_id=client_id,
+            name=client.name,
+            total=len(self._clients),
+        )
+        return client_id, client
+
+    def remove_client(self, client_id: int) -> None:
+        client = self._clients.pop(client_id, None)
+        if client is None:
+            return
+        log_event(
+            logger,
+            logging.DEBUG,
+            "hub.event_broker.client_removed",
+            client_id=client_id,
+            name=client.name,
+            total=len(self._clients),
+        )
+
+    def broadcast(self, sender_id: int, message: str) -> None:
+        """Push ``message`` to every connected client except ``sender_id``.
+
+        Drops the oldest queued message for any client whose queue
+        is full; logs a single warning per overflow event so a stuck
+        consumer is visible without flooding the log.
+        """
+        for client_id, client in self._clients.items():
+            if client_id == sender_id:
+                continue
+            self._enqueue(client, message)
+
+    @staticmethod
+    def _enqueue(client: BrokerClient, message: str) -> None:
+        try:
+            client.queue.put_nowait(message)
+            return
+        except asyncio.QueueFull:
+            pass
+        # Drop oldest, retry once. A second failure would require a
+        # concurrent producer on the same queue, which we don't have
+        # (single-loop), so the bare ``put_nowait`` below should always
+        # succeed.
+        try:
+            client.queue.get_nowait()
+        except asyncio.QueueEmpty:  # pragma: no cover - racy
+            pass
+        log_event(
+            logger,
+            logging.WARNING,
+            "hub.event_broker.queue_overflow",
+            name=client.name,
+        )
+        client.queue.put_nowait(message)
+
+    @property
+    def client_count(self) -> int:
+        return len(self._clients)

--- a/src/rtl_buddy/hub/viewer_http.py
+++ b/src/rtl_buddy/hub/viewer_http.py
@@ -37,6 +37,7 @@ from websockets.exceptions import ConnectionClosed
 from websockets.http11 import Request, Response
 
 from ..logging_utils import log_event
+from .event_broker import EventBroker
 
 
 logger = logging.getLogger(__name__)
@@ -215,6 +216,9 @@ class ViewerServer:
         # spawn — analogous to ``_model_locks`` for /view.json?model=.
         self._axi_notebook_sessions: dict[tuple[str, str], Any] = {}
         self._axi_notebook_locks: dict[tuple[str, str], asyncio.Lock] = {}
+        # Phase 3 SPA↔notebook sync. Opaque pub/sub — see
+        # ``event_broker.py`` for the relay semantics.
+        self._event_broker = EventBroker()
         self._server: Any | None = None
         self._bundle_index = self._resolve_bundle_index(viewer_bundle)
 
@@ -303,7 +307,7 @@ class ViewerServer:
 
         # WS upgrade?  Let websockets handle it.
         if request.headers.get("Upgrade", "").lower() == "websocket":
-            if path == "/ws":
+            if path in ("/ws", "/api/events/sync"):
                 return None
             return _http_response(connection, 404, b"unknown ws path")
 
@@ -681,6 +685,68 @@ class ViewerServer:
     # ------------------------------------------------------------------
 
     async def _handle_ws(self, ws: Any) -> None:
+        """Dispatch the WS handler by path.
+
+        ``/ws`` proxies hub envelopes (legacy). ``/api/events/sync``
+        joins the in-memory pub/sub broker for SPA↔notebook state
+        sync (Phase 3).
+        """
+        raw_path = getattr(getattr(ws, "request", None), "path", "/ws")
+        path, _, _ = raw_path.partition("?")
+        if path == "/api/events/sync":
+            await self._handle_event_sync_ws(ws)
+            return
+        await self._handle_ws_envelope_proxy(ws)
+
+    async def _handle_event_sync_ws(self, ws: Any) -> None:
+        """Bridge a WS client to the in-memory ``EventBroker``.
+
+        Every inbound message is broadcast to every other client.
+        The client's own outbound queue is drained by the writer
+        task. Disconnect cancels both tasks and removes the client
+        from the broker.
+        """
+        client_id, client = self._event_broker.add_client(name="ws")
+
+        async def reader() -> None:
+            try:
+                async for msg in ws:
+                    if isinstance(msg, bytes):
+                        try:
+                            text = msg.decode("utf-8")
+                        except UnicodeDecodeError:
+                            continue
+                    else:
+                        text = msg
+                    self._event_broker.broadcast(client_id, text)
+            except ConnectionClosed:
+                pass
+
+        async def writer() -> None:
+            try:
+                while True:
+                    msg = await client.queue.get()
+                    await ws.send(msg)
+            except ConnectionClosed:
+                pass
+
+        tasks = [
+            asyncio.create_task(reader(), name="event-sync-reader"),
+            asyncio.create_task(writer(), name="event-sync-writer"),
+        ]
+        try:
+            _, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+            for t in pending:
+                t.cancel()
+            for t in tasks:
+                try:
+                    await t
+                except (asyncio.CancelledError, Exception):
+                    pass
+        finally:
+            self._event_broker.remove_client(client_id)
+
+    async def _handle_ws_envelope_proxy(self, ws: Any) -> None:
         """Proxy a WS connection to the hub's TCP port.
 
         Each WebSocket message is one hub envelope. Inbound (WS → hub)

--- a/tests/test_hub_event_broker.py
+++ b/tests/test_hub_event_broker.py
@@ -1,0 +1,155 @@
+"""Tests for the SPA↔notebook event broker (Phase 3 of axi-profiler #16).
+
+Splits in two layers: the in-memory ``EventBroker`` (pure asyncio queue
+fan-out, no IO) and the ``/api/events/sync`` WS endpoint on
+``ViewerServer`` (round-trip through ``websockets.serve``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+import websockets
+
+from rtl_buddy.hub.event_broker import EventBroker, _CLIENT_QUEUE_MAX
+from rtl_buddy.hub.viewer_http import ViewerServer
+
+
+# ---------------------------------------------------------------------
+# EventBroker (no IO)
+# ---------------------------------------------------------------------
+
+
+def test_broadcast_reaches_other_clients_not_sender() -> None:
+    async def go() -> None:
+        broker = EventBroker()
+        a_id, a = broker.add_client(name="a")
+        b_id, b = broker.add_client(name="b")
+        c_id, c = broker.add_client(name="c")
+
+        broker.broadcast(a_id, "hello")
+
+        assert b.queue.get_nowait() == "hello"
+        assert c.queue.get_nowait() == "hello"
+        assert a.queue.empty()
+        # _id values are returned so the handler can call remove_client.
+        assert {a_id, b_id, c_id} == {0, 1, 2}
+
+    asyncio.run(go())
+
+
+def test_remove_client_unsubscribes_and_count_tracks() -> None:
+    async def go() -> None:
+        broker = EventBroker()
+        a_id, _ = broker.add_client()
+        b_id, b = broker.add_client()
+        assert broker.client_count == 2
+
+        broker.remove_client(a_id)
+        assert broker.client_count == 1
+
+        broker.broadcast(b_id, "x")  # only A would have received it
+        assert b.queue.empty()
+
+        # Removing an unknown id is a no-op.
+        broker.remove_client(999)
+        assert broker.client_count == 1
+
+    asyncio.run(go())
+
+
+def test_full_queue_drops_oldest_and_keeps_latest() -> None:
+    async def go() -> None:
+        broker = EventBroker()
+        sender_id, _ = broker.add_client(name="sender")
+        _, slow = broker.add_client(name="slow")
+
+        for i in range(_CLIENT_QUEUE_MAX + 5):
+            broker.broadcast(sender_id, f"m{i}")
+
+        # Drained order: oldest 5 messages were evicted; queue still holds
+        # exactly _CLIENT_QUEUE_MAX latest messages, ending with m{N-1}.
+        drained = []
+        while not slow.queue.empty():
+            drained.append(slow.queue.get_nowait())
+        assert len(drained) == _CLIENT_QUEUE_MAX
+        assert drained[0] == "m5"
+        assert drained[-1] == f"m{_CLIENT_QUEUE_MAX + 4}"
+
+    asyncio.run(go())
+
+
+# ---------------------------------------------------------------------
+# /api/events/sync end-to-end (real websockets server)
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_two_clients_receive_each_others_messages_not_their_own() -> None:
+    server = ViewerServer(hub_host="127.0.0.1", hub_port=1, http_port=0)
+    host, port = await server.start()
+    try:
+        url = f"ws://{host}:{port}/api/events/sync"
+        async with (
+            websockets.connect(url) as ws_a,
+            websockets.connect(url) as ws_b,
+        ):
+            # Give the server a moment to register both clients before
+            # publishing — otherwise B might miss A's first message.
+            for _ in range(20):
+                if server._event_broker.client_count == 2:
+                    break
+                await asyncio.sleep(0.01)
+            assert server._event_broker.client_count == 2
+
+            payload = json.dumps(
+                {"topic": "selection", "data": {"bundle": "axi_xbar"}, "source": "spa"}
+            )
+            await ws_a.send(payload)
+            got_b = await asyncio.wait_for(ws_b.recv(), timeout=2.0)
+            assert got_b == payload
+
+            # A should not get its own message back.
+            with pytest.raises(asyncio.TimeoutError):
+                await asyncio.wait_for(ws_a.recv(), timeout=0.2)
+    finally:
+        await server.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_disconnect_removes_client_from_broker() -> None:
+    server = ViewerServer(hub_host="127.0.0.1", hub_port=1, http_port=0)
+    host, port = await server.start()
+    try:
+        url = f"ws://{host}:{port}/api/events/sync"
+        async with websockets.connect(url):
+            for _ in range(20):
+                if server._event_broker.client_count == 1:
+                    break
+                await asyncio.sleep(0.01)
+            assert server._event_broker.client_count == 1
+        # After ``async with`` exits, the close propagates; the server
+        # cleanup runs in the handler's ``finally``.
+        for _ in range(50):
+            if server._event_broker.client_count == 0:
+                break
+            await asyncio.sleep(0.01)
+        assert server._event_broker.client_count == 0
+    finally:
+        await server.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_unknown_ws_path_is_404() -> None:
+    server = ViewerServer(hub_host="127.0.0.1", hub_port=1, http_port=0)
+    host, port = await server.start()
+    try:
+        url = f"ws://{host}:{port}/ws-does-not-exist"
+        with pytest.raises(websockets.exceptions.InvalidStatus) as ei:
+            async with websockets.connect(url):
+                pass
+        assert ei.value.response.status_code == 404
+    finally:
+        await server.shutdown()


### PR DESCRIPTION
## Summary

- New WebSocket endpoint `/api/events/sync` on the viewer HTTP port; in-memory pub/sub via `EventBroker` (`src/rtl_buddy/hub/event_broker.py`).
- Inbound messages from any client relay to every *other* connected client. The broker is dumb: payloads are opaque strings, so the SPA and the marimo notebook can iterate the wire schema (`topic` + `source` for echo suppression) without redeploying the hub.
- Bounded per-client outbound queue (64 messages, configurable via `_CLIENT_QUEUE_MAX`). On overflow the oldest message is dropped — state-sync events are throwaway and a stuck consumer must not stall the broker.

## Why Phase 3

Phase 3 of the marimo umbrella (axi-profiler #16) is bidirectional state sync: SPA bundle-click → notebook filter, notebook brush → SPA time-window chip. Both ends already share the hub as the single thing they both connect to, so a small broker there is the cleanest fit. PR-H (rtl-buddy-view SPA) and PR-I (axi-profiler notebook template) land on top of this.

## Test plan
- [x] `uv run pytest tests/test_hub_event_broker.py` — 6 new tests:
  - `EventBroker` unit: fan-out skips sender, remove_client unsubscribes, full queue drops oldest.
  - `ViewerServer` end-to-end via real `websockets.serve` / `websockets.connect`: two clients receive each other's messages but not their own, disconnect removes from broker, unknown WS path is 404.
- [x] `uv run pytest tests/` — 835 passed, 10 skipped (no regression on `/ws` envelope proxy or `/api/axi-profile/notebook`).
- [x] `uv run ruff check` + `uv run ruff format --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)