### PR TITLE
feat(machine): standardise --machine stdout JSON envelope across all commands

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,14 +1,44 @@
 ---
-description: How to run rtl_buddy effectively from an AI agent, including local docs access, machine mode, log formats, and the recommended validation workflow.
+description: How rtl_buddy is built for AI-agent use — the bundled skill, local docs access, machine mode, and the structured log and stdout contracts agents can rely on.
 ---
 
-# For Agents
+# Agent use of rtl-buddy
 
-Use this page to run `rtl_buddy` effectively from an AI agent, including local docs access, machine mode, log formats, and the recommended validation workflow.
+`rtl_buddy` is designed to be driven by AI coding agents as well as humans. This page describes the affordances that make agent integration practical:
+
+- a **bundled agent skill** that installs into Claude Code and Codex,
+- **local docs access** through the `rtl-buddy docs` command, so reference material always matches the installed version,
+- a **machine mode** (`--machine`) that switches the orchestration log to JSON Lines and emits a stable stdout envelope on exit,
+- and deterministic [exit codes](concepts/tests.md#exit-codes) that let an orchestrator distinguish test failures from configuration errors.
+
+## Bundled agent skill
+
+The `rtl_buddy` wheel ships an agent skill that teaches Claude Code and Codex the conventions for invoking `rtl_buddy` — when to use `--machine`, where logs are written, how multi-suite runs lay out artefacts, and which docs to consult. Because the skill ships with the wheel, its content is locked to the installed `rtl_buddy` major version.
+
+Users materialize the skill once with `rtl-buddy skill install`:
+
+```bash
+rtl-buddy skill install             # default: user-level
+rtl-buddy skill install --project   # project-level (overrides user-level for that project)
+rtl-buddy skill uninstall           # remove skill files
+```
+
+See [cli reference](reference/cli.md) for full `rb skill` interface.
+
+Install targets:
+
+| Scope | Claude Code | Codex |
+|-------|-------------|-------|
+| User (default) | `~/.claude/skills/rtl_buddy/SKILL.md` | `~/.codex/skills/rtl_buddy/SKILL.md` |
+| Project (`--project`) | `<root>/.claude/skills/rtl_buddy/SKILL.md` | `<root>/.agents/skills/rtl_buddy/SKILL.md` |
+
+User-level is the default because the skill is workflow-pattern guidance that changes rarely across `rtl_buddy` versions; a single copy per machine encourages keeping `rtl_buddy` aligned across projects. Project-level installs are an opt-in override for projects pinned to a divergent `rtl_buddy` major — Claude Code's resolution order puts the project copy first, so both scopes can coexist.
+
+For project-level installs, the install command prints the `.gitignore` lines to add. Project root is discovered by walking up for `root_config.yaml` (falling back to `.git/`), so `rtl-buddy skill install --project` is safe to run from a `verif/` subdirectory.
 
 ## Local docs access
 
-Use the bundled docs commands first when you need CLI or YAML reference:
+The wheel ships the full Markdown docs site alongside the CLI, exposed through:
 
 ```bash
 rtl-buddy docs list
@@ -16,76 +46,26 @@ rtl-buddy docs show agents
 rtl-buddy --machine docs show reference/yaml
 ```
 
-`docs list` shows each page's slug, title, and summary. `docs show --machine` returns lightweight metadata plus the canonical Markdown for the selected page. GitHub Pages remains a convenient human-facing fallback.
+This is the recommended reference surface for agents: the docs are local (no network), and their content always matches the installed version of `rtl_buddy`. `docs list` enumerates each page's slug, title, and description; `docs show` returns the canonical Markdown for a single page. GitHub Pages at <https://rtl-buddy.github.io/rtl_buddy/> remains available as a human-facing fallback.
 
-## Agent Skill Install
+## Machine mode
 
-The `rtl_buddy` wheel bundles an agent skill for Claude Code and Codex. Users run a one-time install to materialize it into their agent skill directories:
+Passing `--machine` switches `rtl_buddy` into a mode designed for programmatic consumption:
 
-```bash
-rtl-buddy skill install             # default: user-level
-rtl-buddy skill install --project   # project-level (overrides user-level for that project)
-rtl-buddy skill install --root PATH # explicit target (implies project-level layout)
-rtl-buddy skill status              # report installed version vs current
-rtl-buddy skill uninstall           # remove skill files
-```
+- `rtl_buddy.log` is written as **JSON Lines** instead of human-readable text.
+- Console output drops Rich formatting, colors, and spinners.
+- Commands that produce structured results print a single JSON envelope to **stdout** on exit.
 
-Targets:
-
-| Scope | Claude Code | Codex |
-|-------|-------------|-------|
-| User (default) | `~/.claude/skills/rtl_buddy/SKILL.md` | `~/.codex/skills/rtl_buddy/SKILL.md` |
-| Project (`--project`) | `<root>/.claude/skills/rtl_buddy/SKILL.md` | `<root>/.agents/skills/rtl_buddy/SKILL.md` |
-
-User-level is the recommended default — one install per machine, one place to keep current. Project-level is an opt-in override for projects pinned to a divergent `rtl_buddy` major; Claude Code's resolution order puts the project copy first, so both can coexist.
-
-For project-level installs, add the target dirs to your project's `.gitignore` — the install command prints the exact lines. `rtl-buddy skill install --project` discovers the project root via `root_config.yaml` (falling back to `.git/`), so it is safe to run from a `verif/` subdirectory.
-
-## Always use machine mode
-
-Run `rtl_buddy` with `--machine` in all agent-driven workflows:
+The intent is that an orchestrator can determine the outcome of a run by parsing the stdout envelope, and reconstruct timing or per-event detail from `rtl_buddy.log`, without screen-scraping human-formatted output.
 
 ```bash
 rtl-buddy --machine test basic
 rtl-buddy --machine regression -c design/regression.yaml
 ```
 
-In machine mode:
+### Stdout envelope
 
-- `rtl_buddy.log` is written as **JSON Lines** (one JSON object per line) instead of human-readable text.
-- Console output switches to plain, colorless text — no Rich formatting, no spinners.
-- All structured event fields (event name, status, durations, paths) are present in the log.
-
-This makes it reliable to parse outcomes from `rtl_buddy.log` without screen-scraping.
-
-## Working directory rules
-
-Use the command from the directory that matches its scope:
-
-- Run single-suite commands such as `test`, `randtest`, `wave`, and `fpv` from the suite directory that contains the relevant `tests.yaml` or `fpv.yaml`.
-- Run project-wide commands such as `regression`, `synth-regression`, `cdc-regression`, `fpv-regression`, `spec ...`, and `docs ...` from the project root unless you are intentionally narrowing scope.
-- Multi-suite commands change into each suite as they execute, so their `rtl_buddy.log` and `artefacts/` outputs are written per suite, not only in the repo-root directory where you launched the command.
-
-## Log file locations
-
-| File | Description |
-|------|-------------|
-| `rtl_buddy.log` | Orchestration log; JSONL in machine mode, human-readable otherwise |
-| `artefacts/{test_name}/test.log` | Simulation stdout for each test |
-| `artefacts/{test_name}/test.err` | Simulation stderr for each test |
-| `artefacts/{test_name}/test.randseed` | Seed used for this test run |
-| `artefacts/{test_name}/coverage.dat` | Coverage database (if coverage is enabled) |
-| `artefacts/{test_name}/compile.log` | Compile transcript |
-| `artefacts/{test_name}/run-NNNN/test.log` | Per-iteration output for `randtest` |
-| `test.log` | Symlink to the most recent test's log |
-| `test.err` | Symlink to the most recent test's stderr |
-| `test.randseed` | Symlink to the most recent test's seed |
-
-For single-suite commands, these files are written relative to the suite directory where you ran `rtl_buddy`. For multi-suite commands such as `regression`, each suite gets its own `rtl_buddy.log`, `artefacts/`, and latest-run symlinks inside that suite directory even though the command was launched from the project root.
-
-## Machine mode stdout envelope
-
-In machine mode, commands that produce structured results print a single JSON object to **stdout** on exit:
+In machine mode, structured-result commands print a single JSON object to stdout on exit:
 
 ```json
 {
@@ -97,115 +77,42 @@ In machine mode, commands that produce structured results print a single JSON ob
     "cwd": "/path/to/suite",
     "git": {"branch": "main", "commit": "abc1234", "modified": 0, "staged": 0}
   },
-  "results": [
-    {"name": "basic", "result": "PASS", "desc": "basic completed"}
-  ]
+  "payload": {
+    "results": [
+      {"name": "basic", "result": "PASS", "desc": "basic completed"}
+    ]
+  }
 }
 ```
 
-The envelope fields are the same across all commands:
+The envelope shape is the same across commands:
 
-- `command`: the subcommand that was run (e.g. `"test"`, `"regression"`, `"synth"`)
-- `exit_code`: integer exit code (0 = all pass, 1 = at least one failure)
-- `meta`: version, argv, working directory, and git status at invocation
-- Additional payload fields vary by command (e.g. `results`, `names`, `blocks`, `items`)
+- `command` — the subcommand that was run (`"test"`, `"regression"`, `"synth"`, …).
+- `exit_code` — integer exit code (see [exit codes](concepts/tests.md#exit-codes)).
+- `meta` — version, argv, working directory, and git status at invocation.
+- `payload` — command-specific structured data.
 
-Commands that emit a `--list` output (e.g. `test --list`, `synth --list`) include a `names` array. Regression commands include a `results` array with a `"suite"` field on each entry.
+The top-level envelope fields are reserved and versioned by `meta.rtl_buddy_version` under `rtl_buddy`'s normal semantic-versioning rules. Adding optional fields under `meta` or `payload` is non-breaking; removing fields, renaming fields, changing field types, or changing the meaning of an existing field is breaking.
 
-The `docs` commands (`docs list`, `docs show`) are excluded from this envelope — they output lightweight bare JSON (e.g. `{"pages": [...]}`, `{"slug": ..., "content": ...}`) since their primary payload is already Markdown text.
+Conventions inside `payload`:
 
-## Machine mode log format
+- `--list` commands (`test --list`, `synth --list`, …) populate `payload.names`.
+- Regression commands populate `payload.results`, with a `"suite"` field on each entry.
+- `docs list` populates `payload.pages` with `slug`, `title`, and `description` from page frontmatter.
 
-Each line in `rtl_buddy.log` (machine mode) is a JSON object:
+### JSONL log format
+
+In machine mode, each line of `rtl_buddy.log` is a JSON object describing one event:
 
 ```json
 {"event": "sim.completed", "test": "smoke", "duration_sec": 4.2, "message": "smoke: simulation completed in 4.20s"}
 {"event": "postproc.completed", "test": "smoke", "result": "PASS", "desc": "smoke completed", "message": "smoke: post-processing completed with result PASS (smoke completed)"}
 ```
 
-Key fields:
+Common fields:
 
-- `event`: dotted event name identifying what happened (e.g. `sim.start`, `compile.failed`, `postproc.completed`)
-- `message`: the human-readable message corresponding to the event
-- Other fields are event-specific (name, duration, seed, exit code, etc.)
+- `event` — dotted event name identifying what happened (`sim.start`, `compile.failed`, `postproc.completed`, …).
+- `message` — the human-readable rendering of the event.
+- Event-specific fields — test name, duration, seed, exit code, file paths, etc.
 
-## How pass/fail is detected
-
-Agents authoring tests need to follow the parser that `rtl_buddy` actually uses:
-
-- If `tests.yaml` sets `uvm:`, `rtl_buddy` parses the UVM Report Summary and compares it against `max_warns` / `max_errors`.
-- Otherwise, `rtl_buddy` parses `artefacts/{test_name}/test.log` and expects one stdout line starting with `PASS` or `FAIL`.
-- When emitting `FAIL`, also print an `ERR:` or `FAT:` line because the default failure parser expects it.
-- If neither `PASS` nor `FAIL` appears, the test result becomes `NA`.
-- Do not rely on simulator exit code alone for non-UVM pass/fail signalling.
-
-Minimal non-UVM example:
-
-```systemverilog
-if (test_passed) begin
-  $display("PASS smoke completed");
-end else begin
-  $display("FAIL smoke completed");
-  $display("ERR: expected done=1 before timeout");
-end
-```
-
-In machine mode, the authoritative per-test outcome appears in the `postproc.completed` event's `result` and `desc` fields.
-
-## Spec traceability commands
-
-The `rb spec` commands check the spec-to-test traceability layer. They do not affect simulation and are safe to run at any time:
-
-```bash
-# List all spec blocks discovered in the project
-rtl-buddy --machine spec list
-
-# Check which spec blocks have a linked design model (models.yaml spec: pointer)
-rtl-buddy --machine spec check-design
-
-# Check which coverage items are addressed by at least one test (tests.yaml covers:)
-rtl-buddy --machine spec check-coverage
-```
-
-In machine mode, `spec list` returns the standard JSON envelope with `"blocks": [...]` and `spec check-coverage` returns one with `"items": [...]` — each item has a `"covered": true/false` field. Use these to identify uncovered items programmatically. See [Machine mode stdout envelope](#machine-mode-stdout-envelope) for the wrapper shape.
-
-All three commands default to searching `spec/`, `design/`, and `verif/` under the project root. Pass `--spec-dir`, `--design-dir`, or `--verif-dir` to narrow the scope.
-
-## Recommended validation workflow
-
-```bash
-# 1. Check rtl_buddy version
-rtl-buddy --version
-
-# 2. Dry-run: verify pre-flight config without compiling or simulating
-rtl-buddy --machine test basic --early-stop pre
-
-# 3. Run a single test
-rtl-buddy --machine test basic
-
-# 4. Check the log for outcome
-grep '"event"' rtl_buddy.log | tail -5
-
-# 5. Run a full regression
-rtl-buddy --machine regression -c design/regression.yaml
-```
-
-Use `--early-stop pre` to validate that config files, model paths, and testbench paths all resolve correctly before committing to a compile step.
-
-## Exit codes
-
-| Code | Meaning |
-|------|---------|
-| 0 | All tests passed |
-| 1 | One or more tests failed |
-| 2 | Fatal configuration or environment error |
-
-## Version checking
-
-Always verify the installed version before running, especially in CI or after dependency updates:
-
-```bash
-rtl-buddy --version
-```
-
-The version follows semantic versioning. Breaking YAML schema or CLI changes are signaled by a major version bump.
+The authoritative per-test outcome is the `postproc.completed` event's `result` and `desc` fields. For multi-suite commands, each suite directory gets its own `rtl_buddy.log`.

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -83,6 +83,35 @@ Use the command from the directory that matches its scope:
 
 For single-suite commands, these files are written relative to the suite directory where you ran `rtl_buddy`. For multi-suite commands such as `regression`, each suite gets its own `rtl_buddy.log`, `artefacts/`, and latest-run symlinks inside that suite directory even though the command was launched from the project root.
 
+## Machine mode stdout envelope
+
+In machine mode, commands that produce structured results print a single JSON object to **stdout** on exit:
+
+```json
+{
+  "command": "test",
+  "exit_code": 0,
+  "meta": {
+    "rtl_buddy_version": "2.4.0",
+    "argv": ["rtl-buddy", "--machine", "test", "basic"],
+    "cwd": "/path/to/suite",
+    "git": {"branch": "main", "commit": "abc1234", "modified": 0, "staged": 0}
+  },
+  "results": [
+    {"name": "basic", "result": "PASS", "desc": "basic completed"}
+  ]
+}
+```
+
+The envelope fields are the same across all commands:
+
+- `command`: the subcommand that was run (e.g. `"test"`, `"regression"`, `"synth"`)
+- `exit_code`: integer exit code (0 = all pass, 1 = at least one failure)
+- `meta`: version, argv, working directory, and git status at invocation
+- Additional payload fields vary by command (e.g. `results`, `names`, `pages`, `blocks`, `items`)
+
+Commands that emit a `--list` output (e.g. `test --list`, `synth --list`) include a `names` array. Regression commands include a `results` array with a `"suite"` field on each entry.
+
 ## Machine mode log format
 
 Each line in `rtl_buddy.log` (machine mode) is a JSON object:
@@ -136,7 +165,7 @@ rtl-buddy --machine spec check-design
 rtl-buddy --machine spec check-coverage
 ```
 
-In machine mode, `spec list` returns `{"blocks": [...]}` and `spec check-coverage` returns `{"items": [...]}` with a `"covered": true/false` field per item. Use these to identify uncovered items programmatically.
+In machine mode, all three commands return the standard JSON envelope (see [Machine mode stdout envelope](#machine-mode-stdout-envelope)). `spec list` includes `"blocks": [...]` and `spec check-coverage` includes `"items": [...]` with a `"covered": true/false` field per item. Use these to identify uncovered items programmatically.
 
 All three commands default to searching `spec/`, `design/`, and `verif/` under the project root. Pass `--spec-dir`, `--design-dir`, or `--verif-dir` to narrow the scope.
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -108,9 +108,11 @@ The envelope fields are the same across all commands:
 - `command`: the subcommand that was run (e.g. `"test"`, `"regression"`, `"synth"`)
 - `exit_code`: integer exit code (0 = all pass, 1 = at least one failure)
 - `meta`: version, argv, working directory, and git status at invocation
-- Additional payload fields vary by command (e.g. `results`, `names`, `pages`, `blocks`, `items`)
+- Additional payload fields vary by command (e.g. `results`, `names`, `blocks`, `items`)
 
 Commands that emit a `--list` output (e.g. `test --list`, `synth --list`) include a `names` array. Regression commands include a `results` array with a `"suite"` field on each entry.
+
+The `docs` commands (`docs list`, `docs show`) are excluded from this envelope — they output lightweight bare JSON (e.g. `{"pages": [...]}`, `{"slug": ..., "content": ...}`) since their primary payload is already Markdown text.
 
 ## Machine mode log format
 
@@ -165,7 +167,7 @@ rtl-buddy --machine spec check-design
 rtl-buddy --machine spec check-coverage
 ```
 
-In machine mode, all three commands return the standard JSON envelope (see [Machine mode stdout envelope](#machine-mode-stdout-envelope)). `spec list` includes `"blocks": [...]` and `spec check-coverage` includes `"items": [...]` with a `"covered": true/false` field per item. Use these to identify uncovered items programmatically.
+In machine mode, `spec list` returns the standard JSON envelope with `"blocks": [...]` and `spec check-coverage` returns one with `"items": [...]` — each item has a `"covered": true/false` field. Use these to identify uncovered items programmatically. See [Machine mode stdout envelope](#machine-mode-stdout-envelope) for the wrapper shape.
 
 All three commands default to searching `spec/`, `design/`, and `verif/` under the project root. Pass `--spec-dir`, `--design-dir`, or `--verif-dir` to narrow the scope.
 

--- a/docs/concepts/tests.md
+++ b/docs/concepts/tests.md
@@ -116,6 +116,16 @@ The transcript parser is not the only source of failures. `rtl_buddy` also marks
 - compilation fails
 - simulation times out
 
+### Exit codes
+
+`rtl_buddy` returns one of three exit codes from test commands:
+
+| Code | Meaning |
+|------|---------|
+| 0 | All tests passed |
+| 1 | One or more tests failed |
+| 2 | Fatal configuration or environment error |
+
 ## Running tests
 
 Run a named test:

--- a/src/rtl_buddy/docs_access.py
+++ b/src/rtl_buddy/docs_access.py
@@ -27,7 +27,7 @@ class DocsPage:
         return {
             "slug": self.slug,
             "title": self.title,
-            "summary": self.summary,
+            "description": self.summary,
         }
 
     def to_show_payload(self) -> dict:

--- a/src/rtl_buddy/rtl_buddy.py
+++ b/src/rtl_buddy/rtl_buddy.py
@@ -110,7 +110,24 @@ class RtlBuddy:
 
     def cb_version(value: bool):
         if value:
-            print(f"rtl_buddy v{version('rtl-buddy')}")
+            if "--machine" in sys.argv:
+                print(
+                    json.dumps(
+                        {
+                            "command": "version",
+                            "exit_code": 0,
+                            "meta": {
+                                "rtl_buddy_version": version("rtl-buddy"),
+                                "argv": sys.argv[:],
+                                "cwd": os.getcwd(),
+                                "git": None,
+                            },
+                        },
+                        ensure_ascii=True,
+                    )
+                )
+            else:
+                print(f"rtl_buddy v{version('rtl-buddy')}")
             raise typer.Exit()
 
     def __init__(self, name):
@@ -586,9 +603,14 @@ class RtlBuddy:
         )
 
         if list_tests:
-            emit_console_text(
-                "  ".join(self.suite_cfg.get_test_names()), stream="stdout"
-            )
+            if self.machine:
+                self._emit_machine_result(
+                    "test --list", 0, names=list(self.suite_cfg.get_test_names())
+                )
+            else:
+                emit_console_text(
+                    "  ".join(self.suite_cfg.get_test_names()), stream="stdout"
+                )
             raise typer.Exit(0)
 
         seed_mode: SeedMode = SeedMode.DEFAULT
@@ -624,10 +646,25 @@ class RtlBuddy:
                 dir_summary_paths=dir_summary_paths,
             )
         )
-        self._render_test_summary(
-            "Test Results Summary", suite_results, metadata=metadata
-        )
-        raise typer.Exit(self._exit_code_from_results(suite_results))
+        exit_code = self._exit_code_from_results(suite_results)
+        if self.machine:
+            self._emit_machine_result(
+                "test",
+                exit_code,
+                results=[
+                    {
+                        "name": r["test_name"],
+                        "result": r["results"].results["result"],
+                        "desc": r["results"].results["desc"],
+                    }
+                    for r in suite_results
+                ],
+            )
+        else:
+            self._render_test_summary(
+                "Test Results Summary", suite_results, metadata=metadata
+            )
+        raise typer.Exit(exit_code)
 
     def do_rand_test(
         self,
@@ -679,12 +716,13 @@ class RtlBuddy:
                 seed_mode=SeedMode.REPLAY,
                 replay_run_id=rpt_i,
             )
-            self._render_test_summary(
-                "RandTest Replay Summary",
-                suite_results,
-                include_run_id=True,
-                metadata=[f"Builder: {self.builder}"],
-            )
+            if not self.machine:
+                self._render_test_summary(
+                    "RandTest Replay Summary",
+                    suite_results,
+                    include_run_id=True,
+                    metadata=[f"Builder: {self.builder}"],
+                )
         else:
             suite_results = self._do_test_suite(
                 self.suite_cfg,
@@ -693,14 +731,30 @@ class RtlBuddy:
                 seed_mode=SeedMode.NEW,
                 replay_run_id=None,
             )
-            self._render_test_summary(
-                "RandTest Results Summary",
-                suite_results,
-                include_run_id=True,
-                metadata=[f"Builder: {self.builder}"],
-            )
+            if not self.machine:
+                self._render_test_summary(
+                    "RandTest Results Summary",
+                    suite_results,
+                    include_run_id=True,
+                    metadata=[f"Builder: {self.builder}"],
+                )
 
-        raise typer.Exit(self._exit_code_from_results(suite_results))
+        exit_code = self._exit_code_from_results(suite_results)
+        if self.machine:
+            self._emit_machine_result(
+                "randtest",
+                exit_code,
+                results=[
+                    {
+                        "name": r["test_name"],
+                        "run_id": r["randmode_i"],
+                        "result": r["results"].results["result"],
+                        "desc": r["results"].results["desc"],
+                    }
+                    for r in suite_results
+                ],
+            )
+        raise typer.Exit(exit_code)
 
     def _append_skip_results(self, test_name, desc, run_ids, suite_results):
         test_results = SkipResults(name=test_name + "/results", desc=desc)
@@ -1106,7 +1160,23 @@ class RtlBuddy:
                 )
             )
 
-        self._render_regression_summary(reg_results, metadata=metadata)
+        if self.machine:
+            self._emit_machine_result(
+                "regression",
+                exit_code,
+                results=[
+                    {
+                        "suite": reg_result["test_suite"],
+                        "name": suite_result["test_name"],
+                        "result": suite_result["results"].results["result"],
+                        "desc": suite_result["results"].results["desc"],
+                    }
+                    for reg_result in reg_results
+                    for suite_result in reg_result["results"]
+                ],
+            )
+        else:
+            self._render_regression_summary(reg_results, metadata=metadata)
         raise typer.Exit(exit_code)
 
     def do_gen_model_filelist(
@@ -1549,7 +1619,7 @@ class RtlBuddy:
     def do_docs_list(self):
         pages = [page.to_list_item() for page in list_pages()]
         if self.machine:
-            print(json.dumps({"pages": pages}, ensure_ascii=True))
+            self._emit_machine_result("docs list", 0, pages=pages)
             return
 
         for page in pages:
@@ -1576,7 +1646,7 @@ class RtlBuddy:
                     f"Unknown section '{anchor}' in page '{page_slug}'. Run `rtl-buddy docs show {page_slug}` to see available sections."
                 )
             if self.machine:
-                print(json.dumps(section, ensure_ascii=True))
+                self._emit_machine_result("docs show", 0, **section)
                 return
             print(section["content"])
             return
@@ -1588,7 +1658,7 @@ class RtlBuddy:
             )
 
         if self.machine:
-            print(json.dumps(page.to_show_payload(), ensure_ascii=True))
+            self._emit_machine_result("docs show", 0, **page.to_show_payload())
             return
 
         print(page.content, end="" if page.content.endswith("\n") else "\n")
@@ -1615,30 +1685,33 @@ class RtlBuddy:
 
         if not os.path.isdir(search_dir):
             emit_console_text(f"Spec directory not found: {search_dir}", style="yellow")
+            if self.machine:
+                self._emit_machine_result(
+                    "spec list", 1, error="Spec directory not found"
+                )
             raise typer.Exit(1)
 
         specs = discover_spec_configs(search_dir)
         blocks = all_spec_blocks(specs)
         if not blocks:
             emit_console_text("No spec blocks found.", style="yellow")
+            if self.machine:
+                self._emit_machine_result("spec list", 0, blocks=[])
             raise typer.Exit(0)
 
         if self.machine:
-            print(
-                json.dumps(
+            self._emit_machine_result(
+                "spec list",
+                0,
+                blocks=[
                     {
-                        "blocks": [
-                            {
-                                "block": b.name,
-                                "desc": b.desc,
-                                "path": cfg.get_path(),
-                                "coverage_items": len(b.coverage_items),
-                            }
-                            for cfg, b in blocks
-                        ]
-                    },
-                    ensure_ascii=True,
-                )
+                        "block": b.name,
+                        "desc": b.desc,
+                        "path": cfg.get_path(),
+                        "coverage_items": len(b.coverage_items),
+                    }
+                    for cfg, b in blocks
+                ],
             )
             raise typer.Exit(0)
 
@@ -1702,27 +1775,24 @@ class RtlBuddy:
         spec_to_models = build_spec_to_models_map(specs, models)
 
         if self.machine:
-            print(
-                json.dumps(
+            self._emit_machine_result(
+                "spec check-testplan",
+                0,
+                blocks=[
                     {
-                        "blocks": [
-                            {
-                                "block": b.name,
-                                "has_model": bool(
-                                    spec_to_models.get(f"{cfg.get_path()}::{b.name}")
-                                ),
-                                "models": [
-                                    {"path": p, "model": m}
-                                    for p, m in spec_to_models.get(
-                                        f"{cfg.get_path()}::{b.name}", []
-                                    )
-                                ],
-                            }
-                            for cfg, b in blocks
-                        ]
-                    },
-                    ensure_ascii=True,
-                )
+                        "block": b.name,
+                        "has_model": bool(
+                            spec_to_models.get(f"{cfg.get_path()}::{b.name}")
+                        ),
+                        "models": [
+                            {"path": p, "model": m}
+                            for p, m in spec_to_models.get(
+                                f"{cfg.get_path()}::{b.name}", []
+                            )
+                        ],
+                    }
+                    for cfg, b in blocks
+                ],
             )
             raise typer.Exit(0)
 
@@ -1791,20 +1861,20 @@ class RtlBuddy:
         cov_map = build_coverage_map(suite_tests)
 
         if self.machine:
-            items_out = []
-            for cfg, b in blocks:
-                for item in b.coverage_items:
-                    tests = cov_map.get(item.id, [])
-                    items_out.append(
-                        {
-                            "block": b.name,
-                            "id": item.id,
-                            "desc": item.desc,
-                            "covered": bool(tests),
-                            "tests": [{"path": p, "test": t} for p, t in tests],
-                        }
-                    )
-            print(json.dumps({"items": items_out}, ensure_ascii=True))
+            items_out = [
+                {
+                    "block": b.name,
+                    "id": item.id,
+                    "desc": item.desc,
+                    "covered": bool(cov_map.get(item.id)),
+                    "tests": [
+                        {"path": p, "test": t} for p, t in cov_map.get(item.id, [])
+                    ],
+                }
+                for cfg, b in blocks
+                for item in b.coverage_items
+            ]
+            self._emit_machine_result("spec check-coverage", 0, items=items_out)
             raise typer.Exit(0)
 
         rows = []
@@ -1839,6 +1909,56 @@ class RtlBuddy:
                 f"Uncovered items: {', '.join(uncovered)}", style="yellow"
             )
         raise typer.Exit(0)
