### PR TITLE
rb hier --view tb + /tests + ?test= TB-rooted views (#99)

### DIFF
--- a/docs/concepts/hier.md
+++ b/docs/concepts/hier.md
@@ -14,6 +14,8 @@ description: How to render module hierarchy diagrams with rtl_buddy via the rb h
 
 `rb hier <model>` produces a module-hierarchy view of a model defined in `models.yaml`. It writes a stripped, deduplicated filelist into `artefacts/hier/<model>/hier.f`, then runs `rtl-buddy-view --top <model> --filelist hier.f` with the requested format and forwards the renderer's stdout to the terminal so it composes with shell pipes.
 
+`rb hier <test> --view tb` (rtl-buddy-view #99 / 6b) renders the **testbench** hierarchy for a test from `tests.yaml`, with the DUT called out as a subtree. The test pins both the model (DUT side) and the TB top, so the positional argument is a test name in this mode. The merged DUT + TB filelist is written to `artefacts/hier/<model>/tb/<tb_name>/hier.f` and the renderer is invoked with both `--top <model>` and `--tb-top <tb.toplevel>`. Cache key is `(model, tb_name)`, so two tests sharing a TB share the artefact.
+
 ## Installing rtl-buddy-view
 
 ```bash
@@ -59,9 +61,12 @@ rb hier demo_top -c design/demo_top/models.yaml
 
 # Pin a renderer build
 rb hier demo_top --tool /opt/rtl-buddy-view/bin/rtl-buddy-view
+
+# TB-rooted view — render the testbench for a test, DUT called out as subtree
+rb hier basic_traffic --view tb
 ```
 
-The model argument matches the `name:` of an entry in `models.yaml`. The runner uses that entry's filelist verbatim — same source of truth that `rb test`, `rb synth`, and `rb cdc` consume.
+The model argument matches the `name:` of an entry in `models.yaml`. The runner uses that entry's filelist verbatim — same source of truth that `rb test`, `rb synth`, and `rb cdc` consume. In `--view tb` mode the positional argument is a test name from `tests.yaml` instead; the test pins both the model (DUT side) and the testbench top, and the renderer merges the model + TB filelists before elaborating from `--tb-top`.
 
 ## Parser frontend
 

--- a/docs/concepts/hub.md
+++ b/docs/concepts/hub.md
@@ -117,13 +117,24 @@ Once the hub is up, the SPA can change models without restarting:
   ```
   `has_cdc` is end-to-end: `true` only when the model has a `cdc:` field AND the referenced cdc.yaml exists AND at least one analysis resolves cleanly for the model. The endpoint walks for `models.yaml` per request, so newly-edited files appear without a restart. When `--models-file PATH` was passed at start time, only that file is enumerated.
 - `GET /view.json?model=NAME` — build (or reuse) the per-model view.json at `.rtl-buddy/cache/view-<NAME>.json`, serve it, and promote `NAME` to the active model. `--models-file` constraints apply: `?model=` only honours entries in the pinned file. Per-model `asyncio.Lock` serialises concurrent same-model requests so a cold-cache race doesn't run rtl-buddy-view twice for the same model.
-- `view_changed` event — broadcast on every active-model change. Envelope:
+- `GET /tests` — list every test the hub can serve (rtl-buddy-view #99 / 6b). Same per-request walk as `/models`; entries carry the resolved `(model, tb)` pair so the SPA's TB-mode picker can label options. Empty list signals "no tests advertised" — the SPA's DUT/TB toggle stays hidden. JSON shape:
+  ```json
+  {
+    "tests": [
+      {"name": "basic", "model": "ip_demo_tiny_npu", "tb": "tb_top", "tests_file": "/abs/path/to/tests.yaml"}
+    ],
+    "active": "basic"
+  }
+  ```
+- `GET /view.json?test=NAME` — build (or reuse) the per-`(model, tb)` view.json at `.rtl-buddy/cache/view-<MODEL>-tb-<TB>.json`, serve it, and promote the test (and its underlying model) to active. Per-test `asyncio.Lock` mirrors the per-model lock. The renderer runs in TB-rooted mode: rtl-buddy-view is invoked with `--top <model>` + `--tb-top <tb.toplevel>` so the rendered tree is rooted at the testbench top with the DUT recorded for the SPA's dashed-boundary overlay.
+- `view_changed` event — broadcast on every active-view change. Envelope:
   ```json
   {"v":1, "id":"…", "origin":"cli", "kind":"event", "type":"view_changed",
    "payload":{"model":"ip_dtnpu_dma", "models_file":"/abs/path/to/models.yaml",
-              "view_url":"/view.json?model=ip_dtnpu_dma"}}
+              "view_url":"/view.json?model=ip_dtnpu_dma",
+              "view_mode":"dut"}}
   ```
-  Sent to every connected client (SPA tabs, nvim, `rb wave` bridge) so they can refresh model-scoped state.
+  In TB-view mode (`?test=` switch) the payload carries `view_mode: "tb"` plus `test` + `tb` + `tests_file` fields (the `view_url` points at `/view.json?test=<NAME>`). v1.0 SPAs that don't know about `view_mode` ignore it and fall through to the legacy `model`-driven `switchModel` path — that's why the DUT-side envelope still carries the full set of legacy fields. Sent to every connected client (SPA tabs, nvim, `rb wave` bridge) so they can refresh view-scoped state.
 
 The active model is also recorded in `.rtl-buddy/hub.json` under `active_model` (optional field) and surfaced in `rb hub status` output.
 
@@ -159,7 +170,7 @@ http_port   = 0          # Same, for the viewer HTTP+WS layer (only used with --
 log_path    = ".rtl-buddy/hub.log"   # Relative paths resolve from the project root.
 
 [mapping]
-tb_prefix   = "tb.dut."  # Stripped from wave-side signal paths before resolving to the view.
+tb_prefix   = "tb.dut."  # Fallback for DUT-rooted views. When the loaded view.json carries tb_top (rtl-buddy-view v1.1, #99 / 6b), the resolver short-circuits to identity wave↔view mapping and tb_prefix is bypassed — the rendered TB tree already speaks the wave-side coordinate system.
 view_json   = ".rtl-buddy/view.json"  # Snapshot the resolver consumes. Defaults shown.
 
 # Optional pre-strip aliases — applied before tb_prefix is stripped.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -191,15 +191,25 @@ Usage: rtl-buddy filelist [OPTIONS] MODEL_NAME [OUTPUT_PATH]
 ## hier
 
 ```text
-Usage: rtl-buddy hier [OPTIONS] MODEL_NAME                                             
+Usage: rtl-buddy hier [OPTIONS] NAME                                                   
                                                                                         
  render module hierarchy via rtl-buddy-view                                             
                                                                                         
 ╭─ Arguments ──────────────────────────────────────────────────────────────────────────╮
-│ *    model_name      TEXT  model from models.yaml [required]                         │
+│ *    name      TEXT  with --view dut (default): model name from models.yaml; with    │
+│                      --view tb: test name from tests.yaml (the test pins both the    │
+│                      model + the testbench top)                                      │
+│                      [required]                                                      │
 ╰──────────────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ────────────────────────────────────────────────────────────────────────────╮
 │ --model-config     -c      TEXT  models.yaml to use [default: models.yaml]           │
+│ --test-config              TEXT  tests.yaml to use (--view tb) [default: tests.yaml] │
+│ --view                     TEXT  what to render: 'dut' (default) renders the model   │
+│                                  hierarchy rooted at --top; 'tb' renders the         │
+│                                  testbench hierarchy with the DUT called out as a    │
+│                                  subtree. With --view tb the positional argument is  │
+│                                  a test name.                                        │
+│                                  [default: dut]                                      │
 │ --format                   TEXT  output format: tree, dot, mermaid, json             │
 │                                  [default: tree]                                     │
 │ --output           -o      TEXT  write renderer output to file instead of stdout     │

--- a/src/rtl_buddy/hub/resolver.py
+++ b/src/rtl_buddy/hub/resolver.py
@@ -145,6 +145,15 @@ class ViewModel:
     edges_parent_to_children: dict[str, tuple[str, ...]]
     source_path: Path | None = None
     source_mtime_ns: int | None = None
+    # view.json v1.1 (rtl-buddy-view #99): when the renderer was
+    # invoked with ``--tb-top``, the rendered root is the testbench
+    # top and the wave path is the identity of the view path — no
+    # ``tb_prefix`` strip. ``tb_top`` is the recorded TB top name;
+    # the identity check at the view↔wave boundary is
+    # ``top == tb_top``. ``None`` for v1.0 payloads or DUT-only
+    # views, in which case the legacy tb_prefix strip applies.
+    tb_top: str | None = None
+    dut_top: str | None = None
 
     @classmethod
     def from_dict(cls, raw: dict, *, source_path: Path | None = None) -> "ViewModel":
