### PR TITLE
Sweep of open issues: list-only startup, sdist trim, dev docs, two infra bugs

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -7,6 +7,10 @@ description: Entry point for contributing to rtl_buddy, with links to the detail
 This page is the entry point for contributors and maintainers.
 Detailed rules live under the Development section so they are visible in the docs site, available through `rb docs show`, and not duplicated across agent-only files.
 
+## Environment Setup
+
+Start with [Environment Setup](development/setup.md) for cloning, `uv sync`, pre-commit hooks, running the test suite, and building the wheel/sdist locally.
+
 ## Development Guidelines
 
 Read [Engineering Guidelines](development/guidelines.md) before changing runtime behavior, command execution, YAML loading, subprocess wrappers, logging, errors, release mechanics, or the bundled agent skill.

--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -1,0 +1,132 @@
+---
+description: How to set up a local rtl_buddy development environment — clone, dependencies, lint, tests, docs, and build verification.
+---
+
+# Development Environment Setup
+
+This page covers the local environment for maintainers and contributors working **on** `rtl_buddy`. End-user install of the published wheel is documented in [Installation](../install.md).
+
+## Prerequisites
+
+- Python 3.11 or later (matches the floor in `pyproject.toml`).
+- `uv` — see <https://docs.astral.sh/uv/> for install instructions.
+- `git`.
+
+`uv` owns the project environment. The repo uses `pyproject.toml` plus a committed `uv.lock`; do not maintain a hand-rolled `requirements.txt`.
+
+External EDA tools (Verilator, Yosys, Verible, OpenROAD, etc.) are only required when running the matching `rb` subcommand. Day-to-day Python and docs work needs none of them. See [Installation](../install.md#external-tools-by-feature) for the full feature-to-dependency matrix.
+
+## Clone And Sync
+
+```bash
+git clone https://github.com/rtl-buddy/rtl_buddy.git
+cd rtl_buddy
+uv sync --group dev
+```
+
+`uv sync --group dev` installs the package plus the composite `dev` dependency group (lint, test, docs). The resulting environment lives in `.venv/`; `uv run <cmd>` and `./venv/bin/python -m rtl_buddy …` both reach it.
+
+Verify the install:
+
+```bash
+uv run rb --version
+```
+
+## Pre-Commit Hook
+
+Install the `pre-commit` hook once so Ruff runs automatically on every commit:
+
+```bash
+uv tool install pre-commit
+pre-commit install
+```
+
+To refresh the pinned hook version:
+
+```bash
+pre-commit autoupdate
+```
+
+CI enforces both `ruff check` and `ruff format --check` via `.github/workflows/lint.yml`, so it pays to catch issues at commit time.
+
+## Lint And Format
+
+```bash
+uv run ruff check          # lint
+uv run ruff format         # format in place
+uv run ruff format --check # check only (what CI runs)
+```
+
+## Tests
+
+The pytest suite under `tests/` is the primary correctness gate. CI runs it on every push and PR via `.github/workflows/test.yml`.
+
+```bash
+uv run pytest                                    # full suite
+uv run pytest tests/test_cli_with_fixture.py     # one file
+uv run pytest -k "list"                          # by keyword
+uv run pytest --cov                              # with coverage summary
+uv run pytest --cov --cov-report=term-missing    # show uncovered lines
+uv run pytest --cov --cov-report=html            # write htmlcov/index.html
+```
+
+Coverage configuration lives in `[tool.coverage.*]` in `pyproject.toml` (source = `src/rtl_buddy`, excludes the bundled `skill/` and `docs/`). `pytest.ini` does not enable `--cov` by default so plain `pytest` stays fast; pass `--cov` explicitly when you want a coverage run.
+
+## Docs
+
+The docs site lives under `docs/` and is built with MkDocs Material. Two checks run in CI on every docs change:
+
+```bash
+uv run python scripts/check_docs_frontmatter.py --check
+uv run --group docs mkdocs build --strict
+```
+
+To preview the site locally:
+
+```bash
+uv run --group docs mkdocs serve
+```
+
+Then open <http://127.0.0.1:8000>.
+
+If you change CLI help strings in `src/rtl_buddy/rtl_buddy.py`, regenerate the CLI reference page:
+
+```bash
+uv run python scripts/gen_cli_reference.py
+```
+
+`docs/reference/cli.md` is auto-generated and should not be edited by hand. The docs build also regenerates it via a hook in `mkdocs.yml`; CI auto-commits drift.
+
+## Building Wheels And Sdists
+
+`rtl_buddy` uses `hatchling` plus `hatch-vcs`, so the version is derived from the latest git tag. Local builds work with `uv build`:
+
+```bash
+uv build              # both wheel and sdist
+uv build --wheel
+uv build --sdist
+```
+
+Artifacts land under `dist/`. The wheel ships `src/rtl_buddy/` plus the `docs/` tree (via `force-include`); the sdist ships the same source plus `README.md`, `LICENSE`, and `pyproject.toml`. Dev/CI files (`tests/`, `scripts/`, `.github/`, `mkdocs.yml`, `uv.lock`, agent guides, pre-commit config) are excluded — keep them that way when changing `[tool.hatch.build.targets.*]`.
+
+## Validating Against The Project Template
+
+For changes that affect end-user behavior, validate against the [rtl-buddy-project-template](https://github.com/rtl-buddy/rtl-buddy-project-template) before opening a PR. The template's `dev/local-rtl-buddy` branch swaps the PyPI pin for an editable path dependency on a sibling `rtl_buddy/` checkout, so you can iterate locally without publishing.
+
+Typical loop:
+
+```bash
+# In a sibling clone of rtl-buddy-project-template:
+git worktree add .worktrees/dev-local dev/local-rtl-buddy
+cd .worktrees/dev-local
+uv sync                              # picks up ../../../rtl_buddy editable
+uv run rb regression -c regression.yaml
+```
+
+The template's `AGENTS.md` documents the same standing-branch convention; do not push that branch back to `main`.
+
+## Where To Go Next
+
+- [Engineering Guidelines](guidelines.md) — public contracts, execution contexts, path ownership, subprocesses, logging, errors, releases, and issue triage.
+- [Documentation Guidelines](docs.md) — frontmatter, page structure, generated pages, and docs validation.
+- [Contributing](../CONTRIBUTING.md) — the contributor entry point that links to both.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,6 +60,7 @@ nav:
       - YAML Formats: reference/yaml.md
   - For Agents: agents.md
   - Development:
+      - Environment Setup: development/setup.md
       - Engineering Guidelines: development/guidelines.md
       - Documentation Guidelines: development/docs.md
   - Migrations:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,23 @@ Tracker = "https://github.com/rtl-buddy/rtl_buddy/issues"
 [tool.hatch.version]
 source = "vcs"
 
+# Source distribution only needs the inputs a downstream installer
+# (pip, uv) actually requires: pyproject.toml, README.md, LICENSE, the
+# package source under src/, and docs/ (because the bundled skill
+# materializes them from the wheel). Dev/CI scaffolding (tests/,
+# scripts/, .github/, .agents/, .claude/, mkdocs.yml, uv.lock,
+# AGENTS.md, CLAUDE.md, .pre-commit-config.yaml, pytest.ini,
+# CONTRIBUTORS) is not needed at install time and only inflates the
+# release tarball.
+[tool.hatch.build.targets.sdist]
+include = [
+  "src/rtl_buddy",
+  "docs",
+  "README.md",
+  "LICENSE",
+  "pyproject.toml",
+]
+
 [tool.hatch.build.targets.wheel]
 packages = ["src/rtl_buddy"]
 exclude = ["src/rtl_buddy/docs"]

--- a/src/rtl_buddy/config/test.py
+++ b/src/rtl_buddy/config/test.py
@@ -427,6 +427,14 @@ class TestConfigFile:
         model = ModelConfigLoader(os.path.join(config_dir, self.model_path)).get_model(
             self.model
         )
+        # Hook script paths are declared relative to the suite config
+        # (tests.yaml), the same as model_path. Resolve them at load
+        # time so VlogSim.pre() / _expand_tests_with_sweep can open()
+        # them regardless of the process cwd — required since #216,
+        # which stopped changing cwd into the suite dir.
+        preproc_path = _resolve_hook_path(self.preproc_path, config_dir)
+        postproc_path = _resolve_hook_path(self.postproc_path, config_dir)
+        sweep_path = _resolve_hook_path(self.sweep_path, config_dir)
         return TestConfig(
             self.name,
             self.desc,
@@ -435,11 +443,25 @@ class TestConfigFile:
             self.pa,
             self.pd,
             self.uvm,
-            self.preproc_path,
-            self.postproc_path,
-            self.sweep_path,
+            preproc_path,
+            postproc_path,
+            sweep_path,
             tb,
             self.timeout,
             covers=self.covers,
             assertions=self.assertions,
         )
+
+
+def _resolve_hook_path(path: str | None, config_dir: str) -> str | None:
+    """Resolve a hook-script path declared in tests.yaml.
+
+    Absolute paths pass through; relative paths anchor on the suite
+    config's directory. Returns None unchanged so commands without a
+    hook stay None.
+    """
+    if path is None:
+        return None
+    if os.path.isabs(path):
+        return path
+    return os.path.normpath(os.path.join(config_dir, path))

--- a/src/rtl_buddy/rtl_buddy.py
+++ b/src/rtl_buddy/rtl_buddy.py
@@ -292,6 +292,15 @@ class RtlBuddy:
             return exc.exit_code
         except (FatalRtlBuddyError, FilelistError) as exc:
             emit_console_text(str(exc), style="red")
+            if self.machine:
+                # Machine consumers parse stdout JSON; a silent stdout
+                # forces them to scrape stderr for an ad-hoc message.
+                # Emit an envelope so the failure surface matches the
+                # success surface.
+                command = (
+                    getattr(self, "_pending_invoked_subcommand", None) or "rtl_buddy"
+                )
+                self._emit_machine_result(command, 2, error=str(exc))
             return 2
         # standalone_mode=False makes click *return* the exit code from
         # `typer.Exit(code=N)` rather than re-raise it, so we have to
@@ -4000,7 +4009,21 @@ class RtlBuddy:
             git_str = f"git: {branch} | commit {commit} | mod {mod} | staged {staged}"
         else:
             git_str = f"git: {branch} | commit {commit} | clean"
-        emit_console_text(git_str, style=None if is_machine_mode() else "dim")
+        # The git status already rides inside every machine-mode JSON
+        # envelope via _emit_machine_result.meta.git — skip the human
+        # banner so machine consumers don't see redundant stderr noise.
+        if is_machine_mode():
+            log_event(
+                logger,
+                logging.INFO,
+                "git.status",
+                branch=branch,
+                commit=commit,
+                modified=mod,
+                staged=staged,
+            )
+            return
+        emit_console_text(git_str, style="dim")
         log_event(
             logger,
             logging.INFO,

--- a/src/rtl_buddy/rtl_buddy.py
+++ b/src/rtl_buddy/rtl_buddy.py
@@ -299,8 +299,17 @@ class RtlBuddy:
         # to exit cleanly with code 0.
         return rv if isinstance(rv, int) else 0
 
-    def _is_test_list_invocation(self, ctx: typer.Context) -> bool:
-        return ctx.invoked_subcommand == "test" and "--list" in sys.argv[1:]
+    # Subcommands that expose a `--list` flag whose only job is to emit
+    # configured names from the primary config file. The `--list` paths
+    # do not need RootConfig, the selected builder, or CoverageReporter,
+    # so list-only invocations short-circuit those setup steps.
+    _LIST_FLAG_COMMANDS = {"test", "synth", "pnr", "power", "cdc", "fpv"}
+
+    def _is_list_invocation(self, ctx: typer.Context) -> bool:
+        return (
+            ctx.invoked_subcommand in self._LIST_FLAG_COMMANDS
+            and "--list" in sys.argv[1:]
+        )
 
     def root_options(
         self,
@@ -379,7 +388,7 @@ class RtlBuddy:
 
         if (
             ctx.invoked_subcommand in self._GIT_COMMANDS
-            and not self._is_test_list_invocation(ctx)
+            and not self._is_list_invocation(ctx)
         ):
             self.show_git_rev()
 
@@ -396,6 +405,7 @@ class RtlBuddy:
         *,
         primary_config: str | Path | None = None,
         command_root: str | Path | None = None,
+        list_only: bool = False,
     ) -> ExecutionContext:
         """Build the command's ExecutionContext and attach the file log.
 
@@ -411,6 +421,12 @@ class RtlBuddy:
         within the same process re-anchor the file log handler so a
         long-running session (e.g. ``rb regression`` iterating suites)
         keeps each suite's log under its own root.
+
+        ``list_only=True`` skips ``RootConfig``, builder, and
+        ``CoverageReporter`` setup. The metadata-only ``--list`` paths
+        only need to read the suite config; skipping the root-config
+        load keeps them usable when the surrounding project config is
+        invalid or unrelated to the listed suite.
         """
         if (primary_config is None) == (command_root is None):
             raise FatalRtlBuddyError(
@@ -432,6 +448,9 @@ class RtlBuddy:
         ctx.command_root.mkdir(parents=True, exist_ok=True)
         attach_file_log(ctx.log_path)
         self.exec_ctx = ctx
+
+        if list_only:
+            return ctx
 
         # Build root_cfg on first entry; on later entries, only rebuild if
         # the new command root walks up to a different root_config.yaml —
@@ -690,7 +709,9 @@ class RtlBuddy:
         self.rtl_builder_mode = (
             "debug" if self.rtl_builder_mode is None else self.rtl_builder_mode
         )
-        ctx = self._enter_command_context(primary_config=test_config)
+        ctx = self._enter_command_context(
+            primary_config=test_config, list_only=list_tests
+        )
         self.suite_cfg = SuiteConfig(path=str(ctx.primary_config))
         log_event(
             logger,
@@ -2298,7 +2319,9 @@ class RtlBuddy:
         """
         run synthesis
         """
-        ctx = self._enter_command_context(primary_config=synth_config)
+        ctx = self._enter_command_context(
+            primary_config=synth_config, list_only=list_synths
+        )
         suite_cfg = SynthSuiteConfig(path=str(ctx.primary_config))
         log_event(
             logger,
@@ -2377,7 +2400,9 @@ class RtlBuddy:
         ] = False,
     ):
         """run place-and-route"""
-        ctx = self._enter_command_context(primary_config=pnr_config)
+        ctx = self._enter_command_context(
+            primary_config=pnr_config, list_only=list_runs
+        )
         suite_cfg = PnrSuiteConfig(path=str(ctx.primary_config))
         if emit_png:
             emit_gds = True
@@ -2569,7 +2594,9 @@ class RtlBuddy:
         ] = 0,
     ):
         """run power analysis"""
-        ctx = self._enter_command_context(primary_config=power_config)
+        ctx = self._enter_command_context(
+            primary_config=power_config, list_only=list_runs
+        )
         suite_cfg = PowerSuiteConfig(path=str(ctx.primary_config))
         log_event(
             logger,
@@ -3018,7 +3045,9 @@ class RtlBuddy:
         """
         run CDC lint
         """
-        ctx = self._enter_command_context(primary_config=cdc_config)
+        ctx = self._enter_command_context(
+            primary_config=cdc_config, list_only=list_cdcs
+        )
         suite_cfg = CdcSuiteConfig(path=str(ctx.primary_config))
         log_event(
             logger,
@@ -3321,7 +3350,9 @@ class RtlBuddy:
         """
         run formal property verification
         """
-        ctx = self._enter_command_context(primary_config=fpv_config)
+        ctx = self._enter_command_context(
+            primary_config=fpv_config, list_only=list_fpvs
+        )
         suite_cfg = FpvSuiteConfig(path=str(ctx.primary_config))
         log_event(
             logger,

--- a/src/rtl_buddy/tools/vlog_filelist.py
+++ b/src/rtl_buddy/tools/vlog_filelist.py
@@ -190,6 +190,7 @@ class VlogFilelist:
         strip=False,
         deduplicate=False,
         test_filelist=None,
+        suite_dir=None,
     ):
         if output_filepath is None:
             output_filepath = self.output_path
@@ -201,13 +202,19 @@ class VlogFilelist:
             model_filelist, unroll, os.path.abspath(self.model_cfg.get_model_path())
         )
 
-        # Get filelist from tests. assume tests.yaml is in the same dir
+        # Get filelist from tests. Entries are declared relative to the
+        # suite config's directory (tests.yaml). Use suite_dir when the
+        # caller supplies it; fall back to cwd for callers that still
+        # assume the legacy "process cwd is the suite dir" model.
         if test_filelist:
+            suite_anchor = (
+                os.path.abspath(suite_dir) if suite_dir else os.path.abspath(".")
+            )
             entries.extend(
                 self._extract(
                     test_filelist,
                     unroll,
-                    os.path.join(os.path.abspath("."), "tests.yaml"),
+                    os.path.join(suite_anchor, "tests.yaml"),
                 )
             )
 

--- a/src/rtl_buddy/tools/vlog_sim.py
+++ b/src/rtl_buddy/tools/vlog_sim.py
@@ -249,6 +249,7 @@ class VlogSim:
             strip=False,
             deduplicate=True,
             test_filelist=self.testbench.get_filelist(),
+            suite_dir=self.suite_work_dir,
         )
 
     def _get_plusargs(self):

--- a/tests/test_cli_with_fixture.py
+++ b/tests/test_cli_with_fixture.py
@@ -145,6 +145,54 @@ def test_test_list_skips_root_config_load(minimal_project: Path):
     assert "basic" in result.output
 
 
+def test_machine_mode_emits_json_envelope_on_fatal_error(
+    minimal_project: Path, capsys, monkeypatch
+):
+    """``rb --machine <cmd>`` must emit a JSON envelope on stdout even on
+    FatalRtlBuddyError. Without it, machine consumers see nothing and have
+    to scrape stderr — defeating the point of --machine."""
+    import json
+
+    rb = RtlBuddy(name="test_cli_machine_err")
+    monkeypatch.setattr(
+        "sys.argv",
+        ["rb", "--machine", "test", "bogus_test_name", "-c", "tests.yaml"],
+    )
+    exit_code = rb.run()
+    captured = capsys.readouterr()
+
+    assert exit_code == 2, captured
+    assert captured.out, "expected JSON envelope on stdout in machine mode"
+    payload = json.loads(captured.out)
+    assert payload["command"] == "test"
+    assert payload["exit_code"] == 2
+    assert "error" in payload["payload"]
+    assert "bogus_test_name" in payload["payload"]["error"]
+    # Human-readable message still rides on stderr.
+    assert "bogus_test_name" in captured.err
+
+
+def test_machine_mode_skips_git_banner_on_stderr(minimal_project: Path, capsys):
+    """The git-rev banner is human-only — machine consumers already get
+    git status inside every JSON envelope via meta.git. Suppress the
+    stderr banner so machine output stays tight."""
+    rb = RtlBuddy(name="test_cli_machine_no_banner")
+    import sys
+
+    saved_argv = sys.argv[:]
+    sys.argv = ["rb", "--machine", "test", "--list", "-c", "tests.yaml"]
+    try:
+        exit_code = rb.run()
+    finally:
+        sys.argv = saved_argv
+    captured = capsys.readouterr()
+    assert exit_code == 0, captured
+    assert "git:" not in captured.err, (
+        "machine mode should not emit the human git banner to stderr; "
+        f"got: {captured.err!r}"
+    )
+
+
 def test_synth_list_skips_root_config_load(tmp_path: Path, monkeypatch):
     """``rb synth --list`` should not require a valid root_config.yaml.
 

--- a/tests/test_cli_with_fixture.py
+++ b/tests/test_cli_with_fixture.py
@@ -122,3 +122,66 @@ def test_root_config_resolves_from_nested_cwd(minimal_project: Path, monkeypatch
     )
     assert result.exit_code == 0, result.output
     assert "basic" in result.output
+
+
+def test_test_list_skips_root_config_load(minimal_project: Path):
+    """``rb test --list`` should not require a valid root_config.yaml.
+
+    Per #67, list-only invocations are metadata-only — they should run
+    against the suite config alone and skip RootConfig, builder, and
+    CoverageReporter setup.
+    """
+    # Corrupt root_config.yaml: replace the configured builder name with
+    # one that does not exist in cfg-rtl-builder, which would normally
+    # fail platform/builder selection during RootConfig load.
+    rc_path = minimal_project / "root_config.yaml"
+    rc_path.write_text(
+        rc_path.read_text().replace('builder: "stub"', 'builder: "absent"')
+    )
+
+    runner, rb = _runner()
+    result = runner.invoke(rb.app, ["test", "-c", "tests.yaml", "--list"])
+    assert result.exit_code == 0, result.output
+    assert "basic" in result.output
+
+
+def test_synth_list_skips_root_config_load(tmp_path: Path, monkeypatch):
+    """``rb synth --list`` should not require a valid root_config.yaml.
+
+    A synth.yaml is placed in a fresh directory with no root_config.yaml
+    anywhere up the tree, and ``rb synth --list`` should still emit the
+    configured synthesis names.
+    """
+    suite_dir = tmp_path / "synth-suite"
+    suite_dir.mkdir()
+    (suite_dir / "models.yaml").write_text(
+        "rtl-buddy-filetype: model_config\n"
+        "models:\n"
+        "  - name: mod_a\n"
+        "    filelist: [top_a.sv]\n"
+        "  - name: mod_b\n"
+        "    filelist: [top_b.sv]\n"
+    )
+    (suite_dir / "synth.yaml").write_text(
+        "rtl-buddy-filetype: synth_config\n"
+        "syntheses:\n"
+        "  - name: synth_a\n"
+        "    desc: alpha\n"
+        "    model: mod_a\n"
+        "    model_path: models.yaml\n"
+        "    tool: yosys\n"
+        "    reglvl: 0\n"
+        "  - name: synth_b\n"
+        "    desc: bravo\n"
+        "    model: mod_b\n"
+        "    model_path: models.yaml\n"
+        "    tool: yosys\n"
+        "    reglvl: 0\n"
+    )
+    monkeypatch.chdir(suite_dir)
+
+    runner, rb = _runner()
+    result = runner.invoke(rb.app, ["synth", "-c", "synth.yaml", "--list"])
+    assert result.exit_code == 0, result.output
+    assert "synth_a" in result.output
+    assert "synth_b" in result.output

--- a/tests/test_config_loaders.py
+++ b/tests/test_config_loaders.py
@@ -336,6 +336,52 @@ tests: []
         SuiteConfig(str(path))
 
 
+def test_suite_config_resolves_hook_paths_against_suite_dir(tmp_path):
+    """preproc/postproc/sweep paths declared in tests.yaml are
+    relative to the suite config's directory. They must be absolute
+    after load so VlogSim.pre() and _expand_tests_with_sweep can
+    open() them regardless of the process cwd (#223)."""
+    import os
+
+    suite_dir = tmp_path / "suite"
+    suite_dir.mkdir()
+    (suite_dir / "models.yaml").write_text(
+        "rtl-buddy-filetype: model_config\n"
+        "models:\n  - name: m\n    filelist: [top.sv]\n"
+    )
+    (suite_dir / "tests.yaml").write_text(
+        "rtl-buddy-filetype: test_config\n"
+        "testbenches:\n"
+        "  - name: tb1\n"
+        "    filelist: [tb.sv]\n"
+        "tests:\n"
+        "  - name: basic\n"
+        "    desc: example\n"
+        "    model: m\n"
+        "    model_path: models.yaml\n"
+        "    reglvl: 0\n"
+        "    plusargs:\n"
+        "    plusdefines:\n"
+        "    uvm:\n"
+        "    preproc:\n"
+        "      path: scripts/pre.py\n"
+        "    postproc:\n"
+        "      path: /abs/path/post.py\n"
+        "    sweep:\n"
+        "      path: scripts/sweep.py\n"
+        "    testbench: tb1\n"
+        "    sim_timeout:\n"
+    )
+
+    cfg = SuiteConfig(str(suite_dir / "tests.yaml"))
+    test = cfg.tests["basic"]
+    # Relative paths resolve against the suite dir.
+    assert test.preproc_path == os.path.normpath(str(suite_dir / "scripts" / "pre.py"))
+    assert test.sweep_path == os.path.normpath(str(suite_dir / "scripts" / "sweep.py"))
+    # Absolute paths pass through unchanged.
+    assert test.postproc_path == "/abs/path/post.py"
+
+
 def test_suite_config_duplicate_test_raises(tmp_path):
     body = """\
 rtl-buddy-filetype: test_config

--- a/tests/test_verible_filelist.py
+++ b/tests/test_verible_filelist.py
@@ -136,6 +136,60 @@ def test_verible_filelist_empty_model_list_errors(tmp_path: Path):
         fl.write_verible_filelist([])
 
 
+def test_write_output_anchors_test_filelist_on_explicit_suite_dir(
+    tmp_path: Path, monkeypatch
+):
+    """``write_output(suite_dir=...)`` resolves testbench filelist entries
+    against the supplied suite dir, not the process cwd. Required since
+    #216 stopped anchoring cwd on the suite (#223 follow-up)."""
+    # Layout:
+    #   <tmp>/suite/tests.yaml
+    #   <tmp>/suite/tb.sv
+    #   <tmp>/suite/inc/  (the +incdir+ target)
+    #   <tmp>/design/m.sv (model source)
+    suite_dir = tmp_path / "suite"
+    suite_dir.mkdir()
+    (suite_dir / "tb.sv").write_text("module tb; endmodule\n")
+    (suite_dir / "inc").mkdir()
+    design_dir = tmp_path / "design"
+    design_dir.mkdir()
+    (design_dir / "m.sv").write_text("module m; endmodule\n")
+
+    model = ModelConfig(
+        name="m",
+        filelist=["m.sv"],
+        path=str(design_dir / "models.yaml"),
+    )
+    artefact_dir = suite_dir / "artefacts" / "basic"
+    artefact_dir.mkdir(parents=True)
+    out = artefact_dir / "run.f"
+
+    # Run from an unrelated cwd to prove the suite_dir argument — not
+    # the cwd — is what anchors testbench entries.
+    monkeypatch.chdir(tmp_path)
+
+    fl = VlogFilelist(name="t", model_cfg=model, output_path=str(out))
+    fl.write_output(
+        unroll=True,
+        test_filelist=["tb.sv", "+incdir+inc"],
+        suite_dir=str(suite_dir),
+    )
+
+    text = out.read_text()
+    assert "tb.sv" in text
+    assert "+incdir+" in text
+    # Sanity-check: the resolved tb.sv path should walk back up to the
+    # suite, not be missing or over-deep.
+    tb_lines = [
+        ln for ln in text.splitlines() if ln and "tb.sv" in ln and "+incdir+" not in ln
+    ]
+    assert tb_lines, f"tb.sv not found in {text!r}"
+    import os
+
+    resolved = os.path.normpath(os.path.join(str(artefact_dir), tb_lines[0]))
+    assert resolved == str((suite_dir / "tb.sv").resolve())
+
+
 # --- rb verible filelist (integration through Typer) ---------------------
 
 


### PR DESCRIPTION
## Summary

Five independent changes against the open-issue backlog. Each commit is self-contained — happy to split the PR if a reviewer prefers per-issue merges.

- **Fixes #67** — `rb test|synth|pnr|power|cdc|fpv --list` skip `RootConfig`, builder selection, and `CoverageReporter` setup. Metadata-only listing no longer needs a valid root config / cfg-rtl-reg, and the human git banner is suppressed on those paths. New tests cover both the test and synth list paths against a corrupt and a missing root config.
- **Fixes #8** — switch the sdist to an explicit include list (`src/rtl_buddy`, `docs`, `README`, `LICENSE`, `pyproject.toml`). Drops the published tarball from 227 entries / 560K to 148 entries / 343K and stops shipping `tests/`, `scripts/`, `.github/`, `.agents/`, `.claude/`, `mkdocs.yml`, `uv.lock`, `AGENTS.md`, `CLAUDE.md`, `.pre-commit-config.yaml`, `pytest.ini`, and `CONTRIBUTORS` to downstream mirrors. Wheel layout unchanged.
- **Fixes #7** — adds `docs/development/setup.md` covering clone + `uv sync`, the pre-commit hook, lint/format, pytest (with coverage), mkdocs serve/build, the generated CLI reference, and wheel/sdist builds. Wired into the mkdocs nav and surfaced from `docs/CONTRIBUTING.md`.
- **Fixes #222** *(filed during this sweep)* — `rb --machine <cmd>` was silent on stdout when a command raised `FatalRtlBuddyError` / `FilelistError`. Now emits the standard `{command, exit_code, meta, payload}` envelope on stdout with `payload.error` carrying the message, and suppresses the human git-rev banner under `--machine` since git status already rides inside every envelope's `meta.git`.
- **Fixes #223** *(filed during this sweep)* — after #216 moved the process cwd off the suite dir, two consumers still used `os.getcwd()` as the suite anchor. `VlogSim.pre()` / `_expand_tests_with_sweep` `open()`'d the YAML-declared `preproc.path` / `sweep.path` / `postproc.path` as plain strings, and `VlogFilelist.write_output(test_filelist=...)` anchored testbench filelist entries on `os.path.abspath(".")`. Both fail when invoked from anywhere outside the suite directory, breaking `rb regression -c regression.yaml` from the project root. Fix: resolve hook script paths against `config_dir` at load time (matching the existing `model_path` pattern), and plumb `suite_dir` through `VlogFilelist.write_output`.

## Test plan

- [x] `uv run pytest` — 964 passed, 8 skipped, no regressions
- [x] `uv run ruff check` / `uv run ruff format --check` — clean
- [x] `uv run python scripts/check_docs_frontmatter.py --check` — clean
- [x] `uv run --group docs mkdocs build --strict` — clean
- [x] `uv build --sdist` — 148 entries / 343K (was 227 / 560K)
- [x] `uv build --wheel` — unchanged
- [x] End-to-end: `rb regression -c regression.yaml` from the rtl-buddy-project-template root — all simulator-side suites pass; remaining failures are environment-only (`vendor/pulp-platform/common_cells/include` missing locally, no cocotb / SystemC in the sandbox).
- [x] End-to-end: `rb --machine test bogus -c tests.yaml` — stdout is a single JSON envelope with `payload.error`; human message on stderr; exit code 2.


---
_Generated by [Claude Code](https://claude.ai/code/session_011AeVKqtXDUk6djH5Vfcwvx)_