+
+    def _synth_result_row(self, r, *, suite: str | None = None) -> dict:
+        res = r["results"].results
+        row = {"name": r["synth_name"], "result": res["result"], "desc": res["desc"]}
+        if suite is not None:
+            row["suite"] = suite
+        for k in ("gate_count", "area_um2", "wns_ps", "tns_ps"):
+            if k in res and res[k] is not None:
+                row[k] = res[k]
+        return row
+
+    def _pnr_result_row(self, r, *, suite: str | None = None) -> dict:
+        res = r["results"].results
+        row = {"name": r["pnr_name"], "result": res["result"], "desc": res["desc"]}
+        if suite is not None:
+            row["suite"] = suite
+        for k in ("cell_count", "area_um2", "wns_setup_ps", "wns_hold_ps", "drc_count"):
+            if k in res and res[k] is not None:
+                row[k] = res[k]
+        return row
+
+    def _power_result_row(self, r, *, suite: str | None = None) -> dict:
+        res = r["results"].results
+        row = {"name": r["power_name"], "result": res["result"], "desc": res["desc"]}
+        if suite is not None:
+            row["suite"] = suite
+        for k in ("mode", "total_w", "internal_w", "switching_w", "leakage_w"):
+            if k in res and res[k] is not None:
+                row[k] = res[k]
+        return row
+
+    def _cdc_result_row(self, r, *, suite: str | None = None) -> dict:
+        res = r["results"].results
+        row = {"name": r["cdc_name"], "result": res["result"], "desc": res["desc"]}
+        if suite is not None:
+            row["suite"] = suite
+        for k in ("violations", "suppressed", "crossings"):
+            if k in res and res[k] is not None:
+                row[k] = res[k]
+        return row
+
+    def _fpv_result_row(self, r, *, suite: str | None = None) -> dict:
+        res = r["results"].results
+        row = {"name": r["fpv_name"], "result": res["result"], "desc": res["desc"]}
+        if suite is not None:
+            row["suite"] = suite
+        for k in ("mode", "depth", "engines", "runtime_s"):
+            if k in res and res[k] is not None:
+                row[k] = res[k]
+        return row
 
     def _render_synth_summary(self, title, synth_results, *, metadata=None):
         has_gates = any("gate_count" in r["results"].results for r in synth_results)