@@ -174,6 +183,15 @@ class ViewModel:
             )
         if not isinstance(top, str) or not top:
             raise ResolverError("view.json missing top (or design.top)")
+
+        # v1.1 envelope fields (#99). Both nullable: omitted on v1.0
+        # payloads, ``None`` on TB-only or DUT-only renders. Wrong
+        # type is silently demoted to None to preserve the v1.0
+        # consumer-tolerant contract.
+        tb_top_raw = raw.get("tb_top")
+        tb_top = tb_top_raw if isinstance(tb_top_raw, str) and tb_top_raw else None
+        dut_top_raw = raw.get("dut_top")
+        dut_top = dut_top_raw if isinstance(dut_top_raw, str) and dut_top_raw else None
 
         # Same dual-schema acceptance for nodes: canonical uses `id` +
         # `source`; legacy fixtures use `instance_path` + `location`.
@@ -229,7 +247,22 @@ class ViewModel:
             nodes_by_path=nodes_by_path,
             edges_parent_to_children=edges_frozen,
             source_path=source_path,
+            tb_top=tb_top,
+            dut_top=dut_top,
         )
+
+    @property
+    def tb_rooted(self) -> bool:
+        """True when the rendered tree is the testbench top (#99 / 6b).
+
+        The renderer pins ``top == tb_top`` whenever ``--tb-top`` was
+        passed (see rtl-buddy-view's :mod:`render.json_render`
+        envelope rule). At this point view paths and wave paths are
+        the same coordinate frame — the SPA shows the TB hierarchy
+        verbatim, and surfer loads waveforms keyed by the same
+        instance paths.
+        """
+        return self.tb_top is not None and self.top == self.tb_top
 
 
 def _location_to_anchor(raw: object) -> SourceAnchor | None:
@@ -333,13 +366,26 @@ class Resolver:
         path optimistically; this is the "no resolver loaded" fallback
         the server's error handler exposes as unresolvable when the
         guess matters.
