### PR TITLE
fix(hier): drop +incdir+/-y/-v from TB filelist in --view tb mode

### DIFF
--- a/src/rtl_buddy/tools/hier_rtl_buddy_view.py
+++ b/src/rtl_buddy/tools/hier_rtl_buddy_view.py
@@ -31,6 +31,26 @@ from ..process_utils import run_managed_process
 logger = logging.getLogger(__name__)
 
 
+def _is_non_source_filelist_line(line: str) -> bool:
+    """Return True when ``line`` is a filelist directive that doesn't
+    name a source file (include dirs, lib dirs, lib files). These
+    must not survive into rtl-buddy-view's filelist because the
+    renderer expects bare source paths and ``strip=True`` would emit
+    the trailing argument as one — turning ``+incdir+../../common``
+    into the bare directory ``../../common`` and crashing the
+    parser with IsADirectoryError on the conventional testbench
+    layout.
+    """
+    s = line.strip()
+    if s.startswith("+incdir+") or s.startswith("+libext+"):
+        return True
+    # ``-y <dir>`` / ``-v <file>`` use a space (or tab) separator.
+    for prefix in ("-y", "-v"):
+        if s.startswith(prefix) and len(s) > len(prefix) and s[len(prefix)].isspace():
+            return True
+    return False
+
+
 class RtlBuddyView:
     """Generates a filelist + invokes ``rtl-buddy-view``.
 
@@ -112,9 +132,23 @@ class RtlBuddyView:
         # TB second — the TB modules instantiate the DUT, not the
         # other way around, and Verible elaborates from the
         # ``--tb-top`` regardless of file order.
-        test_filelist = (
-            self.test_cfg.tb.get_filelist() if self.test_cfg is not None else None
-        )
+        #
+        # Drop non-source entries (``+incdir+...``, ``-y .../``,
+        # ``+libext+...``) from the TB filelist before merging. With
+        # ``strip=True`` VlogFilelist would emit them as bare paths
+        # which rtl-buddy-view then tries to open as source files,
+        # producing ``IsADirectoryError`` on the typical
+        # ``+incdir+../../common`` testbench convention. rtl-buddy-view
+        # works on absolute source paths and does not need include
+        # directories — the TB's compile-time options are not relevant
+        # to its CST walk.
+        test_filelist = None
+        if self.test_cfg is not None:
+            test_filelist = [
+                line
+                for line in self.test_cfg.tb.get_filelist()
+                if not _is_non_source_filelist_line(line)
+            ]
         vlog_fl.write_output(
             output_filepath=fl_path,
             unroll=True,

--- a/tests/test_hier.py
+++ b/tests/test_hier.py
@@ -414,6 +414,83 @@ def test_wrapper_emits_tb_top_and_caches_under_tb_subdir(tmp_path: Path):
     assert argv[argv.index("--filelist") + 1] == str(expected_fl)
 
 
+def test_wrapper_drops_non_source_tb_filelist_entries(tmp_path: Path):
+    """``+incdir+``, ``-y``, ``-v``, ``+libext+`` entries in the TB
+    filelist must not survive into rtl-buddy-view's hier.f. With
+    ``strip=True`` they'd otherwise be emitted as bare paths — rtl-
+    buddy-view then tries to open ``../../common`` as a source file
+    and crashes with IsADirectoryError (caught live against the DMA
+    fixture in rtl-buddy-ai-project after the toplevel: backfill)."""
+    from rtl_buddy.config.test import TestbenchConfig, TestConfig
+    from rtl_buddy.tools.hier_rtl_buddy_view import _is_non_source_filelist_line
+
+    # Unit-test the helper directly — the wrapper-level smoke test
+    # below covers the integration but only assertively when the test
+    # filelist parses cleanly.
+    assert _is_non_source_filelist_line("+incdir+../../common")
+    assert _is_non_source_filelist_line("+libext+.sv+.v")
+    assert _is_non_source_filelist_line("-y rtl/lib")
+    assert _is_non_source_filelist_line("-v rtl/some.sv")
+    assert not _is_non_source_filelist_line("tb_top.sv")
+    assert not _is_non_source_filelist_line("rtl/example.sv")
+    # Leading whitespace tolerated (matches the YAML loader's output).
+    assert _is_non_source_filelist_line("  +incdir+.")
+
+    # Wrapper integration: a TB filelist with mixed entries produces
+    # a hier.f containing only source paths.
+    src = tmp_path / "src" / "example.sv"
+    src.parent.mkdir()
+    src.write_text("module example; endmodule\n")
+    incdir = tmp_path / "incdir"
+    incdir.mkdir()
+    (incdir / "shared.svh").write_text("// header\n")
+    model = ModelConfig(
+        name="example",
+        filelist=[str(src)],
+        path=str(tmp_path / "models.yaml"),
+    )
+    tb_src = tmp_path / "src" / "tb.sv"
+    tb_src.write_text("module tb_top; example u_dut(); endmodule\n")
+    tb = TestbenchConfig(
+        name="tb_basic",
+        filelist=[f"+incdir+{incdir}", str(tb_src)],
+        toplevel="tb_top",
+    )
+    test_cfg = TestConfig(
+        name="basic",
+        desc="",
+        model=model,
+        _reglvl=0,
+        pa=None,
+        pd=None,
+        uvm=None,
+        preproc_path=None,
+        postproc_path=None,
+        sweep_path=None,
+        tb=tb,
+        timeout=None,
+    )
+    script, _ = _make_fake_view(tmp_path)
+    view = RtlBuddyView(
+        name="t",
+        model_cfg=model,
+        suite_dir=str(tmp_path),
+        format="json",
+        executable=str(script),
+        test_cfg=test_cfg,
+    )
+    assert view.run() == 0
+    fl = (
+        tmp_path / "artefacts" / "hier" / "example" / "tb" / "tb_basic" / "hier.f"
+    ).read_text()
+    # +incdir+ entries are filtered before the merge — no bare incdir
+    # path leaks into the rtl-buddy-view filelist.
+    assert str(incdir) not in fl
+    assert "+incdir+" not in fl
+    # The TB source file survives the filter.
+    assert "tb.sv" in fl
+
+
 def test_wrapper_dut_only_does_not_emit_tb_top(tmp_path: Path):
     """Sanity: when ``test_cfg`` is None (today's ``rb hier <model>``
     path), the wrapper invokes the renderer with no ``--tb-top``