@@ -1977,14 +2097,29 @@ class RtlBuddy:
         )
 
         if list_synths:
-            emit_console_text("  ".join(suite_cfg.get_synth_names()), stream="stdout")
+            if self.machine:
+                self._emit_machine_result(
+                    "synth --list", 0, names=list(suite_cfg.get_synth_names())
+                )
+            else:
+                emit_console_text(
+                    "  ".join(suite_cfg.get_synth_names()), stream="stdout"
+                )
             raise typer.Exit(0)
 
         synth_results = self._do_synth_suite(
             suite_cfg, synth_name=synth_name, effort_override=effort
         )
-        self._render_synth_summary("Synthesis Results Summary", synth_results)
-        raise typer.Exit(self._exit_code_from_synth_results(synth_results))
+        exit_code = self._exit_code_from_synth_results(synth_results)
+        if self.machine:
+            self._emit_machine_result(
+                "synth",
+                exit_code,
+                results=[self._synth_result_row(r) for r in synth_results],
+            )
+        else:
+            self._render_synth_summary("Synthesis Results Summary", synth_results)
+        raise typer.Exit(exit_code)
 
     def do_cmd_pnr(
         self,
@@ -2041,7 +2176,12 @@ class RtlBuddy:
         )
 
         if list_runs:
-            emit_console_text("  ".join(suite_cfg.get_run_names()), stream="stdout")
+            if self.machine:
+                self._emit_machine_result(
+                    "pnr --list", 0, names=list(suite_cfg.get_run_names())
+                )
+            else:
+                emit_console_text("  ".join(suite_cfg.get_run_names()), stream="stdout")
             raise typer.Exit(0)
 
         results = self._do_pnr_suite(
@@ -2051,8 +2191,16 @@ class RtlBuddy:
             emit_gds=emit_gds,
             emit_png=emit_png,
         )