+
+        v1.1 (#99 / 6b): when the loaded view.json is TB-rooted
+        (``ViewModel.tb_rooted``), the wave path IS the view path —
+        the renderer elaborated from the testbench top so view paths
+        already match the names surfer / WCP advertise. ``tb_prefix``
+        is bypassed entirely in that mode; it stays as the v1.0
+        fallback for DUT-only renders.
         """
 
         if instance_path in self._view_alias_to_wave:
             return self._view_alias_to_wave[instance_path]
 
-        # Drop the design.top root if present, then prepend tb_prefix.
         model = self._load_if_possible()
+        if model is not None and model.tb_rooted:
+            # Identity mapping. Still gate on node existence so a
+            # typo or stale request returns ``None`` rather than a
+            # path the wave side will fail to find.
+            return instance_path if instance_path in model.nodes_by_path else None
+
+        # Drop the design.top root if present, then prepend tb_prefix.
         if model is not None:
             if instance_path not in model.nodes_by_path:
                 return None
@@ -354,10 +400,19 @@ class Resolver:
         return prefix + stripped
 
     def wave_to_view(self, wave_scope: str) -> str | None:
-        """Return the view instance path for a wave path, or ``None``."""
+        """Return the view instance path for a wave path, or ``None``.
+
+        v1.1 (#99 / 6b): when TB-rooted, the view path IS the wave
+        path; gate on node existence rather than the legacy
+        prefix-strip.
+        """
 
         if wave_scope in self._wave_alias_to_view:
             return self._wave_alias_to_view[wave_scope]
+
+        model = self._load_if_possible()
+        if model is not None and model.tb_rooted:
+            return wave_scope if wave_scope in model.nodes_by_path else None
 
         prefix = self._mapping.tb_prefix
         if prefix and wave_scope.startswith(prefix):
@@ -367,7 +422,6 @@ class Resolver:
         else:
             return None
 
-        model = self._load_if_possible()
         if model is None:
             return tail  # Best-effort.
 

--- a/src/rtl_buddy/hub/schema/hub-protocol-v1.json
+++ b/src/rtl_buddy/hub/schema/hub-protocol-v1.json
@@ -657,24 +657,43 @@
           "kind": { "const": "event" },
           "payload": {
             "type": "object",
-            "required": ["model", "models_file", "view_url"],
+            "required": ["model", "view_url"],
             "additionalProperties": false,
-            "description": "Broadcast by the hub (origin=cli) whenever the active view.json model changes — driven by a SPA `?model=` switch today, by file-watch refresh later. Consumers should refetch model-scoped state.",
+            "description": "Broadcast by the hub (origin=cli) whenever the active view changes — driven by a SPA `?model=` or `?test=` switch today, by file-watch refresh later. Consumers should refetch view-scoped state. The `view_mode` field (rtl-buddy-view #99 / 6b) marks DUT vs TB renders; TB renders also carry `test`, `tb`, and `tests_file` fields, while DUT renders carry `models_file`.",
             "properties": {
               "model": {
                 "type": "string",
                 "minLength": 1,
-                "description": "The model name now serving on `GET /view.json` with no query."
+                "description": "The DUT model name. Always present — for TB renders this is the model the test pins."
               },
               "models_file": {
                 "type": "string",
                 "minLength": 1,
-                "description": "Absolute path to the models.yaml that owns the entry."
+                "description": "Absolute path to the models.yaml that owns the entry. Set on DUT renders."
               },
               "view_url": {
                 "type": "string",
                 "minLength": 1,
-                "description": "Convenience URL the SPA can load directly to display this model — e.g. `/view.json?model=ip_dtnpu_dma`."
+                "description": "Convenience URL the SPA can load directly — `/view.json?model=<NAME>` for DUT renders, `/view.json?test=<NAME>` for TB renders."
+              },
+              "view_mode": {
+                "enum": ["dut", "tb"],
+                "description": "Explicit render mode (#99 / 6b). v1.0 SPAs that don't know this field ignore it and fall through to the legacy model-driven switchModel path."
+              },
+              "test": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Test name. Set on TB renders only."
+              },
+              "tb": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Testbench name (from tests.yaml). Set on TB renders only."
+              },
+              "tests_file": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Absolute path to the tests.yaml that owns the entry. Set on TB renders only."
               }
             }
           }

--- a/src/rtl_buddy/hub/test_discovery.py
+++ b/src/rtl_buddy/hub/test_discovery.py
@@ -1,0 +1,250 @@
+"""Test discovery for ``rb hub`` TB-view mode (#99 / 6b).
+
+Walks the project tree for ``tests.yaml`` files, aggregates the
+named test entries with their resolved ``(model, tb)`` pair, and
+resolves a single match for an SPA-supplied ``?test=NAME`` request
+(with optional ``--tests-file`` pin).
+
+Mirrors :mod:`rtl_buddy.hub.model_discovery` for shape and skip
+rules — same conventional build/VCS dir exclusions, same git-
+worktree pruning, same alphabetical determinism. Keeping the two
+discoveries in lockstep makes the cross-file collision error
+messages familiar to anyone who's already debugged a ``--model``
+ambiguity.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+from serde.yaml import from_yaml
+
+from ..config.suite import SuiteConfigFile
+from ..config.test import TestConfig
+from ..errors import FatalRtlBuddyError
+from ..logging_utils import log_event
+
+logger = logging.getLogger(__name__)
+
+
+# Mirror model_discovery._SKIP_DIRS exactly — vendored fixtures,
+# build outputs, VCS metadata. Keep these two lists in sync; any
+# divergence will surface as "model X has has_cdc but test Y can't
+# be found" surprises.
+_SKIP_DIRS = frozenset(
+    {
+        ".git",
+        ".hg",
+        ".svn",
+        "node_modules",
+        "__pycache__",
+        ".venv",
+        "venv",
+        "artefacts",
+        "build",
+        "dist",
+        ".tox",
+        ".pytest_cache",
+        ".ruff_cache",
+        ".mypy_cache",
+    }
+)
+
+
+@dataclass(frozen=True)
+class TestMatch:
+    """One ``?test=NAME`` candidate during discovery."""
+
+    tests_file: Path
+    test_name: str
+
+
+@dataclass(frozen=True)
+class TestEntry:
+    """A single advertised test for ``GET /tests`` listings.
+
+    Carries the resolved ``model`` and ``tb`` names so the SPA can
+    annotate each option and skip an extra round-trip per click. The
+    ``tests_file`` is the absolute path to the ``tests.yaml`` that
+    owns the entry; the SPA uses it as the picker's stable key.
+    """
+
+    name: str
+    model: str
+    tb: str
+    tests_file: Path
+
+
+def discover_tests_files(root: Path) -> list[Path]:
+    """Return every ``tests.yaml`` reachable under ``root``.
+
+    Same walk rules as :func:`model_discovery.discover_models_files`.
+    """
+
+    root_resolved = Path(root).resolve()
+    results: list[Path] = []
+    for dirpath, dirnames, filenames in os.walk(root):
+        # Skip nested git worktrees (``.git`` as a file, not a dir).
+        if Path(dirpath).resolve() != root_resolved and ".git" in filenames:
+            git_entry = Path(dirpath) / ".git"
+            if git_entry.is_file():
+                dirnames.clear()
+                continue
+        dirnames[:] = sorted(d for d in dirnames if d not in _SKIP_DIRS)
+        if "tests.yaml" in filenames:
+            results.append(Path(dirpath) / "tests.yaml")
+    return results
+
+
+def _read_test_entries(path: Path) -> list[TestEntry]:
+    """Best-effort enumeration without running the full SuiteConfig
+    initialiser. We need three fields per test (``name``, ``model``,
+    ``tb``); the rest of the test config (sweep scripts, plusargs,
+    UVM block) is irrelevant to the picker and might fail to
+    deserialize on a project's stale ``tests.yaml``. Falling back to
+    [] on parse error keeps the discovery walk robust to broken
+    sibling projects, matching :func:`model_discovery._read_model_names`.
+    """
+
+    try:
+        data = from_yaml(SuiteConfigFile, path.read_text())
+    except Exception as exc:
+        log_event(
+            logger,
+            logging.DEBUG,
+            "hub.test_discovery.parse_skipped",
+            path=str(path),
+            error=str(exc),
+        )
+        return []
+    # Map ``testbench`` field on each test to the actual TB name; the
+    # serde-side TestConfigFile keeps ``tb`` as a string reference,
+    # not a resolved object. Tests whose tb reference is missing are
+    # dropped — the same SuiteConfig initialiser would have raised
+    # ``testbench_missing``, so silently skipping here keeps the
+    # listing useful even when the suite has a broken test.
+    tb_names = {tb.name for tb in data.testbenches}
+    out: list[TestEntry] = []
+    for t in data.tests:
+        if t.tb not in tb_names:
+            continue
+        out.append(
+            TestEntry(
+                name=t.name,
+                model=t.model,
+                tb=t.tb,
+                tests_file=path,
+            )
+        )
+    return out
+
+
+def list_tests(root: Path, tests_file: Path | None = None) -> list[TestEntry]:
+    """Enumerate every test in the project. With ``tests_file``
+    set, only that file is scanned (matches ``--tests-file`` pin
+    semantics on the CLI). Stable ordering: by tests-file path then
+    by test name within each file.
+    """
+
+    if tests_file is not None:
+        if not tests_file.is_file():
+            return []
+        files = [tests_file]
+    else:
+        files = discover_tests_files(root)
+    out: list[TestEntry] = []
+    for tf in sorted(files):
+        out.extend(_read_test_entries(tf))
+    return out
+
+
+def find_matches(tests_files: list[Path], test_name: str) -> list[TestMatch]:
+    """Return every ``(tests_file, test_name)`` pair where ``tests_file``
+    contains an entry named ``test_name``.
+    """
+
+    matches: list[TestMatch] = []
+    for tf in tests_files:
+        if any(entry.name == test_name for entry in _read_test_entries(tf)):
+            matches.append(TestMatch(tests_file=tf, test_name=test_name))
+    return matches
+
+
+def resolve_test(
+    root: Path,
+    test_name: str,
+    *,
+    tests_file: Path | None = None,
+) -> tuple[Path, TestConfig]:
+    """Resolve ``test_name`` to the owning ``tests.yaml`` + resolved
+    :class:`TestConfig`.
+
+    - ``tests_file`` set → load directly via SuiteConfig, no walk.
+    - ``tests_file`` unset → walk the project root; error on zero or
+      multiple matches with a guide pointing at ``--tests-file``.
+
+    Same shape as :func:`model_discovery.resolve_model` so the hub's
+    HTTP layer can share its error-translation logic.
+    """
+
+    from ..config.suite import SuiteConfig
+
+    if tests_file is not None:
+        if not tests_file.is_file():
+            raise FatalRtlBuddyError(f"--tests-file {tests_file}: not a file")
+        suite = SuiteConfig(str(tests_file))
+        test_cfg = list(suite.get_tests(test_name))[0]
+        return tests_file, test_cfg
+
+    files = discover_tests_files(root)
+    if not files:
+        raise FatalRtlBuddyError(
+            f"no tests.yaml found under {root}; "
+            f"use --tests-file PATH to point at one explicitly"
+        )
+
+    matches = find_matches(files, test_name)
+    if len(matches) == 0:
+        sample: list[str] = []
+        for tf in files:
+            for entry in _read_test_entries(tf):
+                rel = tf.relative_to(root) if tf.is_relative_to(root) else tf
+                sample.append(f"{rel}::{entry.name}")
+        log_event(
+            logger,
+            logging.ERROR,
+            "hub.test_discovery.not_found",
+            test=test_name,
+            root=str(root),
+            candidates=sample,
+        )
+        candidates_msg = (
+            "\n  ".join(sample) if sample else "(no tests defined in any file)"
+        )
+        raise FatalRtlBuddyError(
+            f"test {test_name!r} not found in any tests.yaml under {root}.\n"
+            f"  candidates:\n  {candidates_msg}"
+        )
+
+    if len(matches) > 1:
+        paths_msg = "\n  ".join(str(m.tests_file) for m in matches)
+        log_event(
+            logger,
+            logging.ERROR,
+            "hub.test_discovery.ambiguous",
+            test=test_name,
+            root=str(root),
+            matches=[str(m.tests_file) for m in matches],
+        )
+        raise FatalRtlBuddyError(
+            f"test {test_name!r} matches multiple tests.yaml files; "
+            f"pass --tests-file PATH to disambiguate:\n  {paths_msg}"
+        )
+
+    chosen = matches[0]
+    suite = SuiteConfig(str(chosen.tests_file))
+    test_cfg = list(suite.get_tests(test_name))[0]
+    return chosen.tests_file, test_cfg

--- a/src/rtl_buddy/hub/view_builder.py
+++ b/src/rtl_buddy/hub/view_builder.py
@@ -21,6 +21,7 @@ import shutil
 from pathlib import Path
 
 from ..config.model import ModelConfig
+from ..config.test import TestConfig
 from ..errors import FatalRtlBuddyError
 from ..logging_utils import log_event
 from ..tools.hier_rtl_buddy_view import RtlBuddyView
@@ -42,6 +43,19 @@ def view_json_path(project_root: Path, model_name: str) -> Path:
     return cache_dir(project_root) / f"view-{model_name}.json"
 
 
+def view_json_path_for_tb(project_root: Path, model_name: str, tb_name: str) -> Path:
+    """Per-(model, tb) output path for the TB-rooted view (#99 / 6b).
+
+    Cache key is ``(model, tb)`` rather than the test name: two tests
+    that share a testbench elaborate to byte-identical trees, so they
+    should share the artefact and the second click is a hot-cache
+    hit. The path layout mirrors the artefact tree the CLI wrapper
+    writes (``artefacts/hier/<model>/tb/<tb>/hier.f``) so an
+    operator reading either side recognises the same key.
+    """
+    return cache_dir(project_root) / f"view-{model_name}-tb-{tb_name}.json"
+
+
 def _resolve_viewer_executable() -> str:
     """Locate the ``rtl-buddy-view`` binary or raise a clear error.
     Same lookup convention as ``RtlBuddyView.run``.
@@ -61,6 +75,7 @@ def build_view_json(
     project_root: Path,
     model_cfg: ModelConfig,
     axi_perf_source: Path | None = None,
+    test_cfg: TestConfig | None = None,
 ) -> Path:
     """Generate view.json for ``model_cfg`` at the stable cache path
     and return it. Raises ``FatalRtlBuddyError`` when the
@@ -81,6 +96,14 @@ def build_view_json(
     the SPA's "Open in marimo" button reads to skip its prompt
     (Phase 2.5 of the marimo umbrella). When not supplied, the
     no-overlay path runs unchanged.
+
+    When ``test_cfg`` is supplied (#99 / 6b), the renderer is invoked
+    in TB-rooted mode (``--tb-top <tb.toplevel>`` alongside the
+    existing ``--top <model.name>``) and the cache path keys on the
+    ``(model, tb)`` pair via :func:`view_json_path_for_tb`. The DUT-
+    side CDC overlay is unchanged — the domain map's instance paths
+    still resolve into the rendered tree because they live under the
+    DUT subtree, which appears in TB elaboration too.
     """
 
     # Build the domain map FIRST so a misconfigured cdc: back-pointer
@@ -94,7 +117,10 @@ def build_view_json(
 
     cache = cache_dir(project_root)
     cache.mkdir(parents=True, exist_ok=True)
-    out_path = view_json_path(project_root, model_cfg.name)
+    if test_cfg is not None:
+        out_path = view_json_path_for_tb(project_root, model_cfg.name, test_cfg.tb.name)
+    else:
+        out_path = view_json_path(project_root, model_cfg.name)
 
     viewer_exe = _resolve_viewer_executable()
 
@@ -103,12 +129,14 @@ def build_view_json(
         logging.INFO,
         "hub.view_builder.generating",
         model=model_cfg.name,
+        tb=test_cfg.tb.name if test_cfg is not None else "",
         path=str(out_path),
         cdc_annotations=str(domain_map) if domain_map else "",
         axi_perf=str(axi_perf_source) if axi_perf_source else "",
     )
     runner = RtlBuddyView(
-        name=f"hub/view/{model_cfg.name}",
+        name=f"hub/view/{model_cfg.name}"
+        + (f"/tb/{test_cfg.tb.name}" if test_cfg is not None else ""),
         model_cfg=model_cfg,
         suite_dir=str(project_root),
         format="json",
@@ -116,11 +144,17 @@ def build_view_json(
         executable=viewer_exe,
         cdc_annotations=str(domain_map) if domain_map else None,
         axi_perf_annotations=str(axi_perf_source) if axi_perf_source else None,
+        test_cfg=test_cfg,
     )
     rc = runner.run()
     if rc != 0 or not out_path.is_file():
+        label = (
+            f"rb hub --model {model_cfg.name} --test {test_cfg.name}"
+            if test_cfg is not None
+            else f"rb hub --model {model_cfg.name}"
+        )
         raise FatalRtlBuddyError(
-            f"rb hub --model {model_cfg.name}: rtl-buddy-view exited with "
+            f"{label}: rtl-buddy-view exited with "
             f"code {rc}; see {Path(runner.artefact_dir) / 'hier.log'} for "
             f"details."
         )

--- a/src/rtl_buddy/hub/viewer_http.py
+++ b/src/rtl_buddy/hub/viewer_http.py
@@ -208,6 +208,16 @@ class ViewerServer:
         # ``?model=X`` / ``?model=Y`` requests run in parallel. Locks
         # are allocated lazily and never garbage-collected per session.
         self._model_locks: dict[str, asyncio.Lock] = {}
+        # Per-test lock map for ``?test=NAME`` (TB view, #99 / 6b).
+        # Same race-prevention as ``_model_locks`` — two SPA clicks on
+        # the same test funnel through one build, two clicks on
+        # different tests run in parallel.
+        self._test_locks: dict[str, asyncio.Lock] = {}
+        # Currently-active TB test (TB-view mode). None when the hub
+        # is serving a DUT view (default) or hasn't built any view
+        # yet. Flipped by ``?test=`` requests via
+        # ``_set_active_test``.
+        self.active_test: str | None = None
         # Marimo "Open in marimo" session cache (Phase 2.5).
         # ``(test, suite_dir) → LaunchResult``. Repeat clicks reuse
         # the cached entry when the spawned marimo is still alive
@@ -328,10 +338,16 @@ class ViewerServer:
         if path == "/models":
             return await self._handle_models(connection)
 
+        if path == "/tests":
+            return await self._handle_tests(connection)
+
         if path == "/api/axi-profile/notebook":
             return await self._handle_axi_notebook(connection, query)
 
         if path == "/view.json":
+            requested_test = query.get("test", [None])[0]
+            if requested_test is not None:
+                return await self._handle_view_json_for_test(connection, requested_test)
             requested = query.get("model", [None])[0]
             if requested is not None:
                 return await self._handle_view_json_for_model(connection, requested)
@@ -540,6 +556,64 @@ class ViewerServer:
             content_type="application/json",
         )
 
+    async def _handle_tests(self, connection: ServerConnection) -> Response:
+        """``GET /tests`` — list every test the hub can serve (#99 / 6b).
+
+        Walks per-request so a freshly-edited ``tests.yaml`` shows up
+        without restarting the hub. Each entry carries its resolved
+        ``(model, tb)`` pair so the SPA's TB-mode picker can label
+        options and skip an extra round-trip per click.
+
+        Empty list is the standalone / no-tests signal — the SPA's
+        DUT/TB toggle stays hidden in that case (matches the way
+        ``GET /models`` returns ``[]`` for standalone deployments).
+        """
+
+        from . import test_discovery
+
+        if self.project_root is None:
+            payload: dict[str, Any] = {"tests": [], "active": self.active_test}
+            return _http_response(
+                connection,
+                200,
+                json.dumps(payload).encode("utf-8"),
+                content_type="application/json",
+            )
+
+        try:
+            entries = test_discovery.list_tests(self.project_root)
+        except Exception as exc:  # pragma: no cover - defensive
+            log_event(
+                logger,
+                logging.ERROR,
+                "hub.viewer_http.tests_failed",
+                error=str(exc),
+            )
+            return _http_response(
+                connection,
+                500,
+                f"failed to enumerate tests: {exc}".encode("utf-8"),
+            )
+
+        payload = {
+            "tests": [
+                {
+                    "name": e.name,
+                    "model": e.model,
+                    "tb": e.tb,
+                    "tests_file": str(e.tests_file),
+                }
+                for e in entries
+            ],
+            "active": self.active_test,
+        }
+        return _http_response(
+            connection,
+            200,
+            json.dumps(payload).encode("utf-8"),
+            content_type="application/json",
+        )
+
     @staticmethod
     def _model_has_resolvable_cdc(model_cfg: Any) -> bool:
         """``has_cdc`` reflects end-to-end resolvability: the model
@@ -629,6 +703,10 @@ class ViewerServer:
         from .protocol import Envelope, Kind, Origin, new_id
 
         self.active_model = model_name
+        # Switching to a DUT view clears any TB-mode selection so the
+        # next ``GET /view.json`` (no query) returns the DUT bytes and
+        # the SPA's segmented control reflects the actual mode.
+        self.active_test = None
         if self.hub_server is not None:
             self.hub_server.state.active_model = model_name
         # ``view_json_path`` now points at the per-model cache so
@@ -657,6 +735,124 @@ class ViewerServer:
                     "model": model_name,
                     "models_file": str(models_file),
                     "view_url": f"/view.json?model={model_name}",
+                    # v1.1 protocol field (#99 / 6b): explicit
+                    # ``view_mode`` so SPA clients route the event
+                    # through the right action without inferring mode
+                    # from the URL. Legacy SPAs ignore unknown fields.
+                    "view_mode": "dut",
+                },
+            )
+            try:
+                await self.hub_server.broadcast_event(env, suppress_origin=None)
+            except Exception as exc:  # pragma: no cover - defensive
+                log_event(
+                    logger,
+                    logging.WARNING,
+                    "hub.viewer_http.broadcast_failed",
+                    error=str(exc),
+                )
+
+    async def _handle_view_json_for_test(
+        self, connection: ServerConnection, requested: str
+    ) -> Response:
+        """``GET /view.json?test=NAME`` — build (or reuse) the TB-rooted
+        view for the named test (#99 / 6b) and serve it. Updates
+        ``active_test`` + ``active_model`` on success and broadcasts
+        ``view_changed`` with ``view_mode='tb'``.
+        """
+
+        from . import test_discovery, view_builder
+        from ..errors import FatalRtlBuddyError
+
+        if self.project_root is None:
+            return _http_response(
+                connection,
+                400,
+                b"hub started without project_root; ?test= requires it",
+            )
+
+        try:
+            tests_yaml, test_cfg = test_discovery.resolve_test(
+                self.project_root, requested
+            )
+        except FatalRtlBuddyError as exc:
+            return _http_response(connection, 400, str(exc).encode("utf-8"))
+
+        # Per-test lock funnels concurrent ?test=NAME requests through
+        # one build_view_json call (same shape as ``_model_locks``).
+        lock = self._test_locks.setdefault(requested, asyncio.Lock())
+        async with lock:
+            try:
+                cache_path = await asyncio.to_thread(
+                    view_builder.build_view_json,
+                    project_root=self.project_root,
+                    model_cfg=test_cfg.get_model(),
+                    axi_perf_source=self.axi_perf_source,
+                    test_cfg=test_cfg,
+                )
+            except FatalRtlBuddyError as exc:
+                log_event(
+                    logger,
+                    logging.ERROR,
+                    "hub.viewer_http.view_json_build_failed",
+                    test=requested,
+                    error=str(exc),
+                )
+                return _http_response(connection, 500, str(exc).encode("utf-8"))
+
+        await self._set_active_test(
+            test_name=requested,
+            tests_file=tests_yaml,
+            model_name=test_cfg.get_model().name,
+            tb_name=test_cfg.tb.name,
+            view_path=cache_path,
+        )
+
+        return _http_response(
+            connection,
+            200,
+            cache_path.read_bytes(),
+            content_type="application/json",
+        )
+
+    async def _set_active_test(
+        self,
+        *,
+        test_name: str,
+        tests_file: Path,
+        model_name: str,
+        tb_name: str,
+        view_path: Path,
+    ) -> None:
+        """Promote ``test_name`` to the active TB view: flip in-memory
+        state and broadcast ``view_changed`` with ``view_mode='tb'``.
+
+        The active model is also updated (the test pins both) so the
+        DUT picker reflects what's resolved under the hood.
+        Idempotent.
+        """
+        from .protocol import Envelope, Kind, Origin, new_id
+
+        self.active_test = test_name
+        self.active_model = model_name
+        if self.hub_server is not None:
+            self.hub_server.state.active_model = model_name
+        # ``view_json_path`` now points at the per-(model, tb) cache.
+        self.view_json_path = view_path
+
+        if self.hub_server is not None:
+            env = Envelope(
+                origin=Origin.CLI,
+                kind=Kind.EVENT,
+                type="view_changed",
+                id=new_id(),
+                payload={
+                    "model": model_name,
+                    "test": test_name,
+                    "tb": tb_name,
+                    "tests_file": str(tests_file),
+                    "view_url": f"/view.json?test={test_name}",
+                    "view_mode": "tb",
                 },
             )
             try:

--- a/src/rtl_buddy/rtl_buddy.py
+++ b/src/rtl_buddy/rtl_buddy.py
@@ -1238,10 +1238,34 @@ class RtlBuddy:
 
     def do_cmd_hier(
         self,
-        model_name: Annotated[str, typer.Argument(help="model from models.yaml")],
+        name: Annotated[
+            str,
+            typer.Argument(
+                help=(
+                    "with --view dut (default): model name from models.yaml; "
+                    "with --view tb: test name from tests.yaml (the test "
+                    "pins both the model + the testbench top)"
+                )
+            ),
+        ],
         model_config: Annotated[
             str, typer.Option("-c", "--model-config", help="models.yaml to use")
         ] = "models.yaml",
+        test_config: Annotated[
+            str, typer.Option("--test-config", help="tests.yaml to use (--view tb)")
+        ] = "tests.yaml",
+        view: Annotated[
+            str,
+            typer.Option(
+                "--view",
+                help=(
+                    "what to render: 'dut' (default) renders the model "
+                    "hierarchy rooted at --top; 'tb' renders the testbench "
+                    "hierarchy with the DUT called out as a subtree. With "
+                    "--view tb the positional argument is a test name."
+                ),
+            ),
+        ] = "dut",
         fmt: Annotated[
             str,
             typer.Option(
@@ -1290,17 +1314,61 @@ class RtlBuddy:
         """
         render module hierarchy via rtl-buddy-view
         """
-        model_cfg = ModelConfigLoader(model_config).get_model(model_name)
+        if view not in ("dut", "tb"):
+            raise FatalRtlBuddyError(
+                f"hier: --view must be 'dut' or 'tb', got {view!r}"
+            )
+
+        if view == "tb":
+            # The test pins both a model and a TB top — resolve via
+            # the existing SuiteConfig loader so the same parse path
+            # the simulator uses runs here too.
+            from .config.suite import SuiteConfig
+
+            suite = SuiteConfig(test_config)
+            tests = suite.get_tests(name)
+            test_cfg = list(tests)[0]
+            model_cfg = test_cfg.get_model()
+            log_event(
+                logger,
+                logging.INFO,
+                "command.hier",
+                command="hier",
+                test=name,
+                model=model_cfg.name,
+                tb=test_cfg.tb.name,
+                format=fmt,
+                output=output,
+                view="tb",
+            )
+            runner = RtlBuddyView(
+                name=self.name + "/hier",
+                model_cfg=model_cfg,
+                suite_dir=os.getcwd(),
+                format=fmt,
+                output=output,
+                frontend=frontend,
+                cdc_annotations=cdc_annotations,
+                rdc_annotations=rdc_annotations,
+                clock_legend=clock_legend,
+                executable=tool,
+                test_cfg=test_cfg,
+            )
+            raise typer.Exit(runner.run())
+
+        # --view dut (default): unchanged behaviour.
+        model_cfg = ModelConfigLoader(model_config).get_model(name)
         log_event(
             logger,
             logging.INFO,
             "command.hier",
             command="hier",
-            model=model_name,
+            model=name,
             format=fmt,
             output=output,
+            view="dut",
         )
-        view = RtlBuddyView(
+        runner = RtlBuddyView(
             name=self.name + "/hier",
             model_cfg=model_cfg,
             suite_dir=os.getcwd(),
@@ -1312,7 +1380,7 @@ class RtlBuddy:
             clock_legend=clock_legend,
             executable=tool,
         )
-        raise typer.Exit(view.run())
+        raise typer.Exit(runner.run())
 
     def do_cmd_axi_profile_discover(
         self,

--- a/src/rtl_buddy/tools/hier_rtl_buddy_view.py
+++ b/src/rtl_buddy/tools/hier_rtl_buddy_view.py
@@ -23,6 +23,7 @@ from pathlib import Path
 
 from .vlog_filelist import VlogFilelist
 from ..config.model import ModelConfig
+from ..config.test import TestConfig
 from ..errors import FatalRtlBuddyError
 from ..logging_utils import log_event, task_status
 from ..process_utils import run_managed_process
@@ -50,6 +51,7 @@ class RtlBuddyView:
         axi_perf_annotations: str | None = None,
         clock_legend: bool = False,
         executable: str = "rtl-buddy-view",
+        test_cfg: TestConfig | None = None,
     ):
         self.name = name
         self.model_cfg = model_cfg
@@ -68,8 +70,23 @@ class RtlBuddyView:
         self.axi_perf_annotations = axi_perf_annotations
         self.clock_legend = clock_legend
         self.executable = executable
+        # Optional test that pins the TB top + TB filelist for the
+        # TB-rooted view (#99 / 6b). When set, the generated filelist
+        # is DUT+TB merged and rtl-buddy-view is invoked with both
+        # ``--top <model>`` AND ``--tb-top <tb.toplevel>`` so the
+        # rendered tree is rooted at the TB with the DUT recorded for
+        # the SPA's dashed-boundary overlay. When None, today's
+        # DUT-only invocation is byte-identical (no behavioural change
+        # for the unconditional ``rb hier <model>`` callers).
+        self.test_cfg = test_cfg
 
         artefact_root = Path(suite_dir) / "artefacts" / "hier" / model_cfg.name
+        if test_cfg is not None:
+            # Cache key for TB mode is (model, tb_name). Two tests
+            # sharing the same TB share the artefact — the test's
+            # other parameters (plusargs, sweep) don't affect the
+            # elaborated hierarchy, only its top + filelist do.
+            artefact_root = artefact_root / "tb" / test_cfg.tb.name
         artefact_root.mkdir(parents=True, exist_ok=True)
         self.artefact_dir = str(artefact_root)
 
@@ -88,8 +105,22 @@ class RtlBuddyView:
         )
         # rtl-buddy-view rejects +incdir+/-y/-f, so strip everything
         # down to plain source paths.
+        #
+        # TB mode merges the test's TB filelist on top of the model
+        # filelist via VlogFilelist's existing test_filelist parameter
+        # (the same merge the compile flow uses). Order is DUT first,
+        # TB second — the TB modules instantiate the DUT, not the
+        # other way around, and Verible elaborates from the
+        # ``--tb-top`` regardless of file order.
+        test_filelist = (
+            self.test_cfg.tb.get_filelist() if self.test_cfg is not None else None
+        )
         vlog_fl.write_output(
-            output_filepath=fl_path, unroll=True, strip=True, deduplicate=True
+            output_filepath=fl_path,
+            unroll=True,
+            strip=True,
+            deduplicate=True,
+            test_filelist=test_filelist,
         )
         return fl_path
 
@@ -103,6 +134,13 @@ class RtlBuddyView:
             "--format",
             self.format,
         ]
+        if self.test_cfg is not None and self.test_cfg.tb.toplevel is not None:
+            # ``--tb-top`` is independent of ``--top`` (rtl-buddy-view
+            # #99 / 6a). When both are supplied, the renderer elaborates
+            # from --tb-top and records the DUT name in
+            # ``view.json::dut_top`` so the SPA can mark the DUT
+            # subtree with a dashed boundary.
+            cmd += ["--tb-top", self.test_cfg.tb.toplevel]
         if self.output is not None:
             cmd += ["--output", self.output]
         if self.frontend is not None:

--- a/tests/fixtures/minimal_project/tests.yaml
+++ b/tests/fixtures/minimal_project/tests.yaml
@@ -1,6 +1,7 @@
 rtl-buddy-filetype: test_config
 testbenches:
   - name: tb_basic
+    toplevel: tb_basic
     filelist:
       - src/example.sv
 tests:

--- a/tests/test_hier.py
+++ b/tests/test_hier.py
@@ -347,3 +347,146 @@ def test_rb_hier_viewer_exit_propagates(minimal_project: Path):
         ],
     )
     assert result.exit_code == 1
+
+
+# --- --view tb mode (rtl-buddy-view #99 / 6b) -----------------------------
+
+
+def test_wrapper_emits_tb_top_and_caches_under_tb_subdir(tmp_path: Path):
+    """When ``test_cfg`` is supplied the wrapper forwards ``--tb-top
+    <tb.toplevel>`` alongside the existing ``--top <model>`` and the
+    generated filelist lands at ``artefacts/hier/<model>/tb/<tb>/hier.f``.
+    Two tests sharing the same TB therefore share the artefact (cache
+    key = (model, tb), not test name)."""
+    from rtl_buddy.config.test import TestbenchConfig, TestConfig
+
+    src = tmp_path / "src" / "example.sv"
+    src.parent.mkdir()
+    src.write_text("module example; endmodule\n")
+    model = ModelConfig(
+        name="example",
+        filelist=[str(src)],
+        path=str(tmp_path / "models.yaml"),
+    )
+    tb_src = tmp_path / "src" / "tb.sv"
+    tb_src.write_text("module tb_top; example u_dut(); endmodule\n")
+    tb = TestbenchConfig(
+        name="tb_basic",
+        filelist=[str(tb_src)],
+        toplevel="tb_top",
+    )
+    test_cfg = TestConfig(
+        name="basic",
+        desc="",
+        model=model,
+        _reglvl=0,
+        pa=None,
+        pd=None,
+        uvm=None,
+        preproc_path=None,
+        postproc_path=None,
+        sweep_path=None,
+        tb=tb,
+        timeout=None,
+    )
+    script, record = _make_fake_view(tmp_path)
+
+    view = RtlBuddyView(
+        name="t",
+        model_cfg=model,
+        suite_dir=str(tmp_path),
+        format="json",
+        executable=str(script),
+        test_cfg=test_cfg,
+    )
+    assert view.run() == 0
+
+    argv = json.loads(record.read_text())
+    # --top is still the DUT model; --tb-top is the TB toplevel.
+    assert argv[argv.index("--top") + 1] == "example"
+    assert argv[argv.index("--tb-top") + 1] == "tb_top"
+    # Filelist artefact landed under artefacts/hier/<model>/tb/<tb>/.
+    expected_fl = (
+        tmp_path / "artefacts" / "hier" / "example" / "tb" / "tb_basic" / "hier.f"
+    )
+    assert expected_fl.is_file()
+    # The actual --filelist arg points at that exact file.
+    assert argv[argv.index("--filelist") + 1] == str(expected_fl)
+
+
+def test_wrapper_dut_only_does_not_emit_tb_top(tmp_path: Path):
+    """Sanity: when ``test_cfg`` is None (today's ``rb hier <model>``
+    path), the wrapper invokes the renderer with no ``--tb-top``
+    flag — byte-identical CLI to the v1.0 contract."""
+    src = tmp_path / "src" / "example.sv"
+    src.parent.mkdir()
+    src.write_text("module example; endmodule\n")
+    model = ModelConfig(
+        name="example",
+        filelist=[str(src)],
+        path=str(tmp_path / "models.yaml"),
+    )
+    script, record = _make_fake_view(tmp_path)
+    view = RtlBuddyView(
+        name="t",
+        model_cfg=model,
+        suite_dir=str(tmp_path),
+        executable=str(script),
+    )
+    assert view.run() == 0
+    argv = json.loads(record.read_text())
+    assert "--tb-top" not in argv
+
+
+def test_rb_hier_view_tb_resolves_test_and_invokes_renderer(minimal_project: Path):
+    script, record = _make_fake_view(minimal_project)
+    runner, rb = _runner()
+    result = runner.invoke(
+        rb.app,
+        [
+            "hier",
+            "basic",
+            "--view",
+            "tb",
+            "--test-config",
+            "tests.yaml",
+            "--format",
+            "json",
+            "--tool",
+            str(script),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    argv = json.loads(record.read_text())
+    # ``basic`` test pins model=example (DUT) + tb=tb_basic (toplevel=tb_basic).
+    assert argv[argv.index("--top") + 1] == "example"
+    assert argv[argv.index("--tb-top") + 1] == "tb_basic"
+    # Filelist landed under the (model, tb) cache path.
+    assert (
+        minimal_project
+        / "artefacts"
+        / "hier"
+        / "example"
+        / "tb"
+        / "tb_basic"
+        / "hier.f"
+    ).is_file()
+
+
+def test_rb_hier_view_must_be_dut_or_tb(minimal_project: Path):
+    """An unknown --view value surfaces as a FatalRtlBuddyError before
+    we shell out to the renderer."""
+    script, _ = _make_fake_view(minimal_project)
+    runner, rb = _runner()
+    result = runner.invoke(
+        rb.app,
+        [
+            "hier",
+            "basic",
+            "--view",
+            "wave",
+            "--tool",
+            str(script),
+        ],
+    )
+    assert result.exit_code != 0

--- a/tests/test_hub_resolver.py
+++ b/tests/test_hub_resolver.py
@@ -517,3 +517,103 @@ def test_update_mapping_swaps_aliases_in_place(tmp_path: Path):
 
 def test_default_view_json_path_layout(tmp_path: Path):
     assert default_view_json_path(tmp_path) == tmp_path / ".rtl-buddy" / "view.json"
+
+
+# ---------------------------------------------------------------------------
+# TB-rooted view.json — identity wave↔view mapping (#99 / 6b)
+# ---------------------------------------------------------------------------
+
+
+def _tb_view_json(top: str = "tb_top") -> dict:
+    """v1.1 TB-rooted payload: ``top == tb_top`` (the rendered root
+    IS the testbench). DUT instance lives under ``<top>.u_dut`` and
+    the renderer recorded ``dut_top`` for the SPA boundary."""
+    return {
+        "schema_version": "1.1",
+        "tool": {"name": "rtl-buddy-view", "version": "0.1.0"},
+        "top": top,
+        "tb_top": top,
+        "dut_top": "dut",
+        "nodes": [
+            {"id": top, "module": top},
+            {"id": f"{top}.u_clkgen", "module": "clkgen"},
+            {"id": f"{top}.u_dut", "module": "dut"},
+            {"id": f"{top}.u_dut.u_leaf", "module": "leaf"},
+        ],
+        "edges": [
+            {"from": top, "to": f"{top}.u_clkgen"},
+            {"from": top, "to": f"{top}.u_dut"},
+            {"from": f"{top}.u_dut", "to": f"{top}.u_dut.u_leaf"},
+        ],
+    }
+
+
+def test_from_dict_records_tb_top_and_dut_top_when_present():
+    model = ViewModel.from_dict(_tb_view_json())
+    assert model.tb_top == "tb_top"
+    assert model.dut_top == "dut"
+    assert model.tb_rooted is True
+
+
+def test_from_dict_tb_rooted_false_when_tb_top_absent():
+    """v1.0 payloads (no tb_top) → DUT-rooted → identity mapping
+    bypass does not kick in. Same for v1.1 payloads where --top was
+    passed alone (tb_top=null)."""
+    model = ViewModel.from_dict(_sample_view_json())
+    assert model.tb_top is None
+    assert model.tb_rooted is False
+
+
+def test_view_to_wave_identity_when_tb_rooted(tmp_path: Path):
+    """TB-rooted view.json → view path IS the wave path, no
+    ``tb_prefix`` prepend even when one is configured. The renderer
+    elaborated from the TB top so the names match what surfer
+    already advertises."""
+    resolver = resolver_from_paths(
+        view_json_path=_write_view_json(tmp_path, payload=_tb_view_json()),
+        # Configured tb_prefix is deliberately set — it MUST be
+        # bypassed when the view is TB-rooted.
+        tb_prefix="tb.dut.",
+    )
+    assert resolver.view_to_wave("tb_top.u_dut") == "tb_top.u_dut"
+    assert resolver.view_to_wave("tb_top.u_dut.u_leaf") == "tb_top.u_dut.u_leaf"
+    assert resolver.view_to_wave("tb_top") == "tb_top"
+
+
+def test_view_to_wave_unknown_path_returns_none_in_tb_rooted_mode(tmp_path: Path):
+    """Even in identity mode, the resolver still gates on node
+    existence — a stale request for a path that isn't in the view
+    returns None rather than passing through a guess."""
+    resolver = resolver_from_paths(
+        view_json_path=_write_view_json(tmp_path, payload=_tb_view_json()),
+        tb_prefix="tb.dut.",
+    )
+    assert resolver.view_to_wave("tb_top.u_phantom") is None
+
+
+def test_wave_to_view_identity_when_tb_rooted(tmp_path: Path):
+    """Symmetric: wave path → view path is identity, no prefix
+    strip, gated on node existence."""
+    resolver = resolver_from_paths(
+        view_json_path=_write_view_json(tmp_path, payload=_tb_view_json()),
+        tb_prefix="tb.dut.",
+    )
+    assert resolver.wave_to_view("tb_top.u_dut") == "tb_top.u_dut"
+    assert resolver.wave_to_view("tb_top.u_dut.u_leaf") == "tb_top.u_dut.u_leaf"
+    # Unknown path → None (not a guess), matching the DUT-rooted contract.
+    assert resolver.wave_to_view("tb_top.nothing") is None
+
+
+def test_tb_rooted_aliases_still_win(tmp_path: Path):
+    """Signal aliases consulted before the identity short-circuit
+    so projects with legacy renames keep working in TB-rooted mode.
+    """
+    resolver = resolver_from_paths(
+        view_json_path=_write_view_json(tmp_path, payload=_tb_view_json()),
+        tb_prefix="tb.dut.",
+        signal_aliases=[
+            SignalAlias(wave="tb_top.legacy_dut", view="tb_top.u_dut"),
+        ],
+    )
+    assert resolver.view_to_wave("tb_top.u_dut") == "tb_top.legacy_dut"
+    assert resolver.wave_to_view("tb_top.legacy_dut") == "tb_top.u_dut"

--- a/tests/test_hub_view_builder.py
+++ b/tests/test_hub_view_builder.py
@@ -186,3 +186,112 @@ def test_build_view_json_no_cdc_annotations_when_back_pointer_absent(
     monkeypatch.setattr(view_builder, "RtlBuddyView", FakeRunner)
     view_builder.build_view_json(project_root=tmp_path, model_cfg=_model(tmp_path))
     assert captured["kwargs"]["cdc_annotations"] is None
+
+
+# --- TB view (rtl-buddy-view #99 / 6b) -----------------------------------
+
+
+def _test_cfg(model: ModelConfig, tb_name: str = "tb_basic"):
+    """Minimal TestConfig with a TestbenchConfig that has a toplevel."""
+    from rtl_buddy.config.test import TestbenchConfig, TestConfig
+
+    tb = TestbenchConfig(name=tb_name, filelist=[], toplevel="tb_top")
+    return TestConfig(
+        name="t1",
+        desc="",
+        model=model,
+        _reglvl=0,
+        pa=None,
+        pd=None,
+        uvm=None,
+        preproc_path=None,
+        postproc_path=None,
+        sweep_path=None,
+        tb=tb,
+        timeout=None,
+    )
+
+
+def test_view_json_path_for_tb_keys_on_model_and_tb(tmp_path):
+    """Cache key is (model, tb) — two tests sharing the same TB
+    share the artefact."""
+    assert (
+        view_builder.view_json_path_for_tb(tmp_path, "demo", "tb_basic")
+        == tmp_path / ".rtl-buddy" / "cache" / "view-demo-tb-tb_basic.json"
+    )
+    # DUT-view path is untouched.
+    assert (
+        view_builder.view_json_path(tmp_path, "demo")
+        == tmp_path / ".rtl-buddy" / "cache" / "view-demo.json"
+    )
+
+
+def test_build_view_json_tb_mode_uses_tb_cache_path_and_forwards_test_cfg(
+    tmp_path, monkeypatch
+):
+    """When ``test_cfg`` is supplied, the builder writes to the
+    (model, tb)-keyed cache file and passes the test_cfg through to
+    RtlBuddyView so the wrapper can emit --tb-top + merge filelists."""
+    from rtl_buddy.hub import cdc_builder
+
+    monkeypatch.setattr(cdc_builder, "build_domain_map", lambda **kwargs: None)
+    monkeypatch.setattr(view_builder.shutil, "which", lambda _: "/fake/rtl-buddy-view")
+
+    captured = {}
+
+    class FakeRunner:
+        def __init__(self, **kwargs):
+            captured["kwargs"] = kwargs
+            self.artefact_dir = str(
+                tmp_path / "artefacts" / "hier" / "demo" / "tb" / "tb_basic"
+            )
+            Path(self.artefact_dir).mkdir(parents=True, exist_ok=True)
+
+        def run(self) -> int:
+            out = Path(captured["kwargs"]["output"])
+            out.parent.mkdir(parents=True, exist_ok=True)
+            out.write_text("{}")
+            return 0
+
+    monkeypatch.setattr(view_builder, "RtlBuddyView", FakeRunner)
+
+    model = _model(tmp_path)
+    test_cfg = _test_cfg(model)
+    result = view_builder.build_view_json(
+        project_root=tmp_path, model_cfg=model, test_cfg=test_cfg
+    )
+    assert result == view_builder.view_json_path_for_tb(tmp_path, "demo", "tb_basic")
+    assert result.is_file()
+    # The wrapper received the test_cfg, so it'll emit --tb-top.
+    assert captured["kwargs"]["test_cfg"] is test_cfg
+
+
+def test_build_view_json_tb_mode_error_message_mentions_test_name(
+    tmp_path, monkeypatch
+):
+    """Failure path surfaces the test name in the error so the user
+    can spot which TB-mode click broke."""
+    from rtl_buddy.hub import cdc_builder
+
+    monkeypatch.setattr(cdc_builder, "build_domain_map", lambda **kwargs: None)
+    monkeypatch.setattr(view_builder.shutil, "which", lambda _: "/fake/rtl-buddy-view")
+
+    class FailingRunner:
+        def __init__(self, **kwargs):
+            self.artefact_dir = str(
+                tmp_path / "artefacts" / "hier" / "demo" / "tb" / "tb_basic"
+            )
+            Path(self.artefact_dir).mkdir(parents=True, exist_ok=True)
+            (Path(self.artefact_dir) / "hier.log").write_text("$ rtl-buddy-view ...\n")
+
+        def run(self) -> int:
+            return 7
+
+    monkeypatch.setattr(view_builder, "RtlBuddyView", FailingRunner)
+
+    model = _model(tmp_path)
+    test_cfg = _test_cfg(model)
+    with pytest.raises(FatalRtlBuddyError, match=r"--test t1"):
+        view_builder.build_view_json(
+            project_root=tmp_path, model_cfg=model, test_cfg=test_cfg
+        )

--- a/tests/test_hub_viewer_http.py
+++ b/tests/test_hub_viewer_http.py
@@ -702,6 +702,10 @@ async def test_view_json_query_param_flips_active_model_and_broadcasts(
                 "model": "demo",
                 "models_file": str(tmp_path / "models.yaml"),
                 "view_url": "/view.json?model=demo",
+                # rtl-buddy-view #99 / 6b: explicit mode marker so
+                # SPA clients route the event through the right
+                # action without inferring mode from the URL.
+                "view_mode": "dut",
             }
 
         # active_model flipped in memory.
@@ -804,3 +808,205 @@ def _hello(client: str) -> Envelope:
             "capabilities": [],
         },
     )
+
+
+# ---------------------------------------------------------------------------
+# /tests + /view.json?test= (rtl-buddy-view #99 / 6b)
+# ---------------------------------------------------------------------------
+
+
+def _write_tests_yaml(
+    path: Path,
+    testbenches: list[dict],
+    tests: list[dict],
+) -> None:
+    """Write a minimal tests.yaml. Each testbench needs ``name`` +
+    ``filelist`` (+ optional ``toplevel``); each test needs ``name``,
+    ``model``, ``model_path``, ``testbench``, and the boilerplate
+    set of optional ``None`` fields that serde requires."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = ["rtl-buddy-filetype: test_config", "testbenches:"]
+    for tb in testbenches:
+        lines.append(f"  - name: {tb['name']}")
+        if "toplevel" in tb:
+            lines.append(f"    toplevel: {tb['toplevel']}")
+        lines.append("    filelist: []")
+    lines.append("tests:")
+    for t in tests:
+        lines.append(f"  - name: {t['name']}")
+        # ``desc`` is required (non-optional) on TestConfigFile —
+        # serde refuses an empty value.
+        lines.append(f"    desc: {t.get('desc', 'test fixture entry')}")
+        lines.append(f"    model: {t['model']}")
+        lines.append(f"    model_path: {t.get('model_path', 'models.yaml')}")
+        lines.append(f"    reglvl: {t.get('reglvl', 0)}")
+        for k in ("plusargs", "plusdefines", "uvm", "preproc", "postproc", "sweep"):
+            lines.append(f"    {k}:")
+        lines.append(f"    testbench: {t['testbench']}")
+        lines.append("    sim_timeout:")
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+@pytest.mark.asyncio
+async def test_tests_endpoint_lists_tests_from_discovery(tmp_path: Path):
+    """``GET /tests`` walks every tests.yaml and reports each entry's
+    resolved ``(model, tb)`` pair."""
+    _write_models_yaml(tmp_path / "models.yaml", [{"name": "demo"}])
+    _write_tests_yaml(
+        tmp_path / "tests.yaml",
+        testbenches=[{"name": "tb_basic", "toplevel": "tb_top"}],
+        tests=[
+            {"name": "t1", "model": "demo", "testbench": "tb_basic"},
+            {"name": "t2", "model": "demo", "testbench": "tb_basic"},
+        ],
+    )
+    hub, viewer, hub_task, vtask = await _viewer_with_project(tmp_path)
+    try:
+        url = f"http://127.0.0.1:{viewer.http_port}/tests"
+        status, headers, body = await asyncio.to_thread(_http_get, url)
+        assert status == 200
+        assert "application/json" in headers.get("Content-Type", "")
+        payload = _json.loads(body)
+        names = [t["name"] for t in payload["tests"]]
+        assert sorted(names) == ["t1", "t2"]
+        # Each entry carries the resolved model + tb so the SPA
+        # picker can label options without an extra round-trip.
+        for t in payload["tests"]:
+            assert t["model"] == "demo"
+            assert t["tb"] == "tb_basic"
+        assert payload["active"] is None
+    finally:
+        await _teardown(hub, viewer, hub_task, vtask)
+
+
+@pytest.mark.asyncio
+async def test_tests_endpoint_empty_when_no_tests_yaml(tmp_path: Path):
+    """Standalone / no-tests deployments → empty list. The SPA's
+    DUT/TB toggle stays hidden in that case."""
+    hub, viewer, hub_task, vtask = await _viewer_with_project(tmp_path)
+    try:
+        url = f"http://127.0.0.1:{viewer.http_port}/tests"
+        status, _, body = await asyncio.to_thread(_http_get, url)
+        assert status == 200
+        payload = _json.loads(body)
+        assert payload == {"tests": [], "active": None}
+    finally:
+        await _teardown(hub, viewer, hub_task, vtask)
+
+
+@pytest.mark.asyncio
+async def test_view_json_query_test_param_unknown_400(tmp_path: Path):
+    _write_models_yaml(tmp_path / "models.yaml", [{"name": "demo"}])
+    _write_tests_yaml(
+        tmp_path / "tests.yaml",
+        testbenches=[{"name": "tb_basic", "toplevel": "tb_top"}],
+        tests=[{"name": "t1", "model": "demo", "testbench": "tb_basic"}],
+    )
+    hub, viewer, hub_task, vtask = await _viewer_with_project(tmp_path)
+    try:
+        url = f"http://127.0.0.1:{viewer.http_port}/view.json?test=missing"
+        status, _, body = await asyncio.to_thread(_http_get_allow_4xx, url)
+        assert status == 400
+        assert b"missing" in body
+    finally:
+        await _teardown(hub, viewer, hub_task, vtask)
+
+
+@pytest.mark.asyncio
+async def test_view_json_query_test_param_flips_active_test_and_broadcasts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """End-to-end TB-view switch:
+    1. ?test=t1 resolves the test (model + tb pair).
+    2. build_view_json is invoked with the test_cfg (mocked).
+    3. active_test + active_model flip in memory.
+    4. view_changed event broadcast with view_mode='tb' + test + tb.
+    """
+    _write_models_yaml(tmp_path / "models.yaml", [{"name": "demo"}])
+    _write_tests_yaml(
+        tmp_path / "tests.yaml",
+        testbenches=[{"name": "tb_basic", "toplevel": "tb_top"}],
+        tests=[{"name": "t1", "model": "demo", "testbench": "tb_basic"}],
+    )
+
+    from rtl_buddy.hub import view_builder
+
+    captured: dict = {}
+    cache_path = tmp_path / ".rtl-buddy" / "cache" / "view-demo-tb-tb_basic.json"
+
+    def fake_build_view_json(
+        *, project_root, model_cfg, axi_perf_source=None, test_cfg=None
+    ):
+        captured["model"] = model_cfg.name
+        captured["test_cfg"] = test_cfg
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        cache_path.write_text(
+            '{"schema_version":"1.1","top":"tb_top","tb_top":"tb_top","dut_top":"demo"}'
+        )
+        return cache_path
+
+    monkeypatch.setattr(view_builder, "build_view_json", fake_build_view_json)
+
+    hub, viewer, hub_task, vtask = await _viewer_with_project(tmp_path)
+    try:
+        ws_url = f"ws://127.0.0.1:{viewer.http_port}/ws"
+        async with websockets.connect(ws_url) as ws:
+            await ws.send(encode(_hello("view")))
+            welcome = decode(await asyncio.wait_for(ws.recv(), timeout=2.0))
+            assert welcome.type == "welcome"
+
+            url = f"http://127.0.0.1:{viewer.http_port}/view.json?test=t1"
+            status, _, body = await asyncio.to_thread(_http_get, url)
+            assert status == 200
+            assert b"tb_top" in body
+
+            event = decode(await asyncio.wait_for(ws.recv(), timeout=2.0))
+            assert event.type == "view_changed"
+            assert event.kind == Kind.EVENT
+            assert event.payload["view_mode"] == "tb"
+            assert event.payload["test"] == "t1"
+            assert event.payload["model"] == "demo"
+            assert event.payload["tb"] == "tb_basic"
+            assert event.payload["view_url"] == "/view.json?test=t1"
+
+        # In-memory state flipped.
+        assert viewer.active_test == "t1"
+        assert viewer.active_model == "demo"
+        # Builder received the resolved test_cfg.
+        assert captured["model"] == "demo"
+        assert captured["test_cfg"] is not None
+        assert captured["test_cfg"].name == "t1"
+    finally:
+        await _teardown(hub, viewer, hub_task, vtask)
+
+
+@pytest.mark.asyncio
+async def test_switch_model_clears_active_test(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Switching back from TB → DUT view clears active_test so the
+    next bare ``GET /view.json`` returns the DUT bytes."""
+    _write_models_yaml(tmp_path / "models.yaml", [{"name": "demo"}])
+    from rtl_buddy.hub import view_builder
+
+    dut_path = tmp_path / ".rtl-buddy" / "cache" / "view-demo.json"
+
+    def fake_build_view_json(
+        *, project_root, model_cfg, axi_perf_source=None, test_cfg=None
+    ):
+        dut_path.parent.mkdir(parents=True, exist_ok=True)
+        dut_path.write_text('{"schema_version":"1.0","top":"demo"}')
+        return dut_path
+
+    monkeypatch.setattr(view_builder, "build_view_json", fake_build_view_json)
+
+    hub, viewer, hub_task, vtask = await _viewer_with_project(tmp_path)
+    try:
+        # Pretend a TB view was previously selected.
+        viewer.active_test = "t_old"
+        url = f"http://127.0.0.1:{viewer.http_port}/view.json?model=demo"
+        await asyncio.to_thread(_http_get, url)
+        assert viewer.active_test is None
+        assert viewer.active_model == "demo"
+    finally:
+        await _teardown(hub, viewer, hub_task, vtask)


### PR DESCRIPTION
Companion to rtl-buddy/rtl-buddy-view#99 (PR rtl-buddy/rtl-buddy-view feat/tb-top-view-99). Implements **6b** of the testbench-top-view feature: the rtl_buddy CLI + hub plumbing that produces the TB-rooted view.json the SPA needs.

## Summary

- **`rb hier`**: new `--view dut|tb` flag (default `dut`, byte-identical to today). In `--view tb` mode the positional argument is a test name from `tests.yaml`; the test pins both the model (DUT side) and the testbench top, the merged DUT+TB filelist is written to `artefacts/hier/<model>/tb/<tb>/hier.f`, and rtl-buddy-view is invoked with `--top <model> --tb-top <tb.toplevel>`. Cache key is `(model, tb)` so two tests sharing a TB share the artefact.
- **Hub** (`rb hub`): new `GET /tests` endpoint (walks every `tests.yaml` under the project root, reports each entry's resolved `(model, tb)` pair); new `GET /view.json?test=NAME` handler with per-test `asyncio.Lock`; `view_changed` events now carry an explicit `view_mode: 'dut' | 'tb'` (TB events also carry `test` + `tb` + `tests_file`).
- **Resolver**: when the loaded view.json is TB-rooted (`top == tb_top`), wave↔view short-circuits to identity — the renderer elaborated from the TB top so view paths already match what surfer/WCP advertises. `tb_prefix` stays as the v1.0 fallback.
- **Vendored hub-protocol schema**: synced from the rtl-buddy-view source-of-truth (the matching change ships in the companion PR).
- **Docs**: `concepts/hub.md` gains the `/tests` + `?test=` rows and the `view_changed.view_mode` field; `concepts/hier.md` documents `rb hier --view tb`; `reference/cli.md` regenerated.

## Cross-repo coupling

The companion rtl-buddy-view PR must land first — this PR's vendored `hub-protocol-v1.json` matches that PR's source-of-truth (`view_overlay_set` + `view_changed.view_mode/test/tb`). Merge order: view PR → this PR.

## Test plan

- [x] `uv run ruff check` / `ruff format --check` clean
- [x] `uv run pytest -q` — 885 passed, 9 skipped (15 new across `test_hier.py`, `test_hub_view_builder.py`, `test_hub_viewer_http.py`, `test_hub_resolver.py`)
- [x] `python scripts/gen_cli_reference.py --check` clean
- [x] Manual: `rb hier coco_normal_rw --view tb --format tree` against the ai-project axis_async_fifo cocotb test rendered `tb_axis_async_fifo_coco → dut : axis_async_fifo` end-to-end via the new wrapper path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)