### PR TITLE
hub: view_overlay_set request + rb hub send overlay CLI

### DIFF
--- a/src/rtl_buddy/hub/schema/hub-protocol-v1.json
+++ b/src/rtl_buddy/hub/schema/hub-protocol-v1.json
@@ -412,6 +412,39 @@
       }
     },
     {
+      "if": { "properties": { "type": { "const": "view_overlay_set" } }, "required": ["type"] },
+      "then": {
+        "oneOf": [
+          {
+            "properties": {
+              "kind": { "const": "request" },
+              "payload": {
+                "type": "object",
+                "required": ["name", "enabled"],
+                "additionalProperties": false,
+                "description": "Ask the SPA to toggle an overlay's enabled state. Names follow the same convention as `graph.overlays_present` — built-ins today are `clock`, `reset`, `axi-perf`, `wave`. Enabling an unknown name is a no-op (the SPA silently drops it, matching the existing soft-miss semantics for unrecognised overlay names).",
+                "properties": {
+                  "name":    { "type": "string", "minLength": 1 },
+                  "enabled": { "type": "boolean" }
+                }
+              }
+            }
+          },
+          {
+            "properties": {
+              "kind": { "const": "response" },
+              "payload": {
+                "type": "object",
+                "required": ["ok"],
+                "additionalProperties": false,
+                "properties": { "ok": { "type": "boolean" } }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
       "if": { "properties": { "type": { "const": "resolve_view_to_wave" } }, "required": ["type"] },
       "then": {
         "oneOf": [

--- a/src/rtl_buddy/hub/send.py
+++ b/src/rtl_buddy/hub/send.py
@@ -415,6 +415,30 @@ def cmd_view_pan(
 
 
 @send_app.command(
+    "overlay",
+    help=(
+        "Flip an overlay's enabled state on the SPA. Built-in NAMES "
+        "are 'clock', 'reset', 'axi-perf', 'wave'; an unknown name is "
+        "a no-op. Use --on / --off (default --on). Useful for agents "
+        "or scripted demos that want to direct the user's attention "
+        "to a specific overlay layer without a UI click."
+    ),
+)
+def cmd_view_overlay(
+    name: Annotated[str, typer.Argument(help="overlay name")],
+    on: Annotated[
+        bool,
+        typer.Option(
+            "--on/--off",
+            help="Enable (default) or disable the named overlay.",
+        ),
+    ] = True,
+) -> None:
+    with _open_or_exit() as h:
+        _print_response(h.request("view_overlay_set", {"name": name, "enabled": on}))
+
+
+@send_app.command(
     "capture",
     help=(
         "Ask the view peer (SPA) to snapshot the current graph and "

--- a/src/rtl_buddy/hub/server.py
+++ b/src/rtl_buddy/hub/server.py
@@ -91,6 +91,7 @@ REQUEST_ROUTING: dict[str, Origin] = {
     "open_source": Origin.SRC,
     "view_pan_to": Origin.VIEW,
     "view_capture": Origin.VIEW,
+    "view_overlay_set": Origin.VIEW,
 }
 """Request ``type`` → ``origin`` of the client that handles it.
 

--- a/tests/test_hub_protocol.py
+++ b/tests/test_hub_protocol.py
@@ -292,6 +292,7 @@ def test_vendored_schema_has_expected_types():
         "wave_values_changed",
         "view_pan_to",
         "view_capture",
+        "view_overlay_set",
         "wave_set_viewport",
         "wave_zoom_to_range",
         "wave_zoom_to_fit",


### PR DESCRIPTION
## Summary

Companion to [rtl-buddy-view #100](https://github.com/rtl-buddy/rtl-buddy-view/pull/100). Adds a hub-protocol request that any peer can fire to flip the SPA's overlay-enabled state remotely.

### Wire shape

\`\`\`json
{ "type": "view_overlay_set", "kind": "request",
  "payload": { "name": "wave", "enabled": true } }
\`\`\`

Routed to the view peer via REQUEST_ROUTING. The SPA dispatch handler lives in the viewer PR; it calls \`store.setOverlayEnabled(name, enabled)\` and replies \`{ok: true}\` (or \`false\` on malformed name).

### CLI

\`\`\`bash
rb hub send overlay wave --on    # enable
rb hub send overlay wave --off   # disable
\`\`\`

Built-in overlay names today: \`clock\`, \`reset\`, \`axi-perf\`, \`wave\`. Unknown names are a soft-miss (SPA drops them) — matches the existing soft-miss semantics for unrecognised overlay names.

### Use cases

- An LLM agent presenting an issue to the user: enable the relevant overlay layer (e.g. flip clock on to show a CDC violation) without a UI click.
- Scripted demos / tutorials that want deterministic overlay state at each step.
- nvim integration: a future :RtlBuddyOverlay command that toggles from the editor.

## Test plan

- [x] uv run pytest -q: 866 passed, 9 skipped
- [x] uv run ruff check: clean
- [x] test_vendored_schema_has_expected_types updated to include view_overlay_set
- [x] Manual demo against rtl-buddy-ai-project: 'rb hub send overlay wave --off' / '--on' toggles badges in real time

## Dependencies

Needs the [rtl-buddy-view PR #100](https://github.com/rtl-buddy/rtl-buddy-view/pull/100) for the SPA-side dispatch. Without it, the envelope reaches the view peer but is silently dropped (SPA doesn't know the type).

🤖 Generated with [Claude Code](https://claude.com/claude-code)