-        self._render_pnr_summary("P&R Results Summary", results)
-        raise typer.Exit(0 if all(r["results"].is_pass() for r in results) else 1)
+        exit_code = 0 if all(r["results"].is_pass() for r in results) else 1
+        if self.machine:
+            self._emit_machine_result(
+                "pnr",
+                exit_code,
+                results=[self._pnr_result_row(r) for r in results],
+            )
+        else:
+            self._render_pnr_summary("P&R Results Summary", results)
+        raise typer.Exit(exit_code)
 
     def _do_pnr_suite(
         self,
@@ -2217,7 +2365,12 @@ class RtlBuddy:
         )
 
         if list_runs:
-            emit_console_text("  ".join(suite_cfg.get_run_names()), stream="stdout")
+            if self.machine:
+                self._emit_machine_result(
+                    "power --list", 0, names=list(suite_cfg.get_run_names())
+                )
+            else:
+                emit_console_text("  ".join(suite_cfg.get_run_names()), stream="stdout")
             raise typer.Exit(0)
 
         results = self._do_power_suite(
@@ -2225,8 +2378,16 @@ class RtlBuddy:
             power_name=power_name,
             reg_level=reg_level,
         )
-        self._render_power_summary("Power Results Summary", results)
-        raise typer.Exit(0 if all(r["results"].is_pass() for r in results) else 1)
+        exit_code = 0 if all(r["results"].is_pass() for r in results) else 1
+        if self.machine:
+            self._emit_machine_result(
+                "power",
+                exit_code,
+                results=[self._power_result_row(r) for r in results],
+            )
+        else:
+            self._render_power_summary("Power Results Summary", results)
+        raise typer.Exit(exit_code)
 
     def _do_power_suite(
         self,
@@ -2396,6 +2557,7 @@ class RtlBuddy:
         )
 
         all_results = []
