### PR TITLE
feat(hub): pass RB_HUB_EVENTS_URL to spawned marimo (Phase 3 close-out)

### DIFF
--- a/src/rtl_buddy/hub/axi_notebook_launcher.py
+++ b/src/rtl_buddy/hub/axi_notebook_launcher.py
@@ -210,6 +210,7 @@ async def launch(
     suite_dir: str,
     project_root: Path,
     timeout_s: float = DEFAULT_TIMEOUT_S,
+    events_url: str | None = None,
 ) -> LaunchResult:
     """Validate inputs, spawn marimo headless, return the URL.
 
@@ -245,6 +246,11 @@ async def launch(
     # marimo's URL line as soon as it's printed (rather than after
     # the kernel's block-buffer fills).
     env = {**os.environ, "PYTHONUNBUFFERED": "1"}
+    if events_url:
+        # Phase 3 sync (axi-profiler#16): the notebook template's
+        # ``notebook/sync.py`` reads this and joins the hub event
+        # broker so SPA bundle clicks reach the notebook.
+        env["RB_HUB_EVENTS_URL"] = events_url
     proc = await asyncio.create_subprocess_exec(
         *cmd,
         cwd=str(resolved_suite),

--- a/src/rtl_buddy/hub/viewer_http.py
+++ b/src/rtl_buddy/hub/viewer_http.py
@@ -439,6 +439,11 @@ class ViewerServer:
                     test=test,
                     suite_dir=suite_dir,
                     project_root=self.project_root,
+                    events_url=(
+                        f"ws://127.0.0.1:{self.http_port}/api/events/sync"
+                        if self.http_port
+                        else None
+                    ),
                 )
             except axi_notebook_launcher.AxiNotebookLaunchError as e:
                 return _http_response(

--- a/tests/test_hub_axi_notebook.py
+++ b/tests/test_hub_axi_notebook.py
@@ -138,6 +138,62 @@ def test_launch_returns_url_when_subprocess_prints_one(
         pass
 
 
+def test_launch_propagates_events_url_to_subprocess_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Phase 3: when called with ``events_url``, the launcher exports
+    ``RB_HUB_EVENTS_URL`` so the spawned marimo can join the broker.
+    When omitted, no env var leaks through."""
+    suite = _write_suite(tmp_path)
+    fake = _fake_marimo(tmp_path, url="http://localhost:31337")
+
+    monkeypatch.setattr(axi_notebook_launcher.shutil, "which", lambda _: "marimo")
+    monkeypatch.setattr(
+        axi_notebook_launcher,
+        "_build_cmd",
+        lambda *, suite_dir, test, port: [str(fake)],
+    )
+    captured: dict[str, dict[str, str]] = {}
+    real_create = axi_notebook_launcher.asyncio.create_subprocess_exec
+
+    async def spy(*args, **kwargs):
+        captured["env"] = kwargs["env"]
+        return await real_create(*args, **kwargs)
+
+    monkeypatch.setattr(axi_notebook_launcher.asyncio, "create_subprocess_exec", spy)
+
+    result = asyncio.run(
+        axi_notebook_launcher.launch(
+            test="basic",
+            suite_dir=str(suite),
+            project_root=tmp_path,
+            timeout_s=5.0,
+            events_url="ws://127.0.0.1:7000/api/events/sync",
+        )
+    )
+    assert captured["env"]["RB_HUB_EVENTS_URL"] == "ws://127.0.0.1:7000/api/events/sync"
+    try:
+        os.kill(result.pid, 9)
+    except ProcessLookupError:
+        pass
+
+    # Second pass without events_url — env stays clean.
+    captured.clear()
+    result2 = asyncio.run(
+        axi_notebook_launcher.launch(
+            test="basic",
+            suite_dir=str(suite),
+            project_root=tmp_path,
+            timeout_s=5.0,
+        )
+    )
+    assert "RB_HUB_EVENTS_URL" not in captured["env"]
+    try:
+        os.kill(result2.pid, 9)
+    except ProcessLookupError:
+        pass
+
+
 def test_launch_raises_when_subprocess_exits_before_url(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

- `axi_notebook_launcher.launch()` gains an optional `events_url` kwarg; when set it exports `RB_HUB_EVENTS_URL` into the spawned marimo subprocess's env.
- `viewer_http._handle_axi_notebook` derives the URL from the viewer's own HTTP port (`ws://127.0.0.1:<port>/api/events/sync`) and passes it through. When the viewer hasn't bound a port yet (test fixtures only), the env var is omitted and the notebook just runs standalone.

## Why

Closes Phase 3 of the marimo umbrella (rtl-buddy-axi-profiler#16). The SPA half (rtl-buddy-view#98) and the notebook half (rtl-buddy-axi-profiler#29) already speak the broker protocol — this PR is the small wire that hands the notebook the broker URL on launch, so SPA bundle clicks reach the notebook without the user setting env vars by hand.

## Test plan
- [x] `uv run pytest tests/test_hub_axi_notebook.py` — 18 passed, including a new `test_launch_propagates_events_url_to_subprocess_env` that spies on `create_subprocess_exec` to confirm `RB_HUB_EVENTS_URL` is set when `events_url=` is passed and absent otherwise.
- [x] `uv run pytest` — 866 passed, 10 skipped (no regression).
- [x] `uv run ruff check` + `uv run ruff format --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)