### PR DESCRIPTION
## Summary

Follow-up to #214 (rtl-buddy-view #99 / 6b) spotted live after backfilling `toplevel:` across the template + ai-project testbench suites.

The 6b filelist merge passes the test's `tb.filelist` straight into `VlogFilelist.write_output(test_filelist=...)` which then runs the shared strip+dedupe pass. `strip=True` removes only the leading option marker, so `+incdir+../../common` (the conventional TB include-dir convention) survives as the bare path `../../common` in `hier.f` — and rtl-buddy-view promptly tries to read it as a source file, crashing with `IsADirectoryError`.

This PR filters non-source filelist tokens (`+incdir+`, `+libext+`, `-y <dir>`, `-v <file>`) from the TB filelist before the merge. rtl-buddy-view operates on absolute source paths and doesn't have a concept of include directories — its CST walk doesn't need them. DUT-side filelists go through the unchanged path (the model-filelist convention has worked since #106).

## Test plan

- [x] New unit test `test_wrapper_drops_non_source_tb_filelist_entries` covers the helper (`_is_non_source_filelist_line`) + the wrapper integration (a TB filelist with mixed `+incdir+` and `.sv` entries produces a hier.f with only source paths).
- [x] `uv run pytest -q` — 886 passed, 9 skipped (one new test).
- [x] `uv run ruff check` / `ruff format --check` clean.
- [x] Smoke: `cd <ai-project>/verif/dma && rb hier basic --view tb --format tree` rendered the full `tb_top → i_axi_if / t_apb_if / i_dut → ip_dma → ...` tree end-to-end (previously crashed with IsADirectoryError on `../../common`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)