+        machine_rows = []
         try:
             for suite_cfg in power_reg.get_suite_configs():
                 suite_dir = os.path.dirname(suite_cfg.get_path())
@@ -2410,15 +2572,26 @@ class RtlBuddy:
                     suite_cfg, power_name=None, reg_level=reg_level
                 )
                 all_results.extend(suite_results)
+                if self.machine:
+                    machine_rows.extend(
+                        self._power_result_row(r, suite=suite_cfg.get_path())
+                        for r in suite_results
+                    )
         finally:
             os.chdir(start_dir)
 
-        self._render_power_summary(
-            "Power Regression Summary",
-            all_results,
-            metadata=[f"Reg Level: {reg_level}"],
-        )
-        raise typer.Exit(self._exit_code_from_power_results(all_results))
+        exit_code = self._exit_code_from_power_results(all_results)
+        if self.machine:
+            self._emit_machine_result(
+                "power-regression", exit_code, results=machine_rows
+            )
+        else:
+            self._render_power_summary(
+                "Power Regression Summary",
+                all_results,
+                metadata=[f"Reg Level: {reg_level}"],
+            )
+        raise typer.Exit(exit_code)
 
     def do_synth_regression(
         self,
@@ -2477,6 +2650,7 @@ class RtlBuddy:
         )
 
         all_results = []
+        machine_rows = []
         try:
             for suite_cfg in synth_reg.get_suite_configs():
                 suite_dir = os.path.dirname(suite_cfg.get_path())
@@ -2494,15 +2668,26 @@ class RtlBuddy:
                     effort_override=effort,
                 )
                 all_results.extend(suite_results)
+                if self.machine:
+                    machine_rows.extend(
+                        self._synth_result_row(r, suite=suite_cfg.get_path())
+                        for r in suite_results
+                    )
         finally:
             os.chdir(start_dir)
 
-        self._render_synth_summary(
-            "Synthesis Regression Summary",
-            all_results,
-            metadata=[f"Reg Level: {reg_level}"],
-        )
-        raise typer.Exit(self._exit_code_from_synth_results(all_results))
+        exit_code = self._exit_code_from_synth_results(all_results)
+        if self.machine:
+            self._emit_machine_result(
+                "synth-regression", exit_code, results=machine_rows
+            )
+        else:
+            self._render_synth_summary(
+                "Synthesis Regression Summary",
+                all_results,
+                metadata=[f"Reg Level: {reg_level}"],
+            )
+        raise typer.Exit(exit_code)
 
     # --- CDC subcommands ----------------------------------------------------
 
