### PR TITLE
docs: add development guidelines

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,30 @@
+name: Bug
+description: Report unexpected behavior in rtl_buddy.
+type: Bug
+body:
+  - type: input
+    id: version
+    attributes:
+      label: rtl_buddy version
+      description: Output of `rb --version`.
+      placeholder: e.g. 2.5.0
+    validations:
+      required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What you expected to happen, what actually happened, and the command you ran.
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduction
+      description: Minimal steps to reproduce. Paste relevant YAML config snippets if useful.
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or output
+      description: Paste the relevant `rtl_buddy.log` excerpt or terminal output. `--machine` mode produces structured JSON lines that are often easier to diagnose.
+      render: text

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Documentation
+    url: https://rtl-buddy.github.io/rtl_buddy/
+    about: Check the docs site for install, configuration, and usage questions before filing an issue.

--- a/.github/ISSUE_TEMPLATE/docs.yml
+++ b/.github/ISSUE_TEMPLATE/docs.yml
@@ -1,0 +1,16 @@
+name: Docs
+description: Report a docs problem or request a docs improvement.
+type: Docs
+body:
+  - type: input
+    id: page
+    attributes:
+      label: Page or section
+      description: URL on the docs site, or path under `docs/`.
+      placeholder: e.g. https://rtl-buddy.github.io/rtl_buddy/concepts/tests/ or docs/concepts/tests.md
+  - type: textarea
+    id: issue
+    attributes:
+      label: What is wrong or missing?
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,21 @@
+name: Feature
+description: Request a new feature or behavior change.
+type: Feature
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What user-facing problem does this solve? What is blocked or painful today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed approach
+      description: How might this work? Sketch CLI surface, YAML schema, or behavior if helpful. Skip if you would rather discuss first.
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you weighed and why this one is preferred.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,20 +50,12 @@ src/rtl_buddy/
     └── ...                # filelist, sim, postproc, verible wrappers
 ```
 
-## Development Rules
-
-- Keep changes targeted. Avoid broad refactors unless the task requires them.
-- Preserve CLI behavior unless intentionally changing it.
-- Treat YAML config classes and runtime behavior as part of the public interface for downstream RTL projects.
-- When adding or changing behavior, update downstream docs and validation assets after validating the implementation.
-
 ## Implementation Notes
 
 - `rtl_buddy.py` owns CLI wiring, global options, and command dispatch.
 - `RootConfig` selects platform, builder, verible, and regression config from `root_config.yaml`.
 - `TestRunner` drives PRE, COMPILE, SIM, and POST with early-stop support.
 - `VlogSim` captures the suite cwd once, but both compile and sim now run from per-test workspaces under `artefacts/<sanitized-test>/`; repeated runs use `artefacts/<sanitized-test>/run-0001/`, while `test.log`, `test.err`, and `test.randseed` in the suite directory remain latest-run symlinks.
-- Compile-side generated files such as `run.f`, `compile.log`, builder outputs, and relative `builder-simv` paths are resolved from the per-test artefact root, not from the suite directory.
 - `VlogFilelist` handles `.f` parsing and transformations. It resolves model entries from the real `models.yaml` location, resolves testbench entries from the suite cwd, and writes paths relative to the directory containing the generated `run.f`.
 - Nested raw coverage paths such as `artefacts/<test>/run-0001/coverage.dat` must preserve the suite-root hint during LCOV/Coverview `SF:` rewriting. When updating coverage path logic, make sure duplicate basenames still resolve against the originating suite root instead of falling back to repo-wide basename matching.
 - Hook scripts (`sweep`, `preproc`, `postproc`) are executed dynamically and should be treated as compatibility-sensitive APIs.
@@ -73,7 +65,7 @@ src/rtl_buddy/
 
 ## Validation
 
-Typical checks:
+For validation policy (what to run for which change), see [Validation](docs/development/guidelines.md#validation) in the engineering guidelines. Concrete commands:
 
 ```bash
 # from a project root that has `rtl_buddy` installed
@@ -128,43 +120,15 @@ uv run pytest --cov --cov-report=html            # write htmlcov/index.html
 
 Coverage configuration lives in `[tool.coverage.*]` in `pyproject.toml` (source = `src/rtl_buddy`, excludes the bundled `skill/` and `docs/`). No `--cov` is set in `pytest.ini` so plain `pytest` stays fast; pass `--cov` explicitly when you want a coverage run.
 
