### PR TITLE
docs(concepts): add cdc, hier, axi-profile, tool-check pages

### DIFF
--- a/docs/concepts/axi-profile.md
+++ b/docs/concepts/axi-profile.md
@@ -1,0 +1,188 @@
+---
+description: How to profile AXI interconnect performance with rtl_buddy via the rb axi-profile subcommand group, models.yaml fields, and the standalone rtl-buddy-axi-profiler.
+---
+
+# AXI Interconnect Profiling
+
+> **Integration type:** Pluggable — curated. `rb axi-profile` drives the standalone [rtl-buddy-axi-profiler](https://github.com/rtl-buddy/rtl-buddy-axi-profiler) at subprocess granularity; rtl_buddy is not coupled to its Python API.
+>
+> **External binary required:** `axi-profiler` — install with `uv tool install rtl-buddy-axi-profiler`.
+>
+> **Optional extras:** `[parquet]` (pyarrow) for `--emit-txns-parquet`; `[notebook]` (marimo + altair + polars) for `rb axi-profile notebook`.
+>
+> See also: [Installation — External tools by feature](../install.md#external-tools-by-feature).
+
+`rb axi-profile` is a workflow for measuring AXI interconnect performance directly from a simulation trace. The four subcommands form a pipeline:
+
+1. **`discover`** — parse RTL to produce an `axi-bundles.yaml` manifest of the model's AXI interfaces.
+2. **`gen-monitor`** — emit a bind-style SystemVerilog monitor whose `axi-stream` taps are added to the testbench's filelist.
+3. **`run`** — ingest a test's FST trace and emit per-test `axi-perf.json` (and optionally a per-transaction Parquet).
+4. **`notebook`** — launch the packaged marimo notebook against the per-transaction Parquet for interactive deep-dive.
+
+The four wrappers share the same subprocess-granularity integration: pass `--tool /path/to/axi-profiler` to pin a specific build, otherwise the binary on `PATH` is used.
+
+## Installing rtl-buddy-axi-profiler
+
+```bash
+uv tool install rtl-buddy-axi-profiler                    # base — discover, gen-monitor, run
+uv pip install 'rtl-buddy-axi-profiler[parquet]'          # adds pyarrow for --emit-txns-parquet
+uv pip install 'rtl-buddy-axi-profiler[notebook]'         # adds marimo + altair + polars for rb axi-profile notebook
+```
+
+The base install gives you `discover`, `gen-monitor`, and `run` without parquet. The `[parquet]` extra unlocks `--emit-txns-parquet`, which is the prerequisite for `rb axi-profile notebook`. The `[notebook]` extra additionally brings in marimo so the notebook can be launched.
+
+## `models.yaml` fields
+
+Two optional fields on each `models.yaml` entry drive `rb axi-profile`:
+
+```yaml
+models:
+  - name: "soc_top"
+    filelist:
+      - "-F soc_top.f"
+    axi_bundles: "axi-bundles.yaml"               # manifest path (input to run / gen-monitor)
+    axi_monitor_out: "../verif/soc_top/gen/axi_perf_mon.sv"  # where gen-monitor writes
+```
+
+| Field | Description |
+|-------|-------------|
+| `axi_bundles` | Relative path from `models.yaml` to the model's checked-in `axi-bundles.yaml` manifest. Consumed by `rb axi-profile run` and `rb axi-profile gen-monitor`; produced by `rb axi-profile discover`. |
+| `axi_monitor_out` | Relative path from `models.yaml` to where `rb axi-profile gen-monitor` writes the generated SV monitor. Typically points into the verif testbench source tree so the file is picked up by the tb's filelist (e.g. `../verif/soc_top/gen/axi_perf_mon.sv`). |
+
+Both fields are optional from rtl_buddy's perspective; missing them surfaces a clear error from the subcommand that needs them, pointing at the prerequisite command.
+
+## Subcommand: `discover`
+
+```bash
+# Generate axi-bundles.yaml at the path declared in models.yaml
+rb axi-profile discover soc_top
+
+# Custom output path
+rb axi-profile discover soc_top -o /tmp/axi-bundles.yaml
+
+# Different models.yaml
+rb axi-profile discover soc_top -c design/soc_top/models.yaml
+```
+
+The runner writes a stripped, deduplicated filelist for the model, then invokes `axi-profiler discover --top <model> --filelist <fl> --output <path>`. When `-o` is omitted, the output goes to the model's `axi_bundles:` path if set, otherwise to `artefacts/axi/<model>/axi-bundles.yaml`.
+
+The generated `axi-bundles.yaml` is a checked-in manifest — re-running `discover` after RTL changes lets you diff the manifest in code review. The `--amend` option is reserved for a future user-edit merge workflow; passing it today emits a warning.
+
+## Subcommand: `gen-monitor`
+
+```bash
+# Emit SV monitor at model.axi_monitor_out
+rb axi-profile gen-monitor soc_top
+
+# Custom output path
+rb axi-profile gen-monitor soc_top -o /tmp/axi_perf_mon.sv
+
+# Match the testbench's `timeprecision`
+rb axi-profile gen-monitor soc_top --time-precision 1ps
+
+# Cap per-bundle FIFO depth (drained only at $finish)
+rb axi-profile gen-monitor soc_top --buffer-cap 16384
+```
+
+The runner reads the manifest from `model.axi_bundles` and invokes `axi-profiler gen-monitor <manifest> --output <path>`. The generated `.sv` file uses SystemVerilog `bind` semantics so the monitor instances live alongside the DUT without modifying its source.
+
+You add the generated SV to the testbench's filelist once. If `axi_monitor_out:` points at a path inside the verif tree (e.g. `../verif/soc_top/gen/axi_perf_mon.sv`), that's a one-time step — subsequent `gen-monitor` runs just rewrite the file in place.
+
+`--time-precision` must match the IEEE 1800 `timeprecision` of the wrapping testbench, otherwise the monitor's timestamp arithmetic will be off by a power of ten. `--buffer-cap` bounds memory growth on extremely long traces — the buffer is drained to disk only at `$finish`.
+
+## Subcommand: `run`
+
+```bash
+# Ingest the test's FST and emit axi-perf.json
+rb axi-profile run my_test
+
+# Also produce the per-txn parquet that the notebook reads
+rb axi-profile run my_test --emit-txns-parquet
+
+# Explicit parquet path (implies --emit-txns-parquet)
+rb axi-profile run my_test --emit-txns-parquet-path /tmp/txns.parquet
+
+# Custom output path for axi-perf.json
+rb axi-profile run my_test -o /tmp/axi-perf.json
+
+# Override the FST top scope (default = the test's tb name)
+rb axi-profile run my_test --tb-prefix my_custom_wrapper
+```
+
+The runner resolves everything from `tests.yaml` and the standard artefact layout:
+
+| Input | Where it comes from |
+|-------|---------------------|
+| Model | `tests.yaml` → `model:` |
+| Manifest | `model.axi_bundles` in `models.yaml` (must exist — run `discover` first) |
+| FST trace | `<suite_dir>/artefacts/<test>/dump.fst` (same convention as `rb wave`) |
+| Top scope prefix | The test's `testbenches:` entry name in `tests.yaml` |
+
+You only type `rb axi-profile run <test>` — everything else auto-resolves. The `--tb-prefix` override exists for setups where the Verilator wrapper renames the testbench scope; pass an empty string to disable prefix matching entirely.
+
+Pass `--emit-txns-parquet` to also write per-transaction rows to `artefacts/axi/<test>/axi-txns.parquet` — that's the canonical location `rb axi-profile notebook` reads. Requires the `axi-profiler` `[parquet]` extra (pyarrow).
+
+## Subcommand: `notebook`
+
+```bash
+# Foreground (default) — opens marimo in your browser
+rb axi-profile notebook my_test
+
+# Pin the marimo edit-server port
+rb axi-profile notebook my_test --port 2718
+
+# Hub-initiated (SPA opens the URL; marimo runs headless without a token)
+rb axi-profile notebook my_test --headless
+```
+
+The runner resolves three things up-front:
+
+1. The per-test parquet at `artefacts/axi/<test>/axi-txns.parquet` — missing → clear error pointing at `rb axi-profile run <test> --emit-txns-parquet`.
+2. The notebook template via `importlib.resources.files('rtl_buddy_axi_profiler.notebook') / 'template.py'`.
+3. The `marimo` binary on `PATH` — missing → install hint for `rtl-buddy-axi-profiler[notebook]`.
+
+It then spawns `marimo edit <template>` with `$AXI_TXNS_PARQUET` exported so the template's first cell loads the parquet. `--headless` adds `--no-token` so the SPA can navigate to the URL without threading a per-session token through the hub→browser handoff — loopback-only, so the security trade is fine.
+
+`--daemon` is accepted but currently falls back to foreground; background detach is a follow-up (same pattern as `rb hub start`).
+
+## Artefacts
+
+Per-model and per-test outputs land under `artefacts/axi/`:
+
+```
+artefacts/axi/
+├── <model>/
+│   ├── axi.f                                    # filelist used by discover / gen-monitor
+│   ├── axi-bundles.yaml                         # only when -o defaults here
+│   ├── axi-profile-discover.log                 # stderr from `axi-profiler discover`
+│   └── axi-profile-gen-monitor.log              # stderr from `axi-profiler gen-monitor`
+└── <test>/
+    ├── axi.f                                    # filelist used by run
+    ├── axi-perf.json                            # aggregate per-bundle throughput / latency
+    ├── axi-txns.parquet                         # per-transaction rows (only with --emit-txns-parquet)
+    ├── axi-profile-run.log                      # stderr from `axi-profiler run`
+    └── axi-profile-notebook.log                 # stderr from marimo
+```
+
+`axi-perf.json` is the artefact picked up by `rb hier --overlay axi-perf=...` and by the hub's view-builder when `--axi-perf-from` is wired up — see [Hub](hub.md) for the SPA overlay flow.
+
+## Hub integration
+
+When the [coordination hub](hub.md) is running, two paths surface AXI-perf data in the rtl-buddy-view SPA:
+
+- **Static overlay**: `rb hub start --axi-perf-from <test>` threads the test's `axi-perf.json` into the SPA's view builder, decorating each AXI bundle node with throughput badges.
+- **Notebook launch**: the SPA's "Open in marimo" button calls `/api/axi-profile/notebook?test=<name>`, which invokes `rb axi-profile notebook <test> --headless` and proxies the marimo URL back to the SPA. The user gets the full interactive notebook without leaving the hub UI.
+
+Both flows reuse the same per-test artefact layout, so the static and interactive views agree on what data they're showing.
+
+## Pass/fail detection
+
+Each `rb axi-profile` subcommand exits with the underlying `axi-profiler` exit code. A non-zero exit means the profiler reported an elaboration, ingest, or write error — check the relevant `.log` file under `artefacts/axi/`.
+
+Missing prerequisites (no `axi_bundles:` in `models.yaml`, no FST at the expected path, no `marimo` for `notebook`) surface as a clear `FatalRtlBuddyError` *before* invoking `axi-profiler`, so the error is anchored at the prerequisite step rather than buried in profiler output.
+
+## Out of scope (today)
+
+- **Non-AXI protocols.** AXI4 / AXI4-Lite / AXI4-Stream are supported by `rtl-buddy-axi-profiler`'s bundle discovery; AHB, APB, TileLink, and custom protocols are not. The pluggable wrapper boundary makes adding sibling profilers straightforward, but no other profilers are wired up yet.
+- **Background-detached `notebook`.** `--daemon` is accepted for forward compatibility but runs in foreground today.
+- **Manifest user-edit merging.** `rb axi-profile discover --amend <prev>` is reserved for merging user edits across re-runs; today the manifest is rewritten in full and you diff in git.

--- a/docs/concepts/cdc.md
+++ b/docs/concepts/cdc.md
@@ -1,0 +1,157 @@
+---
+description: How to run CDC lint with rtl_buddy via the rb cdc command, cdc.yaml, and the standalone rtl-buddy-cdc analyzer.
+---
+
+# CDC Lint
+
+> **Integration type:** Pluggable — curated. `rb cdc` is built around [rtl-buddy-cdc](https://github.com/rtl-buddy/rtl-buddy-cdc) today; a SpyGlass-style commercial backend would plug in as a sibling driver (see [issue #85](https://github.com/rtl-buddy/rtl_buddy/issues/85)).
+>
+> **External binary required:** `rtl-buddy-cdc` — install with `uv tool install rtl-buddy-cdc` (or `pip install rtl-buddy-cdc`).
+>
+> See also: [Installation — External tools by feature](../install.md#external-tools-by-feature).
+
+`rb cdc` drives the standalone `rtl-buddy-cdc lint` CLI: it generates a filelist from the model's `models.yaml`, hands the SystemVerilog sources, SDC, and optional waivers to the analyzer, and parses the JSON report into a pass/fail verdict.
+
+The flow is intentionally compact and config-driven — per-analysis knobs (model, SDC, waivers, frontend) live in `cdc.yaml`, tool-wide defaults live in `cfg-cdc-tools` in `root_config.yaml`.
+
+## Supported backend
+
+Today only `rtl-buddy-cdc` is wired up. The `tool:` field in `cdc.yaml` selects it; the runner raises a clear error if no matching `cfg-cdc-tools` entry exists. Adding a commercial backend parallels how `rb fpv` is structured — implement a sibling driver under `src/rtl_buddy/tools/`, then dispatch from `CdcRunner`.
+
+## Installing rtl-buddy-cdc
+
+```bash
+uv tool install rtl-buddy-cdc    # recommended — isolated tool env
+# or
+uv pip install rtl-buddy-cdc     # into the project venv
+```
+
+Once installed, the binary lands on `PATH` as `rtl-buddy-cdc`. The default `cfg-cdc-tools` entry in `root_config.yaml` resolves it from `PATH`; override with an absolute path if you need a specific version.
+
+## CDC config: `cdc.yaml`
+
+`cdc.yaml` declares one or more CDC analyses. Each entry references a model from `models.yaml`, an SDC describing the clocks, and an optional waivers file:
+
+```yaml
+rtl-buddy-filetype: cdc_config
+
+analyses:
+  - name: "demo_cdc_full"
+    desc: "Full-design CDC lint, no waivers"
+    tool: "rtl-buddy-cdc"
+    model: "demo_top"
+    model_path: "../../design/demo_top/models.yaml"
+    constraints: "demo_top.sdc"
+    waivers: "demo_top_waivers.yaml"     # optional
+    frontend: "slang"                    # optional — overrides default
+    reglvl: 1000
+```
+
+### Fields
+
+| Field | Description |
+|-------|-------------|
+| `name` | Analysis identifier used on the command line and in `artefacts/<name>/` |
+| `desc` | Human-readable description |
+| `tool` | Backend tool name — must match a `cfg-cdc-tools` entry (only `rtl-buddy-cdc` today) |
+| `model` | Model name from `models.yaml` |
+| `model_path` | Path to `models.yaml`, resolved relative to `cdc.yaml` |
+| `constraints` | SDC path (required), resolved relative to `cdc.yaml` |
+| `waivers` | Optional waivers YAML, resolved relative to `cdc.yaml` |
+| `frontend` | Optional parser frontend — forwarded as-is to `rtl-buddy-cdc --frontend` (rtl_buddy does not validate the set so the analyzer can add frontends without an rtl_buddy release) |
+| `reglvl` | Regression level for filtering, or a dict `{tool_name: level, default: level}` |
+| `tool_overrides` | Optional per-tool overrides (e.g. `sync_depth`, `extra_args`), keyed by tool name |
+
+### Where inputs come from
+
+The runner reads the model's filelist via `VlogFilelist` (the same helper `rb synth` and `rb fpv` use), strips down to plain source paths (no `+incdir+`, no `-y`, no `-f`), and passes them as positional arguments to `rtl-buddy-cdc lint` alongside `--top`, `--sdc`, and optionally `--waivers`. The top module is taken from the model's `name:` field.
+
+## Root config: `cfg-cdc-tools`
+
+`cfg-cdc-tools` declares the CDC tools available to all suites in this project:
+
+```yaml
+cfg-cdc-tools:
+  - name: "rtl-buddy-cdc"
+    tool: "rtl-buddy-cdc"           # binary on PATH, or absolute path
+    opts:
+      sync-depth: 2                 # optional — passed via --sync-depth
+      extra-args: ""                # optional — appended verbatim
+```
+
+| Field | Description |
+|-------|-------------|
+| `name` | Referenced by `tool:` in `cdc.yaml` |
+| `tool` | Binary name (PATH-resolved) or absolute path |
+| `opts.sync-depth` | Default synchronizer depth, forwarded via `--sync-depth` |
+| `opts.extra-args` | Passed through verbatim to the analyzer command line |
+
+## Running CDC
+
+```bash
+# All analyses in the default ./cdc.yaml
+rb cdc
+
+# A single analysis from a specific config
+rb cdc demo_cdc_full -c cdc/demo_top/cdc.yaml
+
+# List analyses without executing
+rb cdc -c cdc/demo_top/cdc.yaml --list
+
+# Regression across multiple cdc.yaml suites, filtered by reglvl
+rb cdc-regression -c cdc_regression.yaml -l 1000
+```
+
+## Results table
+
+A summary table prints after each run, with one row per analysis:
+
+```
+                       CDC Results Summary
+┏━━━━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━┓
+┃ CDC Analysis    ┃ Result ┃ Violations ┃ Suppressed ┃ Crossings ┃
+┡━━━━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━┩
+│ demo_cdc_full   │ PASS   │ 0          │ 3          │ 142       │
+└─────────────────┴────────┴────────────┴────────────┴───────────┘
+```
+
+- **Violations** — non-waived findings parsed from `summary.violations` in the JSON report.
+- **Suppressed** — waiver-matched findings, parsed from `summary.suppressed`.
+- **Crossings** — total clock-domain crossings detected (informational, parsed from `summary.crossings`).
+
+## Artefacts
+
+Per-analysis outputs land under `<suite>/artefacts/<analysis>/`:
+
+| File | Contents |
+|---|---|
+| `cdc.f` | Generated filelist (unrolled, deduplicated) |
+| `cdc.log` | Combined stdout/stderr from both analyzer invocations |
+| `cdc.txt` | Human-readable findings report |
+| `cdc.json` | Machine-readable JSON report (parsed for the results table) |
+
+`rb cdc` runs the analyzer twice per analysis — once with `--format text` for human consumption, once with `--format json` for the parsed verdict. If this becomes a hotspot, both views could be rendered from a single JSON probe; today the duplicate elaborate keeps the output decoupled.
+
+## Pass/fail detection
+
+A run is PASS when:
+1. `rtl-buddy-cdc` exits with code 0 or 1 (1 = rule violations found, the analyzer's "ran cleanly" signal), AND
+2. The JSON report parses successfully, AND
+3. `summary.violations` is `0`.
+
+A run is FAIL when violations are present, when the JSON report is missing or malformed, or when the analyzer exits with any other code (typically 2 = elaboration failure). The failure description includes the violation count and points at `cdc.log` for diagnosis.
+
+SKIP is returned when the analysis's `reglvl` is above the `-l` filter passed to `rb cdc-regression`.
+
+## Hub integration
+
+When the [coordination hub](hub.md) is running for the current project, every successful `rb cdc` analysis publishes its violations to the hub as a `diagnostics_set` event under the source key `rb-cdc:<analysis_name>`. The rtl-buddy-view SPA's on-canvas badge layer and `rtl-buddy-nvim`'s `rtlbuddy` diagnostics namespace light up immediately — no `rb hub send` copy-paste.
+
+The publish step is best-effort: missing hub, no live PID, connect failure, or a malformed JSON payload all silently no-op with a debug-level log line. The CDC analysis itself is never failed by a sidecar UI being unreachable.
+
+Re-running an analysis after a fix replaces (or clears) just that source-key slot, so a project with several analyses doesn't have one fix wiping all the others.
+
+## Out of scope (today)
+
+- **rtl-buddy-cdc only.** Commercial CDC tools (SpyGlass CDC, JasperGold CDC, Questa CDC) are not yet wired up — adding them follows the same pattern documented for `rb fpv`'s SymbiYosys backend.
+- **Reset-domain crossing (RDC).** Reset-domain analysis is a planned extension of `rtl-buddy-cdc`; once it lands there, `rb cdc` will surface its findings alongside CDC. Today RDC overlays surface in `rb hier --rdc-annotations` via a separate analyzer pass.

--- a/docs/concepts/hier.md
+++ b/docs/concepts/hier.md
@@ -1,0 +1,117 @@
+---
+description: How to render module hierarchy diagrams with rtl_buddy via the rb hier command and the standalone rtl-buddy-view renderer.
+---
+
+# Hierarchy Rendering
+
+> **Integration type:** Pluggable — curated. `rb hier` shells out to the standalone [rtl-buddy-view](https://github.com/rtl-buddy/rtl-buddy-view) renderer at subprocess granularity; rtl_buddy is not coupled to its Python API.
+>
+> **External binary required:** `rtl-buddy-view` — install with `uv tool install rtl-buddy-view` (or `pip install rtl-buddy-view`).
+>
+> **Optional:** `graphviz` (`dot`) for SVG/PNG conversion of `--format dot`; `pyslang` for `--frontend slang`.
+>
+> See also: [Installation — External tools by feature](../install.md#external-tools-by-feature).
+
+`rb hier <model>` produces a module-hierarchy view of a model defined in `models.yaml`. It writes a stripped, deduplicated filelist into `artefacts/hier/<model>/hier.f`, then runs `rtl-buddy-view --top <model> --filelist hier.f` with the requested format and forwards the renderer's stdout to the terminal so it composes with shell pipes.
+
+## Installing rtl-buddy-view
+
+```bash
+uv tool install rtl-buddy-view    # recommended — isolated tool env
+# or
+uv pip install rtl-buddy-view     # into the project venv
+```
+
+Once installed, the binary lands on `PATH` as `rtl-buddy-view`. Override with `--tool /absolute/path/to/rtl-buddy-view` if you need a specific build.
+
+For `--format dot` rendering to SVG/PNG, install Graphviz (`brew install graphviz` / `apt install graphviz`) and pipe the output through `dot` (see [Output formats](#output-formats) below).
+
+## Output formats
+
+`--format` selects one of four renderers:
+
+| Format | What you get |
+|--------|--------------|
+| `tree` (default) | ASCII tree, ideal for terminal inspection |
+| `dot` | Graphviz DOT source — pipe through `dot -Tsvg` / `-Tpng` for graphics |
+| `mermaid` | Mermaid diagram source — paste into Markdown that renders Mermaid |
+| `json` | Structured JSON (schema_version, tool.\*, design.top, nodes, edges) for programmatic consumption |
+
+When `-o`/`--output` is not set, the renderer's stdout passes through to your terminal so `rb hier x --format dot | dot -Tsvg -o x.svg` works as a one-liner.
+
+## Running `rb hier`
+
+```bash
+# ASCII tree (default)
+rb hier demo_top
+
+# Save Mermaid source to a file
+rb hier demo_top --format mermaid -o demo_top.mmd
+
+# DOT → SVG via Graphviz
+rb hier demo_top --format dot | dot -Tsvg -o demo_top.svg
+
+# JSON export for downstream tooling
+rb hier demo_top --format json -o demo_top.hier.json
+
+# Point at a non-default models.yaml
+rb hier demo_top -c design/demo_top/models.yaml
+
+# Pin a renderer build
+rb hier demo_top --tool /opt/rtl-buddy-view/bin/rtl-buddy-view
+```
+
+The model argument matches the `name:` of an entry in `models.yaml`. The runner uses that entry's filelist verbatim — same source of truth that `rb test`, `rb synth`, and `rb cdc` consume.
+
+## Parser frontend
+
+`--frontend` is forwarded as-is to `rtl-buddy-view`. The default frontend ships with the renderer; `--frontend slang` uses pyslang for SystemVerilog constructs the default frontend doesn't parse. rtl_buddy does not validate the set of accepted frontends — that lets the renderer add frontends without an rtl_buddy release. Unknown values are rejected by the renderer's own argument parser.
+
+## CDC and RDC annotations
+
+`rb hier` can overlay clock-domain and reset-domain information when the corresponding analyzer pass has emitted a JSON map:
+
+```bash
+# Clock-domain overlay — colors each module by its primary clock
+rtl-buddy-cdc --emit-domain-map -o clocks.json ...
+rb hier demo_top --format dot --cdc-annotations clocks.json | dot -Tsvg -o hier.svg
+
+# With a side legend mapping color → clock name (dot format only)
+rb hier demo_top --format dot --cdc-annotations clocks.json --clock-legend | dot -Tsvg -o hier.svg
+
+# Reset-domain overlay — colors each module by its primary reset
+rtl-buddy-cdc --emit-reset-domain-map -o resets.json ...
+rb hier demo_top --format dot --rdc-annotations resets.json | dot -Tsvg -o hier.svg
+```
+
+Both annotation files are JSON keyed by hierarchical instance path. `rb hier` validates that the files exist before invoking the renderer; the renderer's JSON contract (`schema_version`, `tool.*`, `design.top`, `nodes`, `edges`) is the integration boundary.
+
+`--clock-legend` is honored only for `--format dot`; the tree and Mermaid renderers ignore it.
+
+## Artefacts
+
+Per-model outputs land under the current directory's `artefacts/hier/<model>/`:
+
+| File | Contents |
+|---|---|
+| `hier.f` | Stripped, deduplicated filelist passed to the renderer |
+| `hier.log` | Renderer stderr (its stdout goes to your terminal when `-o` is not set) |
+
+When `-o <path>` is supplied the renderer writes directly to that path; otherwise its stdout is the diagram source itself.
+
+## Pass/fail detection
+
+`rb hier` exits with the renderer's exit code. A non-zero exit means the renderer reported a parse, elaboration, or output error — check `hier.log` for the captured stderr.
+
+The `Failed to locate rtl-buddy-view` error before the renderer runs is the most common failure mode and indicates that `rtl-buddy-view` is not installed in the active venv or on `PATH`. Run `rb tool-check --explain rtl-buddy-view` for the install hint.
+
+## Hub integration
+
+The [coordination hub](hub.md) consumes `rb hier`'s JSON output (`--format json`) to drive the rtl-buddy-view SPA's interactive hierarchy view. Annotation files (`--cdc-annotations`, `--rdc-annotations`, `--overlay axi-perf=...`) are surfaced as overlays in the SPA when the hub is running.
+
+`rb hub start --model <name>` discovers the model's `models.yaml`, invokes `rb hier` under the hood, and serves the result alongside live diagnostics and AXI-perf overlays — `rb hier` is the underlying renderer for both the static CLI use case and the live SPA flow.
+
+## Out of scope (today)
+
+- **rtl-buddy-view only.** No alternative hierarchy renderers are wired up. The integration is intentionally subprocess-granularity so a viewer release can be picked up via `uv sync` without code changes here.
+- **In-place SVG/PNG.** `rb hier` does not directly emit SVG or PNG — it emits DOT and lets you pipe through Graphviz. This keeps the rtl_buddy ↔ renderer boundary at "text in, text out" and avoids a Graphviz dependency for the common terminal-inspection flow.

--- a/docs/concepts/tool-check.md
+++ b/docs/concepts/tool-check.md
@@ -1,0 +1,174 @@
+---
+description: How to verify the rtl_buddy external-tool environment with the rb tool-check command, the declarative tool manifest, and the per-subcommand readiness report.
+---
+
+# Tool Dependency Check
+
+`rb tool-check` reports which external tools `rtl_buddy` has located, which subcommands are ready to run, and which are blocked on a missing or outdated dependency. It is a diagnostic surface for the declarative [tool manifest](#how-the-manifest-works) — the same source of truth that subcommand wrappers consult when they refuse to run because a tool is missing.
+
+`rb tool-check` must work both inside and outside a project: it opportunistically discovers a `root_config.yaml` to honor project pins (verible/surfer paths, `cfg-tools` min-versions, `cfg-fpv-tools` solver pins), but degrades gracefully when none is present.
+
+## Quick start
+
+```bash
+# Default — text report of all tools + per-subcommand readiness
+rb tool-check
+
+# JSON for scripting / CI
+rb tool-check --format json
+
+# Only the deps relevant to one subcommand
+rb tool-check --required-for fpv
+
+# Install instructions for a single tool
+rb tool-check --explain surfer
+
+# Fail the shell when something required is missing/outdated
+rb tool-check --strict
+```
+
+`rb tool-check` runs at the top level — it does not require a `root_config.yaml`, a suite directory, or any prior command. The `--include-optional/--no-include-optional` flag (default on) controls whether optional tools (gtkwave, klayout, graphviz, pyslang, cocotb, FPV solvers, etc.) appear in the report.
+
+## Output
+
+The default text format has two sections plus a hint line:
+
+```
+Tools (12 ok, 1 missing, 1 outdated)
+----------------------------------------------------------------------
+Tool                  Status      Version       Path
+verible               ok          v0.0-3724     /opt/homebrew/bin/verible-verilog-syntax
+yosys                 ok          0.45+115      /opt/homebrew/bin/yosys
+verilator             outdated    5.0.18        /opt/homebrew/bin/verilator  (need ≥ 5.020)
+surfer                ok          0.3.0         /opt/homebrew/bin/surfer
+sby                   missing     —             —  (optional)
+...
+
+Subcommand readiness
+----------------------------------------------------------------------
+  ok        rb test                 (verible, yosys, verilator, ...)
+  outdated  rb test                 (outdated: verilator)
+  missing   rb fpv                  (needs: sby)                            (optional feature)
+  ...
+
+Hint: `rb tool-check --explain <tool>` for install instructions.
+```
+
+The **Tools** section is the per-tool table — name, status (`ok` / `missing` / `outdated`), captured version, resolved path. Python-package detectors show `(python)` in the Path column. A `(need ≥ X)` suffix appears when a tool is present but below `minimum_version`. An `(optional)` suffix appears for tools whose absence does not gate any subcommand.
+
+The **Subcommand readiness** section lists every `rb <subcommand>` whose deps are declared in the manifest. The gloss after each subcommand calls out what is missing or outdated, or lists the participating tools when everything is OK. `(optional feature)` indicates a subcommand whose deps are all optional — `rb wave` is ready even without `gtkwave` installed, for example.
+
+## Subcommand: `--required-for`
+
+```bash
+rb tool-check --required-for fpv
+```
+
+Narrows the report to just the tools whose `used_by:` includes the named subcommand. Pairs naturally with `--strict` for a "is `rb fpv` ready right now?" CI check:
+
+```bash
+rb tool-check --required-for fpv --strict || \
+  { echo "rb fpv is not ready — see above"; exit 1; }
+```
+
+Exit code semantics under `--required-for` differ slightly from the default — see [Exit codes](#exit-codes) below.
+
+## Subcommand: `--explain`
+
+```bash
+rb tool-check --explain surfer
+```
+
+Prints the full manifest entry for a single tool — description, used-by subcommands, per-platform install hints, minimum version, and optional notes. Example:
+
+```
+surfer — Web-native waveform viewer
+  Status:  ok
+  Version: 0.3.0
+  Path:    /opt/homebrew/bin/surfer
+  Used by: rb wave, rb wave-fpv, rb hub
+  Install:
+    source   https://github.com/rtl-buddy/surfer (branch rtl-buddy)
+    build    cd ../surfer && cargo build --release
+```
+
+This is also what subcommand wrappers point you at when they refuse to run because a tool is missing — e.g. `rb wave` saying "surfer not found — run `rb tool-check --explain surfer`".
+
+## JSON output
+
+```bash
+rb tool-check --format json
+```
+
+Emits a structured payload with `tools`, `subcommands`, and a top-level `exit_code` (the same code the process exits with). Schema sketch:
+
+```json
+{
+  "tools": {
+    "verible": { "status": "ok", "version": "v0.0-3724", "path": "/opt/homebrew/bin/...", "optional": false },
+    "sby":     { "status": "missing", "version": null, "path": null, "optional": true }
+  },
+  "subcommands": {
+    "fpv":  { "status": "missing", "missing": ["sby"], "outdated": [], "optional_feature": true },
+    "test": { "status": "ok", "missing": [], "outdated": [] }
+  },
+  "exit_code": 1
+}
+```
+
+JSON output is the wire format for CI agents and IDE integrations — `rb tool-check --format json` is stable enough to script against. Combine with `--required-for` to narrow the result to a single subcommand.
+
+## How the manifest works
+
+The single source of truth lives in `src/rtl_buddy/tool_manifest.py`. Each `ToolSpec` declares:
+
+| Field | Purpose |
+|-------|---------|
+| `name` | Canonical key used by `--explain`, JSON output, and runtime `require()` |
+| `binaries` | Binary names to look for; first one found wins |
+| `version_cmd` / `version_regex` | How to probe and parse the installed version |
+| `minimum_version` | Lower bound; if violated, status flips to `outdated` |
+| `detection` | Ordered detectors (`PathDetector`, `VendorDetector`, `AbsolutePathDetector`, `PythonPackageDetector`, `PythonSiblingDetector`) — first `found=True` wins |
+| `install_hint` | Per-platform install instructions for `--explain` |
+| `used_by` | Subcommands gated by this tool; drives the readiness section |
+| `optional` | If true, missing does not gate subcommand readiness |
+
+The same `ToolSpec` is consulted at runtime when a wrapper invokes `tool_manifest.require("<name>")` — that's how subcommand wrappers produce a uniform "missing tool, see `rb tool-check --explain X`" message instead of an opaque `FileNotFoundError`.
+
+## Reconciliation with `root_config.yaml`
+
+When a project's `root_config.yaml` is discoverable from the current directory, `rb tool-check` reconciles it with the manifest:
+
+- **`cfg-verible`** — the active platform's verible directory is added to verible's detector chain as the *preferred* lookup, with `PATH` retained as fallback.
+- **`cfg-surfer`** — the `surfer-default` entry's resolved path is added similarly.
+- **`cfg-tools`** — overrides `minimum_version` for any matching tool. Project pins always win over manifest defaults.
+- **`cfg-fpv-tools[*].opts.solver-versions`** — pins each FPV solver to an exact version. Runtime semantics is exact-equality (`rb fpv` hard-fails on mismatch); `rb tool-check` surfaces the pin as `minimum_version` so users see a single "outdated" indication for solvers that don't match.
+
+Outside a project (no `root_config.yaml` discoverable), the manifest defaults apply unchanged. The "outside a project" mode is important for first-run setup: `rb tool-check` after `pip install rtl_buddy` is a valid invocation and tells the user what to install before they create a project.
+
+## Version cache
+
+Probed versions are cached to `${XDG_CACHE_HOME:-~/.cache}/rtl_buddy/tool_versions.json` keyed by `(path, mtime)`. The cache makes repeated `rb tool-check` invocations cheap — most tools don't need to be re-probed if their binary hasn't changed. Pass `--no-probe-versions` to skip version probing entirely (faster, but the Version column shows `—` for everything).
+
+## Exit codes
+
+| Exit | Meaning |
+|------|---------|
+| `0` | All required tools present and up-to-date (optional gaps don't matter) |
+| `1` | At least one required tool missing or outdated |
+| `2` | `--required-for <sub>` was passed and that subcommand's deps are missing/outdated |
+
+`--strict` is implied for `--required-for` — exit code semantics differ from the default to make the "this one subcommand is broken" case distinguishable from the broader "some tool, somewhere, is missing" case.
+
+## When to use it
+
+- **First-time setup.** Right after `uv add rtl_buddy`, run `rb tool-check` to see which external tools you still need to install for the subcommands you care about.
+- **CI gate.** A `rb tool-check --strict` step at the start of a CI job fails fast with an actionable error if the runner image drifted from the expected toolchain.
+- **Triaging a "tool not found" error.** When a subcommand wrapper says "X not found — run `rb tool-check --explain X`", that's the canonical entry point.
+- **After upgrading a tool.** Re-running `rb tool-check` after `brew upgrade verilator` (etc.) updates the cached version and re-evaluates `minimum_version` checks.
+
+## Out of scope (today)
+
+- **Tool installation.** `rb tool-check` reports state and gives install hints; it does not run installers itself. Treat the install hints as documentation, not as automation.
+- **Cross-platform install scripts.** Hints are per-OS (`macos`, `linux`, `source`, `vendor`, `any`); a unified setup script generator is a future possibility but not built today.
+- **Custom user manifests.** The manifest is built-in; projects can pin versions and binary paths via `root_config.yaml`, but they cannot add wholly new tools to the manifest. Adding a tool is a code change to `src/rtl_buddy/tool_manifest.py`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,11 +44,15 @@ nav:
       - cocotb: concepts/cocotb.md
       - Spec Traceability: concepts/spec-traceability.md
       - Waveform Viewer: concepts/wave.md
+      - Hierarchy Rendering: concepts/hier.md
       - Hub: concepts/hub.md
       - Synthesis: concepts/synthesis.md
       - Place-and-Route: concepts/pnr.md
       - Power Analysis: concepts/power.md
+      - CDC Lint: concepts/cdc.md
       - Formal Property Verification: concepts/fpv.md
+      - AXI Profiling: concepts/axi-profile.md
+      - Tool Check: concepts/tool-check.md
   - Reference:
       - CLI: reference/cli.md
       - YAML Formats: reference/yaml.md


### PR DESCRIPTION
## Summary

These four subcommands have been first-class on `main` for a while but didn't have their own concept pages — the only mention of them was in the README features list (most recently expanded in #147). This adds full pages covering integration type, install steps, YAML config (where applicable), CLI surface, artefacts, pass/fail detection, hub integration (where applicable), and out-of-scope notes — matching the style of the existing `pnr` / `fpv` / `power` / `wave` pages.

| New page | Covers |
|----------|--------|
| `docs/concepts/cdc.md` | `rb cdc`, `rb cdc-regression` via rtl-buddy-cdc — `cdc.yaml`, `cfg-cdc-tools`, results / artefacts, hub diagnostics publish |
| `docs/concepts/hier.md` | `rb hier` via rtl-buddy-view — output formats, parser frontend, `--cdc-annotations` / `--rdc-annotations` overlays, hub integration |
| `docs/concepts/axi-profile.md` | `rb axi-profile discover / gen-monitor / run / notebook` — `models.yaml` fields (`axi_bundles`, `axi_monitor_out`), per-test artefact layout, hub overlays + notebook launch |
| `docs/concepts/tool-check.md` | `rb tool-check` — declarative manifest, per-subcommand readiness, JSON output, `root_config.yaml` reconciliation, exit codes |

`mkdocs.yml` is updated to surface the four new pages under **Concepts**, with `Hierarchy Rendering` placed near `Waveform Viewer` / `Hub`, `CDC Lint` next to `Formal Property Verification`, and `Tool Check` at the bottom of the group.

## Out of scope

- No CLI surface changes — `scripts/gen_cli_reference.py --check` is a no-op.
- No README changes — the feature bullets landed in #147.
- No tests changed — pure docs.

## Test plan

- [ ] Render each new page on the PR file view and skim — every code block syntax-highlights, every table renders, every internal link resolves (`hub.md`, `install.md`, the `../reference/yaml.md` link in CDC).
- [ ] Confirm the **Concepts** nav grouping reads sensibly in the rendered site.
- [ ] `python scripts/check_docs_frontmatter.py --check` — passes locally.
- [ ] `python scripts/gen_cli_reference.py --check` — passes locally (no CLI surface changes, so this is a no-op).
- [ ] `mkdocs build --strict` — passes locally (the only output is the Material/MkDocs theme's generic 2.0 advisory, unrelated to this branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)