@@ -2627,14 +2812,27 @@ class RtlBuddy:
         )
 
         if list_cdcs:
-            emit_console_text(
-                "  ".join(suite_cfg.get_analysis_names()), stream="stdout"
-            )
+            if self.machine:
+                self._emit_machine_result(
+                    "cdc --list", 0, names=list(suite_cfg.get_analysis_names())
+                )
+            else:
+                emit_console_text(
+                    "  ".join(suite_cfg.get_analysis_names()), stream="stdout"
+                )
             raise typer.Exit(0)
 
         cdc_results = self._do_cdc_suite(suite_cfg, cdc_name=cdc_name)
-        self._render_cdc_summary("CDC Lint Results Summary", cdc_results)
-        raise typer.Exit(self._exit_code_from_cdc_results(cdc_results))
+        exit_code = self._exit_code_from_cdc_results(cdc_results)
+        if self.machine:
+            self._emit_machine_result(
+                "cdc",
+                exit_code,
+                results=[self._cdc_result_row(r) for r in cdc_results],
+            )
+        else:
+            self._render_cdc_summary("CDC Lint Results Summary", cdc_results)
+        raise typer.Exit(exit_code)
 
     def do_cdc_regression(
         self,
@@ -2681,6 +2879,7 @@ class RtlBuddy:
         )
 
         all_results = []
+        machine_rows = []
         try:
             for suite_cfg in cdc_reg.get_suite_configs():
                 suite_dir = os.path.dirname(suite_cfg.get_path())
@@ -2695,15 +2894,24 @@ class RtlBuddy:
                     suite_cfg, cdc_name=None, reg_level=reg_level
                 )
                 all_results.extend(suite_results)
+                if self.machine:
+                    machine_rows.extend(
+                        self._cdc_result_row(r, suite=suite_cfg.get_path())
+                        for r in suite_results
+                    )
         finally:
             os.chdir(start_dir)
 
-        self._render_cdc_summary(
-            "CDC Regression Summary",
-            all_results,
-            metadata=[f"Reg Level: {reg_level}"],
-        )
-        raise typer.Exit(self._exit_code_from_cdc_results(all_results))
+        exit_code = self._exit_code_from_cdc_results(all_results)
+        if self.machine:
+            self._emit_machine_result("cdc-regression", exit_code, results=machine_rows)
+        else:
+            self._render_cdc_summary(
+                "CDC Regression Summary",
+                all_results,
+                metadata=[f"Reg Level: {reg_level}"],
+            )
+        raise typer.Exit(exit_code)
 
     # --- FPV subcommands ----------------------------------------------------
 
@@ -2820,14 +3028,27 @@ class RtlBuddy:
         )
 
         if list_fpvs:
-            emit_console_text(
-                "  ".join(suite_cfg.get_verification_names()), stream="stdout"
-            )
+            if self.machine:
+                self._emit_machine_result(
+                    "fpv --list", 0, names=list(suite_cfg.get_verification_names())
+                )
+            else:
+                emit_console_text(
+                    "  ".join(suite_cfg.get_verification_names()), stream="stdout"
+                )
             raise typer.Exit(0)
 
         fpv_results = self._do_fpv_suite(suite_cfg, fpv_name=fpv_name)
-        self._render_fpv_summary("FPV Results Summary", fpv_results)
-        raise typer.Exit(self._exit_code_from_fpv_results(fpv_results))
+        exit_code = self._exit_code_from_fpv_results(fpv_results)
+        if self.machine:
+            self._emit_machine_result(
+                "fpv",
+                exit_code,
+                results=[self._fpv_result_row(r) for r in fpv_results],
+            )
+        else:
+            self._render_fpv_summary("FPV Results Summary", fpv_results)
+        raise typer.Exit(exit_code)
 
     def do_fpv_regression(
         self,
@@ -2874,6 +3095,7 @@ class RtlBuddy:
         )
 
         all_results = []
+        machine_rows = []
         try:
             for suite_cfg in fpv_reg.get_suite_configs():
                 suite_dir = os.path.dirname(suite_cfg.get_path())
@@ -2888,15 +3110,24 @@ class RtlBuddy:
                     suite_cfg, fpv_name=None, reg_level=reg_level
                 )
                 all_results.extend(suite_results)
+                if self.machine:
+                    machine_rows.extend(
+                        self._fpv_result_row(r, suite=suite_cfg.get_path())
+                        for r in suite_results
+                    )
         finally:
             os.chdir(start_dir)
 
-        self._render_fpv_summary(
-            "FPV Regression Summary",
-            all_results,
-            metadata=[f"Reg Level: {reg_level}"],
-        )
-        raise typer.Exit(self._exit_code_from_fpv_results(all_results))
+        exit_code = self._exit_code_from_fpv_results(all_results)
+        if self.machine:
+            self._emit_machine_result("fpv-regression", exit_code, results=machine_rows)
+        else:
+            self._render_fpv_summary(
+                "FPV Regression Summary",
+                all_results,
+                metadata=[f"Reg Level: {reg_level}"],
+            )
+        raise typer.Exit(exit_code)
 
     def do_cmd_wave(
         self,
@@ -3230,7 +3461,7 @@ class RtlBuddy:
         )
         vlog_fl.write_verible_filelist(selected, output_filepath=output)
 
-    def show_git_rev(self):
+    def _collect_git_status(self) -> dict | None:
         status_result = subprocess.run(
             ["git", "status", "-sb"],
             stdout=subprocess.PIPE,
@@ -3245,32 +3476,61 @@ class RtlBuddy:
             text=True,
             check=False,
         )
-
         if status_result.returncode != 0 or commit_result.returncode != 0:
-            logger.debug("git metadata unavailable for banner")
-            return
-
+            return None
         status_lines = status_result.stdout.splitlines()
-        git_branch = status_lines[0][3:].split("...")[0] if status_lines else "unknown"
+        branch = status_lines[0][3:].split("...")[0] if status_lines else "unknown"
         file_lines = status_lines[1:]
         mod = sum(1 for ln in file_lines if len(ln) > 1 and ln[1] not in (" ", "?"))
         staged = sum(1 for ln in file_lines if len(ln) > 0 and ln[0] not in (" ", "?"))
-        git_commit = commit_result.stdout.strip()
+        return {
+            "branch": branch,
+            "commit": commit_result.stdout.strip(),
+            "modified": mod,
+            "staged": staged,
+        }
 
-        if mod > 0 or staged > 0:
-            git_str = (
-                f"git: {git_branch} | commit {git_commit} | mod {mod} | staged {staged}"
+    def _emit_machine_result(self, command: str, exit_code: int, **payload) -> None:
+        git = self._collect_git_status()
+        print(
+            json.dumps(
+                {
+                    "command": command,
+                    "exit_code": exit_code,
+                    "meta": {
+                        "rtl_buddy_version": version("rtl-buddy"),
+                        "argv": sys.argv[:],
+                        "cwd": os.getcwd(),
+                        "git": git,
+                    },
+                    **payload,
+                },
+                ensure_ascii=True,
             )
-        else:
-            git_str = f"git: {git_branch} | commit {git_commit} | clean"
+        )
 
+    def show_git_rev(self):
+        git = self._collect_git_status()
+        if git is None:
+            logger.debug("git metadata unavailable for banner")
+            return
+        branch, commit, mod, staged = (
+            git["branch"],
+            git["commit"],
+            git["modified"],
+            git["staged"],
+        )
+        if mod > 0 or staged > 0:
+            git_str = f"git: {branch} | commit {commit} | mod {mod} | staged {staged}"
+        else:
+            git_str = f"git: {branch} | commit {commit} | clean"
         emit_console_text(git_str, style=None if is_machine_mode() else "dim")
         log_event(
             logger,
             logging.INFO,
             "git.status",
-            branch=git_branch,
-            commit=git_commit,
+            branch=branch,
+            commit=commit,
             modified=mod,
             staged=staged,
         )

--- a/src/rtl_buddy/rtl_buddy.py
+++ b/src/rtl_buddy/rtl_buddy.py
@@ -122,6 +122,7 @@ class RtlBuddy:
                                 "cwd": os.getcwd(),
                                 "git": None,
                             },