-## Logging Practices
+## Logging and Error Handling
 
-All runtime logging goes through `log_event()` in `src/rtl_buddy/logging_utils.py`. Do not use `logger.info(f"...")` directly — use `log_event(logger, level, "event.name", key=value, ...)` so that both human and machine modes produce correct output.
+Policy lives in [Logging](docs/development/guidelines.md#logging) and [Error Handling](docs/development/guidelines.md#error-handling). Code-level helpers and entry points in this repo:
 
-### How it works
-
-- **Human mode (default)**: `_human_message()` converts each event into a readable sentence for `rtl_buddy.log` and the console. Machine-oriented fields are not visible.
-- **Machine mode (`--machine`)**: `rtl_buddy.log` is written as JSON Lines with the event name, all fields, and the human message. Console output is plain text.
-
-### Adding new events
-
-1. Choose a dotted event name following the existing convention (e.g. `compile.start`, `sim.timeout`, `suite_config.load_failed`).
-2. Call `log_event(logger, logging.<LEVEL>, "your.event", field1=val1, ...)`.
-3. If the event is logged at **WARNING or above**, add a dedicated `case` entry in `_human_message()`. Users see these messages directly, so they must be clear and actionable.
-4. DEBUG and INFO events may rely on the wildcard fallback formatter, which converts `"foo.bar"` to `"foo bar"` and appends select fields.
-
-### Error handling
-
-- Fatal config/environment errors: log at `logging.ERROR`, then `raise FatalRtlBuddyError(...)`. The top-level `run()` catches these and exits with code 2.
-- Per-test filelist failures: log at `logging.ERROR`, then `raise FilelistError(...)`. `TestRunner` catches these and records a `FilelistFailResults`.
-- Sweep/preproc script failures: return an error string from `pre()` or `_expand_tests_with_sweep()`. The caller records a `SetupFailResults` and continues.
+- `log_event(logger, level, "event.name", **fields)` in `src/rtl_buddy/logging_utils.py` — the only sanctioned runtime-logging call. Do not use `logger.info(f"...")` directly.
+- `_human_message()` in the same module — add a `case` entry for any new WARNING or ERROR event so the human-mode message stays clear.
+- Exception classes: `FatalRtlBuddyError` (top-level `run()` exits with code 2), `FilelistError` (caught by `TestRunner`, becomes `FilelistFailResults`), and the setup-failure string contract from `pre()` / `_expand_tests_with_sweep()` (becomes `SetupFailResults`).
 - Do not use `logger.critical()` — the old `ExitHandler` abort pattern has been removed.
-
-### Console output
-
-- Use `emit_console_text()` for direct user-facing output (e.g. git status banner, regression directory).
-- Use `render_summary()` for result tables — it writes a Rich table to the console and plain text to the log file.
-- Use `task_status()` for spinners on long-running phases (compile, sim). Falls back to plain text on non-interactive terminals.
-
-## Required Follow-Through
-
-After meaningful `rtl_buddy` changes:
-
-1. **If any CLI command, flag, or help text changed**: run `python scripts/gen_cli_reference.py` and commit the updated `docs/reference/cli.md` in the same PR. The file is committed to the repo and must stay in sync — CI will catch drift via `python scripts/gen_cli_reference.py --check`.
-2. **If you add or edit a docs page**: ensure it has a non-empty `description:` YAML frontmatter field. CI enforces this via `python scripts/check_docs_frontmatter.py --check`. See `docs/CONTRIBUTING.md` for the required format.
-3. Update any downstream agent docs if command behavior, YAML schema, version expectations, or validation notes changed.
-4. Update downstream integrations to the intended commit as needed.
+- Console helpers: `emit_console_text()` for direct user-facing output, `render_summary()` for result tables (Rich on console, plain text in the log), `task_status()` for spinners on long-running phases.
 
 ## Skill Distribution
 
@@ -191,11 +155,11 @@ The rtl_buddy agent skill ships inside this wheel at `src/rtl_buddy/skill/` and 
 
 ## Release Workflow
 
-Releases are triggered by merging a PR to `main` with a `version/` label, or via `workflow_dispatch`.
+Release policy (when stable vs pre-release, do-not-do rules) lives in [Releases](docs/development/guidelines.md#releases). This section covers what the workflow does mechanically.
 
 ### Stable release
 
-Apply one of `version/patch`, `version/minor`, or `version/major` to the PR. On merge:
+Triggered by merging a PR to `main` with a `version/{patch,minor,major}` label. On merge:
 
 1. The workflow computes the next `vMAJOR.MINOR.PATCH` tag, creates it, and pushes it.
 2. A GitHub release is created (not marked pre-release).
@@ -204,15 +168,12 @@ Apply one of `version/patch`, `version/minor`, or `version/major` to the PR. On 
 
 ### Pre-release
 
-Pre-releases are cut from a **feature branch** via `workflow_dispatch` — never by merging to `main`. Merging to `main` with a `version/` label always produces a stable release.
+Cut from a feature branch via `workflow_dispatch` with the **Mark as pre-release** checkbox enabled:
 
-To cut a pre-release:
-
-1. Run the Release workflow on your feature branch with the desired bump type and the **Mark as pre-release** checkbox enabled.
-2. The workflow appends `rcN` to the computed base tag (PEP 440). If `v2.3.0rc1` already exists, the next is `v2.3.0rc2`.
-3. A GitHub release is created and marked **pre-release**.
-4. The wheel is published to PyPI as a pre-release version (e.g. `2.3.0rc1`). Unqualified version ranges (`>=2.2.0`) will not resolve to it.
-5. Docs are **not** published — the `latest` alias is not updated.
+1. The workflow appends `rcN` to the computed base tag (PEP 440). If `v2.3.0rc1` already exists, the next is `v2.3.0rc2`.
+2. A GitHub release is created and marked **pre-release**.
+3. The wheel is published to PyPI as a pre-release version (e.g. `2.3.0rc1`). Unqualified version ranges (`>=2.2.0`) will not resolve to it.
+4. Docs are **not** published — the `latest` alias is not updated.
 
 The version is computed from the latest stable tag at dispatch time. If `main` advances and releases the same bump tier before your branch merges, the next RC will shift to the following version — that is expected and acceptable.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,23 @@
 
 This repo is the source-of-truth implementation of the `rtl_buddy` CLI.
 
+## Canonical Guidelines
+
+Read these before opening issues or PRs, or before changing runtime behavior:
+
+- [docs/development/guidelines.md](docs/development/guidelines.md) — engineering rules: execution contexts, path ownership, artifact layout, subprocesses, dependencies, logging, errors, validation, releases, **issue triage**, and **milestones**.
+- [docs/development/docs.md](docs/development/docs.md) — documentation authoring rules.
+- [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md) — contributor entry point that links to both.
+
+Issue conventions worth knowing up front:
+
+- Type, Priority, and Effort are org-level GitHub Issue Fields, not labels. Templates under `.github/ISSUE_TEMPLATE/` pre-bind Type.
+- Area is captured with repo-level `area/*` labels (`area/test`, `area/abv`, `area/impl`, `area/hier`, `area/axi-profile`, `area/hub`, `area/skill`, `area/config`, `area/tooling`, `area/infra`). Plus `discussion`.
+- The `version/{patch,minor,major}` labels are PR-only and drive the release workflow.
+- Multi-issue long-running efforts get a theme-named milestone (e.g. "Hub Phase 3"), not a version-named one.
+
+Where this file overlaps with the canonical guidelines, treat the guidelines as authoritative.
+
 ## Key Files
 
 ```text

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,66 +1,31 @@
 ---
-description: Guidelines for contributing to rtl_buddy documentation, including the frontmatter convention, writing style, and what is auto-generated.
+description: Entry point for contributing to rtl_buddy, with links to the detailed development and documentation guidelines maintainers follow.
 ---
 
-# Contributing to Docs
+# Contributing
 
-This page covers the standards for writing and maintaining `rtl_buddy` documentation.
-It applies to everyone editing files under `docs/`. It is also accessible via `rb docs show CONTRIBUTING`.
+This page is the entry point for contributors and maintainers.
+Detailed rules live under the Development section so they are visible in the docs site, available through `rb docs show`, and not duplicated across agent-only files.
 
-## Frontmatter
+## Development Guidelines
 
-Every docs page must start with a YAML frontmatter block containing a `description:` field:
+Read [Engineering Guidelines](development/guidelines.md) before changing runtime behavior, command execution, YAML loading, subprocess wrappers, logging, errors, release mechanics, or the bundled agent skill.
 
-```markdown
----
-description: One or two sentences describing what this page covers.
----
+Those rules define the public contracts maintainers should preserve.
+When the current implementation differs from a guideline, treat the mismatch as behavior debt: fix it in the same change when it is in scope, or document the exception and add a follow-up issue.
 
-# Page Title
-```
+## Documentation Guidelines
 
-The `description:` value is used as the page summary in `rb docs list` and `rb docs show --machine`.
-Agents read it to decide which page to fetch; make it accurate and specific.
+Read [Documentation Guidelines](development/docs.md) before adding or editing files under `docs/`.
 
-Rules:
-- Required on every page except `reference/cli.md` (auto-generated — see below)
-- One or two sentences; focus on what the page covers, not that it "explains" or "describes" something
-- CI enforces this via `scripts/check_docs_frontmatter.py --check`
+Documentation changes must keep frontmatter valid, keep generated pages in sync, and avoid duplicating reference material that is already generated from the CLI or schemas.
 
-## Writing style
+## Validation
 
-Write for both humans and agents:
+Use the narrowest validation that proves the change:
 
-- **Be concise.** Agents parse these pages programmatically. Long preambles add noise.
-- **Be complete.** Every H2 section should stand alone. Agents may fetch a single section via `rb docs show slug#anchor`.
-- **One topic per H2.** If a section covers two things, split it.
-- **Prose over bullets** for explanations. Bullets are fine for option lists and step sequences.
+- Docs-only edits: run `uv run python scripts/check_docs_frontmatter.py --check` and `uv run --group docs mkdocs build --strict`.
+- CLI help changes: regenerate `docs/reference/cli.md` with `uv run python scripts/gen_cli_reference.py` and check the docs build.
+- Runtime behavior changes: add or update focused tests, then run the affected test subset. Broaden to the full suite when shared contracts or command dispatch are touched.
 
-## Page structure
-
-```markdown
----
-description: ...
----
-
-# Title
-
-Opening sentence or short paragraph that orients the reader.
-
-## Section One
-
-Content.
-
-## Section Two
-
-Content.
-```
-
-Avoid deeply nested subsections (`###` and below) when the content can be reorganized into top-level H2 sections.
-
-## Auto-generated pages
-
-`docs/reference/cli.md` is generated from `rtl-buddy --help` output by `scripts/gen_cli_reference.py`.
-Do not edit it by hand — changes will be overwritten. Edit CLI help strings in `src/rtl_buddy/rtl_buddy.py` instead.
-
-CI auto-commits regenerated `cli.md` if it drifts. Its `description:` frontmatter is part of the generated output and is maintained by the generator, not by hand.
+If validation cannot be run locally, say which check was skipped and why in the PR.

--- a/docs/development/docs.md
+++ b/docs/development/docs.md
@@ -1,0 +1,86 @@
+---
+description: Documentation authoring rules for rtl_buddy, including frontmatter, page structure, generated files, and local validation.
+---
+
+# Documentation Guidelines
+
+These rules apply to files under `docs/`.
+The docs are both the human-facing site and the local reference surface exposed by `rb docs list` and `rb docs show`.
+
+## Frontmatter
+
+Every docs page must start with a YAML frontmatter block containing a `description:` field:
+
+```markdown
+---
+description: One or two sentences describing what this page covers.
+---
+
+# Page Title
+```
+
+The `description:` value is used as the page summary in `rb docs list` and `rb docs show --machine`.
+Agents read it to decide which page to fetch; make it accurate and specific.
+
+Rules:
+
+- Required on every page except `reference/cli.md`, which is auto-generated.
+- One or two sentences; focus on what the page covers, not that it "explains" or "describes" something.
+- CI enforces this via `scripts/check_docs_frontmatter.py --check`.
+
+## Writing Style
+
+Write for both humans and agents:
+
+- Be concise. Agents parse these pages programmatically. Long preambles add noise.
+- Be complete. Every H2 section should stand alone. Agents may fetch a single section via `rb docs show slug#anchor`.
+- Keep one topic per H2. If a section covers two things, split it.
+- Prefer prose for explanations. Bullets are fine for option lists, checklists, and step sequences.
+
+## Page Structure
+
+Use this shape for hand-written pages:
+
+```markdown
+---
+description: ...
+---
+
+# Title
+
+Opening sentence or short paragraph that orients the reader.
+
+## Section One
+
+Content.
+
+## Section Two
+
+Content.
+```
+
+Avoid deeply nested subsections (`###` and below) when the content can be reorganized into top-level H2 sections.
+
+## Generated Pages
+
+`docs/reference/cli.md` is generated from `rtl-buddy --help` output by `scripts/gen_cli_reference.py`.
+Do not edit it by hand; changes will be overwritten.
+Edit CLI help strings in `src/rtl_buddy/rtl_buddy.py` instead.
+
+CI auto-commits regenerated `cli.md` if it drifts.
+Its `description:` frontmatter is part of the generated output and is maintained by the generator, not by hand.
+
+## Local Checks
+
+Run the docs checks before opening a PR that touches docs:
+
+```bash
+uv run python scripts/check_docs_frontmatter.py --check
+uv run --group docs mkdocs build --strict
+```
+
+For CLI help changes, regenerate the CLI reference first:
+
+```bash
+uv run python scripts/gen_cli_reference.py
+```

--- a/docs/development/guidelines.md
+++ b/docs/development/guidelines.md
@@ -204,6 +204,17 @@ One extra label exists outside the area set:
 The `version/patch`, `version/minor`, and `version/major` labels are reserved for PRs and drive the release workflow.
 Do not apply them to issues.
 
+## Milestones
+
+Use milestones to group issues and PRs that share a long-running, multi-issue effort.
+Single-issue work does not need a milestone.
+
+Name milestones by theme, not by version — for example `Hub Phase 3` or `ABV in sim`.
+Release impact already lives on the `version/*` labels and PyPI tags, so milestones should carry orthogonal information.
+
+Open a milestone when the effort is scoped enough to enumerate its first few issues, and close it when the last constituent issue is closed.
+Roll over remaining work into a follow-up milestone rather than leaving the original open indefinitely.
+
 ## Releases
 
 Stable releases are produced by merging to `main` with one of the `version/patch`, `version/minor`, or `version/major` labels.

--- a/docs/development/guidelines.md
+++ b/docs/development/guidelines.md
@@ -1,0 +1,179 @@
+---
+description: Engineering guidelines for rtl_buddy maintainers, covering execution contexts, paths, artifacts, subprocesses, logging, errors, validation, and release-sensitive files.
+---
+
+# Engineering Guidelines
+
+These are maintainer rules for code and docs changes in `rtl_buddy`.
+They describe the contracts new work should preserve and existing code should converge toward.
+When implementation and guideline disagree, treat the mismatch as a bug or documented exception.
+
+## Public Contracts
+
+Treat CLI behavior, YAML config loading, generated artifact layout, machine-mode output, event names, and bundled skill behavior as public interfaces.
+Downstream RTL projects and automation depend on them.
+
+Prefer targeted changes over broad refactors.
+When a change intentionally alters a contract, update docs, tests, generated references, and downstream validation assets in the same PR.
+
+## Execution Contexts
+
+Keep command execution rooted in explicit contexts rather than ambient `os.getcwd()`:
+
+- `invocation_cwd`: the directory where the user ran `rb`. Use it to resolve relative CLI arguments before they become absolute.
+- `command_root`: the directory containing the command's primary config file.
+- `suite_dir`: the command root for per-suite flows such as `tests.yaml`, `synth.yaml`, `cdc.yaml`, `fpv.yaml`, `pnr.yaml`, and `power.yaml`.
+- `artifact_dir`: the generated workspace for one command item, normally `suite_dir/artefacts/<name>`.
+
+Config-driven commands should be rooted at their primary config file.
+Generated artifacts should go under the command root.
+External tools should run from their artifact directory.
+Explicit CLI input and output paths should remain relative to `invocation_cwd`, matching normal shell behavior.
+
+## Command Roots
+
+Use these roots unless a command documents a narrower exception:
+
+| Command | Command root | Artifact root | External tool CWD |
+|---|---:|---:|---:|
+| `test` | `dirname(tests.yaml)` | `<suite>/artefacts/<test>` | compile: `<artifact>`; sim: `<artifact>` |
+| `randtest` | `dirname(tests.yaml)` | `<suite>/artefacts/<test>` | compile: `<artifact>`; sim: `<artifact>/run-NNNN` |
+| `regression` | `dirname(regression.yaml)` | each suite's `<suite>/artefacts/<test>` | same as `test` per suite |
+| `wave --resim` | `dirname(tests.yaml)` | `<suite>/artefacts/<test>` | same as `test` |
+| `synth` | `dirname(synth.yaml)` | `<suite>/artefacts/<synth>` | `<artifact>` |
+| `cdc` | `dirname(cdc.yaml)` | `<suite>/artefacts/<cdc>` | `<artifact>` |
+| `fpv` | `dirname(fpv.yaml)` | `<suite>/artefacts/<fpv>` | `<artifact>` |
+| `pnr` | `dirname(pnr.yaml)` | `<suite>/artefacts/<pnr>` | `<artifact>` |
+| `power` | `dirname(power.yaml)` | `<suite>/artefacts/<power>` | `<artifact>` |
+| `hier --view dut` | `dirname(models.yaml)` | `<model_root>/artefacts/hier/<model>` | `<artifact>` |
+| `hier --view tb` | `dirname(tests.yaml)` | `<suite>/artefacts/hier/<test-or-model>` | `<artifact>` |
+| `axi-profile run` | `dirname(tests.yaml)` | `<suite>/artefacts/axi/<test>` | `<artifact>` |
+| `axi-profile notebook` | `dirname(tests.yaml)` | `<suite>/artefacts/axi/<test>` | `<artifact>` |
+| `axi-profile discover` | `dirname(models.yaml)` | `<model_root>/artefacts/axi/<model>` | `<artifact>` |
+| `axi-profile gen-monitor` | `dirname(models.yaml)` | configured or explicit output; fallback artifact dir | `<artifact>` |
+| `filelist` | `dirname(models.yaml)` for config reads | explicit output path | no hidden tool CWD |
+| `saif` | invocation CWD for explicit paths | explicit output path | no hidden tool CWD |
+| `hub` | project root | `.rtl-buddy/...` | project root or `.rtl-buddy`, depending subcommand |
+| `docs`, `skill` | no project execution context | none | none |
+
+## Path Ownership
+
+Resolve config-owned paths from the config file that owns them:
+
+- `root_config.yaml` is discovered from the command root for config-driven commands.
+- `regression.yaml` resolves listed suite configs relative to itself.
+- `tests.yaml` resolves testbench filelists, hook script paths, and suite-local runtime assets relative to the suite directory.
+- `models.yaml` resolves model filelist entries relative to the `models.yaml` file that defined them.
+- `synth.yaml`, `cdc.yaml`, `fpv.yaml`, `pnr.yaml`, and `power.yaml` resolve their own fields relative to their config directory.
+
+Do not let relative paths silently depend on where the user happened to invoke the command.
+If a path is passed to an external tool, prefer an absolute path unless the value is intentionally artifact-relative.
+
+## Artifact Layout
+
+Generated outputs should live under `artefacts/<name>/` below the command root.
+Repeated or randomized runs should use stable run directories such as `run-0001`, `run-0002`, and so on.
+Convenience symlinks may point at the latest run, but they must not be the only durable location.
+
+Compile-side generated files such as `run.f`, `compile.log`, builder outputs, and relative `builder-simv` paths belong in the per-test artifact root.
+Simulation outputs for `randtest` belong in the per-run artifact directory to avoid side-file clobbering across iterations.
+
+## Subprocesses
+
+Every external tool invocation should pass an explicit `cwd`.
+Use the command's artifact directory unless the command has a documented reason to run elsewhere.
+
+Use `run_managed_process()` for long-running or tool-managed subprocesses so cleanup, timeout handling, and signal behavior stay consistent.
+Plain `subprocess.run()` is acceptable only for short probes or helpers where lifecycle management is not needed; document that choice when it is not obvious.
+
+## Dependencies
+
+Classify every dependency using the buckets in [Installation](../install.md#dependency-types): required dependency, integrated tool, pluggable, or pluggable curated.
+Use the classification to decide whether the dependency belongs in `pyproject.toml`, user install instructions, tool manifests, root-config schema, or command-specific docs.
+
+Every new feature or dependency must update `docs/install.md` in the same PR.
+The install page is the source of truth for feature-to-dependency mapping, required external tools, optional sub-dependencies, curated tools, and fork requirements.
+
+Every external tool dependency must also be represented in `src/rtl_buddy/tool_manifest.py` unless there is a documented reason it cannot be checked.
+The manifest is the source used by `rb tool-check`, `rb tool-check --required-for`, `rb tool-check --explain`, and runtime `tool_manifest.require()` errors.
+Keep the manifest's `used_by`, `optional`, `minimum_version`, detector, install hint, and notes fields aligned with `docs/install.md`.
+
+When a new feature adds or changes tool requirements, update `tests/test_tool_manifest.py` so `rb tool-check` reports the right readiness and install guidance.
+Update [Tool Dependency Check](../concepts/tool-check.md) when manifest semantics, detector behavior, exit-code behavior, or command coverage changes.
+
+Required Python dependencies should be kept minimal because they are installed for every user.
+Prefer optional external tools for feature-specific functionality unless the dependency is needed by the core CLI, config loading, local docs access, or a command that cannot operate without it.
+
+When adding an external tool integration, document:
+
+- the command or feature that needs it;
+- whether it is integrated, pluggable, or pluggable curated;
+- any required version or fork;
+- optional sub-dependencies such as coverage, rendering, or notebook extras;
+- the concept page that explains build or setup details.
+- the `rb tool-check --explain <tool>` hint users should see when it is missing.
+
+## Logging
+
+All runtime logging goes through `log_event()` in `src/rtl_buddy/logging_utils.py`.
+Do not use direct `logger.info(f"...")` calls for runtime events.
+
+Human mode converts events into readable text for `rtl_buddy.log` and console output.
+Machine mode writes JSON Lines with the event name, fields, and human message.
+
+When adding events:
+
+- Use dotted names such as `compile.start`, `sim.timeout`, or `suite_config.load_failed`.
+- Include structured fields that are stable and useful for agents.
+- Add a dedicated human-message case for WARNING or ERROR events.
+- Keep DEBUG and INFO events concise enough for machine logs.
+
+## Error Handling
+
+Fatal config and environment errors should log at ERROR and raise `FatalRtlBuddyError`.
+The top-level command exits with code 2.
+
+Per-test setup and filelist failures should become structured test results when the broader command can continue.
+Use `FilelistError` for filelist failures caught by `TestRunner`.
+Sweep and preproc failures should return a setup-failure string so the suite records `SetupFailResults`.
+
+Do not use process-wide abort patterns for recoverable per-item failures.
+
+## Validation
+
+Let validation scale with risk:
+
+- Docs-only edits: run frontmatter and MkDocs strict checks.
+- CLI help changes: regenerate `docs/reference/cli.md` and run the generated-reference check.
+- Path, artifact, or subprocess changes: add focused tests proving roots, generated paths, and subprocess `cwd`.
+- Shared command-dispatch or config-loader changes: run the affected test module subset, then broaden if the change crosses command families.
+
+Report skipped checks in the PR with the reason.
+
+## Required Follow-Through
+
+After meaningful `rtl_buddy` changes:
+
+1. If CLI command names, flags, help text, or output behavior changed, regenerate `docs/reference/cli.md` with `uv run python scripts/gen_cli_reference.py`.
+2. If a feature, command, optional extra, or external tool dependency changed, update `docs/install.md`.
+3. If an external tool dependency changed, update `src/rtl_buddy/tool_manifest.py`, `tests/test_tool_manifest.py`, and `docs/concepts/tool-check.md` when tool-check behavior or coverage changes.
+4. If docs changed, keep frontmatter valid and run the docs build. See [Documentation Guidelines](docs.md).
+5. If behavior, YAML schema, version expectations, or validation workflows changed, update user docs and the bundled skill if agents rely on the behavior.
+6. If release or packaging behavior changed, verify wheel inclusion rules and update downstream integrations after release.
+
+## Bundled Skill
+
+The `rtl_buddy` agent skill ships inside the wheel at `src/rtl_buddy/skill/` and is installed by `rtl-buddy skill install`.
+There is no separate source-of-truth skill repo.
+
+Keep `src/rtl_buddy/skill/SKILL.md` short and agent-specific.
+Prefer links to local docs commands over duplicating reference content.
+Project-level installs are an override mechanism; the default install scope should remain user-level unless the policy is deliberately revisited.
+
+## Releases
+
+Stable releases are produced by merging to `main` with one of the `version/patch`, `version/minor`, or `version/major` labels.
+Pre-releases are cut from feature branches by workflow dispatch and should not be produced by merging pre-release branches into `main`.
+
+Docs publishing, PyPI publishing, and downstream template updates depend on that sequence.
+Do not push a template pin for an unreleased `rtl_buddy` version.

--- a/docs/development/guidelines.md
+++ b/docs/development/guidelines.md
@@ -170,6 +170,40 @@ Keep `src/rtl_buddy/skill/SKILL.md` short and agent-specific.
 Prefer links to local docs commands over duplicating reference content.
 Project-level installs are an override mechanism; the default install scope should remain user-level unless the policy is deliberately revisited.
 
+## Issue Triage
+
+Issues are classified along three axes that live on GitHub itself, not in this repo:
+
+- **Type** — the org-level Issue Type: `Bug`, `Feature`, or `Docs`. Set once on every issue.
+- **Priority** — the org-level Issue Field: `Urgent`, `High`, `Medium`, or `Low`. Reflects how soon the work should land, not how big it is.
+- **Effort** — the org-level Issue Field: `High`, `Medium`, or `Low`. Optional; fill it in when the answer is non-obvious.
+
+Type, Priority, and Effort are not labels.
+They are GitHub Issue Fields configured at the `rtl-buddy` organization level and are queryable via the REST and GraphQL APIs.
+
+Area is captured with repo-level labels.
+Pick one or more from the table below; an issue with no area label is fine for cross-cutting work but a single area is preferred when one fits.
+
+| Label | Covers |
+|---|---|
+| `area/test` | `test`, `randtest`, `regression`, `wave`, and the compile/sim runner pipeline |
+| `area/abv` | `cdc`, `fpv`, assertion-based verification in sim |
+| `area/impl` | `synth`, `pnr`, `power`, and other implementation flows |
+| `area/hier` | `hier` viewer and `rtl-buddy-view` integration |
+| `area/axi-profile` | `axi-profile` discover, run, notebook, and monitor generation |
+| `area/hub` | the hub server, marimo integration, hub event plumbing |
+| `area/skill` | the bundled agent skill and `skill install` |
+| `area/config` | `root_config.yaml`, suite YAML loading, `filelist`, and model resolution |
+| `area/tooling` | `tool-check`, `tool_manifest.py`, and external-tool integration |
+| `area/infra` | CI workflows, packaging, release mechanics, dependencies, and machine-mode logging |
+
+One extra label exists outside the area set:
+
+- `discussion` — for issues that are scope or design conversations rather than tracked work.
+
+The `version/patch`, `version/minor`, and `version/major` labels are reserved for PRs and drive the release workflow.
+Do not apply them to issues.
+
 ## Releases
 
 Stable releases are produced by merging to `main` with one of the `version/patch`, `version/minor`, or `version/major` labels.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,6 +58,9 @@ nav:
       - CLI: reference/cli.md
       - YAML Formats: reference/yaml.md
   - For Agents: agents.md
+  - Development:
+      - Engineering Guidelines: development/guidelines.md
+      - Documentation Guidelines: development/docs.md
   - Migrations:
       - Submodule to uv: migrations/submodule-to-uv.md
       - v2 to v3: migrations/v2-to-v3.md


### PR DESCRIPTION
## Summary

- Adds a Development section to the docs with engineering guidelines for execution contexts, path ownership, artifact layout, subprocess CWDs, logging, errors, validation, bundled skill policy, and release-sensitive follow-through.
- Moves the detailed documentation authoring rules out of `CONTRIBUTING.md` into `docs/development/docs.md`.
- Keeps `CONTRIBUTING.md` as a short overview that links to the detailed development and documentation guidelines.

This codifies the proposed execution-context scheme discussed in #216 without claiming the current implementation already satisfies every rule.

## Validation

- `uv run python scripts/check_docs_frontmatter.py --check`
- `git diff --check`
- `uv run --group docs mkdocs build --strict`