+                            "payload": {},
                         },
                         ensure_ascii=True,
                     )
@@ -1623,11 +1624,11 @@ class RtlBuddy:
     def do_docs_list(self):
         pages = [page.to_list_item() for page in list_pages()]
         if self.machine:
-            print(json.dumps({"pages": pages}, ensure_ascii=True))
+            self._emit_machine_result("docs list", 0, pages=pages)
             return
 
         for page in pages:
-            print(f"{page['slug']} - {page['title']}: {page['summary']}")
+            print(f"{page['slug']} - {page['title']}: {page['description']}")
 
     def do_docs_show(
         self,
@@ -3640,7 +3641,7 @@ class RtlBuddy:
                         "cwd": os.getcwd(),
                         "git": git,
                     },
-                    **payload,
+                    "payload": payload,
                 },
                 ensure_ascii=True,
             )

--- a/src/rtl_buddy/rtl_buddy.py
+++ b/src/rtl_buddy/rtl_buddy.py
@@ -1623,7 +1623,7 @@ class RtlBuddy:
     def do_docs_list(self):
         pages = [page.to_list_item() for page in list_pages()]
         if self.machine:
-            self._emit_machine_result("docs list", 0, pages=pages)
+            print(json.dumps({"pages": pages}, ensure_ascii=True))
             return
 
         for page in pages:
@@ -1650,7 +1650,7 @@ class RtlBuddy:
                     f"Unknown section '{anchor}' in page '{page_slug}'. Run `rtl-buddy docs show {page_slug}` to see available sections."
                 )
             if self.machine:
-                self._emit_machine_result("docs show", 0, **section)
+                print(json.dumps(section, ensure_ascii=True))
                 return
             print(section["content"])
             return
@@ -1662,7 +1662,7 @@ class RtlBuddy:
             )
 
         if self.machine:
-            self._emit_machine_result("docs show", 0, **page.to_show_payload())
+            print(json.dumps(page.to_show_payload(), ensure_ascii=True))
             return
 
         print(page.content, end="" if page.content.endswith("\n") else "\n")

--- a/src/rtl_buddy/skill/SKILL.md
+++ b/src/rtl_buddy/skill/SKILL.md
@@ -13,8 +13,7 @@ Use <https://rtl-buddy.github.io/rtl_buddy/> only as a fallback reference.
 
 ## Always use `--machine`
 
-All agent invocations must use `--machine` so `rtl_buddy.log` is JSONL and console output is plain text.
-Commands that produce structured results (`test`, `regression`, `synth`, `pnr`, `power`, `cdc`, `fpv`, `spec`, and their `--list`/regression variants) also print a single JSON envelope to **stdout** on exit — parse this for results rather than scraping the log.
+All agent invocations must use `--machine` so `rtl_buddy.log` is JSONL. Structured result commands, including `rb docs list` but excluding `rb docs show`, print a single JSON envelope to **stdout** on exit — parse this for results.
 
 See `rtl-buddy docs show agents` for the stdout envelope schema, JSONL log format, and exit codes (0 pass, 1 test failures, 2 fatal).
 
@@ -23,20 +22,15 @@ See `rtl-buddy docs show agents` for the stdout envelope schema, JSONL log forma
 Report `rtl-buddy --version` at the top of every run summary.
 This skill ships with the CLI, so its content matches the installed major. Surface any observed behavior differences in your summary.
 
-## YAML types
+## Config files
 
 Use `rtl-buddy --machine docs show reference/yaml` for exact schemas.
 
-- **`root_config.yaml`** — project root, platform/build defaults, regression default path, synthesis tool defaults (`cfg-synth-tools`), PDK assets (`cfg-pdks`), synth/P&R platforms (`cfg-synth-platforms`, `cfg-pnr-platforms`).
-- **`regression.yaml`** — repo-level suite list for `regression`.
-- **`tests.yaml`** — suite-level tests/testbenches; run `test` and `randtest` from this directory.
-- **`models.yaml`** — design source filelists referenced by `tests.yaml` and `synth.yaml`.
-- **`synth.yaml`** — synthesis runs; `model` name is the top; `tool` selects `cfg-synth-tools` entry; `params`/`defines`/`tool_overrides` for per-run customization.
-- **`synth_regression.yaml`** — repo-level synthesis suite list for `synth-regression`.
-- **`pnr.yaml`** — P&R runs that consume an upstream `rb synth` artefact; each entry names `synth`/`synth-path`, `platform` (a `cfg-pnr-platforms` entry), and `constraints` (SDC). Only `tool: openroad` today.
-- **`cdc.yaml`** — CDC lint analyses; each entry names a `model`, `tool` (selects `cfg-cdc-tools` entry), an SDC, and optional waivers.
-- **`fpv.yaml`** — formal property verification runs; each entry names a `model`, `top`, a list of `properties:` (SV files with bound checker modules), `mode` (bmc/prove/cover/live), `depth`, and `engines:`. `tool` selects `cfg-fpv-tools` entry; only `sby` (SymbiYosys) today.
-- **`specs.yaml`** — spec traceability data; consumed by `rtl-buddy spec`.
+- `root_config.yaml` sets project defaults and tool/platform entries.
+- `tests.yaml` and `regression.yaml` drive sim suites; run `test`/`randtest` from the suite directory and `regression` from the repo root.
+- `models.yaml` lists design sources used by sim, synth, P&R, CDC, FPV, and hierarchy commands.
+- `synth.yaml`, `pnr.yaml`, `power.yaml`, `cdc.yaml`, and `fpv.yaml` configure implementation/analysis runs.
+- `specs.yaml` holds spec traceability data consumed by `rtl-buddy spec`.
 
 ## Pass/fail detection
 
@@ -45,29 +39,21 @@ Use `rtl-buddy --machine docs show reference/yaml` for exact schemas.
 - When emitting `FAIL`, also print an `ERR:` or `FAT:` line. Missing markers report `NA`; simulator exit code alone is not authoritative.
 - See `rtl-buddy docs show agents` and `rtl-buddy docs show concepts/cocotb`.
 
-## Multi-suite discovery and CWD rules
+## Multi-suite runs
 
 - Discover suites with `rg --files -g '**/tests.yaml'`.
-- Run `test` / `randtest` from each suite directory.
-- Run `regression` from the repo root.
 - Summarize results per suite, not just globally.
 
 ## Artefact locations
 
 - `rtl_buddy.log` — JSONL in `--machine` mode; written to the suite root (CWD you invoked from).
 - `artefacts/<test>/test.log`, `test.err`, `test.randseed`, `coverage.dat` — sim outputs for a single run.
-- `artefacts/<test>/compile.log`, `run.f` — compile outputs, always at the test root (not per run-id).
 - `artefacts/<test>/run-0001/test.log` etc. — per-iteration outputs for `randtest`.
 - `artefacts/<test>/dump.fst` — FST waveform produced by debug-mode builds (`-M debug`).
-- Symlinks `test.log`, `test.err`, `test.randseed` at the suite root point at the latest run.
 - For multi-suite runs, each suite directory has its own `rtl_buddy.log` and `artefacts/`; report logs per suite.
 - Next docs: `rtl-buddy docs show reference/cli`, `rtl-buddy docs show reference/yaml`, `rtl-buddy docs show known-issues`
 
 ## Waveform viewing
 
 - `rb wave <test>` opens `artefacts/<test>/dump.fst` in Surfer (runs debug sim first if no FST exists).
-- Signal layout files follow the convention `<test>.surfer` placed next to `tests.yaml` (e.g. `verif/sandbox/basic.surfer`). Use `variable_add <path>` and `zoom_fit` commands. See `verif/mem/tb_spsram.surfer` for a reference example.
 - Surfer must be configured in `cfg-surfer` in `root_config.yaml`. Run `rtl-buddy docs show concepts/root-config` for the schema.
-
-## Bugs & Improvements
-If you discover a rtl_buddy bug or potential improvement, you can post an issue on GitHub <https://github.com/rtl-buddy/rtl_buddy/> documenting your findings, with permission from your user.

--- a/src/rtl_buddy/skill/SKILL.md
+++ b/src/rtl_buddy/skill/SKILL.md
@@ -14,8 +14,9 @@ Use <https://rtl-buddy.github.io/rtl_buddy/> only as a fallback reference.
 ## Always use `--machine`
 
 All agent invocations must use `--machine` so `rtl_buddy.log` is JSONL and console output is plain text.
+Commands that produce structured results (`test`, `regression`, `synth`, `pnr`, `power`, `cdc`, `fpv`, `spec`, and their `--list`/regression variants) also print a single JSON envelope to **stdout** on exit — parse this for results rather than scraping the log.
 
-See `rtl-buddy docs show agents` for the JSONL schema and exit codes (0 pass, 1 test failures, 2 fatal).
+See `rtl-buddy docs show agents` for the stdout envelope schema, JSONL log format, and exit codes (0 pass, 1 test failures, 2 fatal).
 
 ## Version check
 

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -47,7 +47,7 @@ def test_docs_list_human():
     runner, rb = _runner()
     result = runner.invoke(rb.app, ["docs", "list"])
     assert result.exit_code == 0, result.output
-    # Each line is "<slug> - <title>: <summary>"; at least one slug present.
+    # Each line is "<slug> - <title>: <description>"; at least one slug present.
     assert " - " in result.output
     assert ":" in result.output
 
@@ -57,12 +57,13 @@ def test_docs_list_machine_outputs_json():
     result = runner.invoke(rb.app, ["--machine", "docs", "list"])
     assert result.exit_code == 0, result.output
     payload = json.loads(result.output)
-    assert "pages" in payload
-    assert isinstance(payload["pages"], list)
-    assert payload["pages"], "expected at least one bundled docs page"
-    # Each entry should have slug/title/summary keys.
-    first = payload["pages"][0]
-    for key in ("slug", "title", "summary"):
+    assert payload["command"] == "docs list"
+    assert payload["exit_code"] == 0
+    assert isinstance(payload["payload"]["pages"], list)
+    assert payload["payload"]["pages"], "expected at least one bundled docs page"
+    # Each entry should have slug/title/description keys.
+    first = payload["payload"]["pages"][0]
+    for key in ("slug", "title", "description"):
         assert key in first, f"{key} missing from page list item"
 
 

--- a/tests/test_docs_access.py
+++ b/tests/test_docs_access.py
@@ -67,8 +67,8 @@ def test_get_page_returns_expected_sections():
     page = get_page("agents")
 
     assert page is not None
-    assert page.title == "For Agents"
-    assert any(section.title == "Agent Skill Install" for section in page.sections)
+    assert page.title == "Agent use of rtl-buddy"
+    assert any(section.title == "Bundled agent skill" for section in page.sections)
 
 
 def test_get_section_returns_section_payload():
@@ -99,8 +99,15 @@ def test_docs_list_machine_output():
     )
 
     assert result.returncode == 0
-    payload = json.loads(result.stdout)
-    assert any(page["slug"] == "agents" for page in payload["pages"])
+    envelope = json.loads(result.stdout)
+    assert envelope["command"] == "docs list"
+    assert envelope["exit_code"] == 0
+    assert "meta" in envelope
+    assert any(page["slug"] == "agents" for page in envelope["payload"]["pages"])
+    assert all(
+        {"slug", "title", "description"} <= set(page)
+        for page in envelope["payload"]["pages"]
+    )
 
 
 def test_docs_show_machine_output():
@@ -115,12 +122,12 @@ def test_docs_show_machine_output():
     assert result.returncode == 0
     payload = json.loads(result.stdout)
     assert payload["slug"] == "agents"
-    assert payload["title"] == "For Agents"
+    assert payload["title"] == "Agent use of rtl-buddy"
     assert payload["summary"]
     assert any(
-        section["title"] == "Agent Skill Install" for section in payload["sections"]
+        section["title"] == "Bundled agent skill" for section in payload["sections"]
     )
-    assert "# For Agents" in payload["content"]
+    assert "# Agent use of rtl-buddy" in payload["content"]
 
 
 def test_docs_show_section_machine_output():


### PR DESCRIPTION
## Summary

Standardise the `--machine` stdout JSON envelope across `rtl_buddy` and align the agent-facing surfaces (bundled skill + `docs/agents.md`) with it.

### Machine-mode stdout envelope

- Introduce `_emit_machine_result(command, exit_code, **payload)` — a single helper that serialises a consistent JSON envelope to stdout in `--machine` mode, with a `meta` block (version, argv, cwd, git status) and a `payload` block.
- Extract `_collect_git_status()` from `show_git_rev()` so git metadata is reused without duplicating subprocess logic.
- Expand structured stdout JSON to commands that had none before: `test`, `randtest`, `regression`, `synth`, `pnr`, `power`, `cdc`, `fpv`, their `--list` variants, and all regression counterparts. `spec` is migrated onto the same envelope.
- Add per-command result-row helpers (`_synth_result_row`, `_pnr_result_row`, `_power_result_row`, `_cdc_result_row`, `_fpv_result_row`) for consistent extraction of optional metrics (gate_count, area_um2, wns_ps, etc.).
- `rb docs list` rides the envelope; `rb docs show` is intentionally exempt so Markdown-oriented workflows can consume the page payload directly. Rename the `docs list` per-page field from `summary` to `description` to match the docs frontmatter key.

### Agent-facing docs

- Rewrite `docs/agents.md` to describe the affordances `rtl_buddy` provides for agent integration (bundled skill, local docs access, machine mode with envelope and JSONL log), rather than reading as a list of imperatives directed at the agent.
- Drop sections that duplicate `concepts/tests.md` (pass/fail, working directory rules) and `concepts/spec-traceability.md`.
- Add an `Exit codes` subsection in `concepts/tests.md` as the single canonical home; `agents.md` links to it.
- Trim `SKILL.md` to the conventions that are genuinely agent-specific (machine mode, version reporting, multi-suite discovery, artefact locations); defer YAML schemas and full CLI surfaces to `rb docs show reference/yaml` and `rb docs show reference/cli`.

## Test plan

- [x] Full `uv run pytest -q` suite passes (865 passed, 10 skipped).
- [x] `uv run ruff check` and `uv run ruff format --check` pass.
- [x] `uv run python scripts/gen_cli_reference.py --check` passes (no CLI flags changed).
- [x] `uv run python scripts/check_docs_frontmatter.py --check` passes.
- [x] Existing machine-mode tests for `docs list`, `docs show`, and `docs show <page#section>` updated to assert on the unified envelope shape and the renamed `description` field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)