### PR TITLE
feat(mut): rb mut mutation-testing slice (#206)

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -63,6 +63,7 @@ Usage: rtl-buddy [OPTIONS] COMMAND [ARGS]...
 │ tool-check         check installed tool dependencies and subcommand readiness        │
 │ axi-profile        profile AXI interconnect performance via rtl-buddy-axi-profiler   │
 │ verible            verible commands                                                  │
+│ mut                mutation testing                                                  │
 │ hub                manage the rtl-buddy-hub daemon                                   │
 │ skill              manage the rtl_buddy agent skill                                  │
 │ docs               browse bundled documentation                                      │

--- a/src/rtl_buddy/config/mut.py
+++ b/src/rtl_buddy/config/mut.py
@@ -1,0 +1,217 @@
+"""Configuration schema for ``rb mut`` (mutation testing) runs.
+
+A ``mut.yaml`` names a design file to mutate, the set of mutation
+operators to apply (mapped 1:1 onto ``rtl_buddy_xeno.MutationKind``),
+a budget, and the FPV verification that acts as the kill oracle. The
+mutation engine itself lives in the external ``rtl-buddy-xeno``
+library; this schema only describes *what* to mutate and *how* to
+score it.
+
+Unlike ``fpv.yaml`` (a list of verifications), one ``mut.yaml``
+describes a single mutation campaign — keeping ``rb mut list`` /
+``rb mut run`` unambiguous about which design is under test.
+"""
+
+import logging
+import os
+import pprint
+from dataclasses import dataclass, field as dc_field
+from typing import Literal
+
+from serde import field, serde
+from serde.yaml import from_yaml
+
+from .model import ModelConfig, ModelConfigLoader
+from ..errors import FatalRtlBuddyError
+from ..logging_utils import log_event
+
+logger = logging.getLogger(__name__)
+
+
+# The six rb-mut operators implemented in rtl-buddy-xeno. Validated here
+# (rather than by importing xeno) so config loading stays light and does
+# not pull in the Verible / pyslang toolchain just to parse a YAML file.
+# Must stay in sync with rtl_buddy_xeno.MutationKind's rb-mut variants.
+_VALID_OPERATORS = (
+    "arith_flip",
+    "bit_op_flip",
+    "cond_negate",
+    "cond_const",
+    "assign_drop",
+    "port_binding_swap",
+)
+
+_VALID_SCHEDULES = ("sequential", "round_robin")
+
+
+# ---- budget ----------------------------------------------------------------
+
+
+@serde
+class MutBudgetFile:
+    max_mutants: int = field(rename="max_mutants", default=100)
+    per_module_cap: int | None = field(rename="per_module_cap", default=None)
+    time_budget_minutes: float | None = field(
+        rename="time_budget_minutes", default=None
+    )
+    schedule: str = "sequential"
+
+
+@dataclass
+class MutBudget:
+    max_mutants: int
+    per_module_cap: int | None
+    time_budget_minutes: float | None
+    schedule: str
+
+
+# ---- verify (the kill oracle) ----------------------------------------------
+
+
+@serde
+class MutVerifyFile:
+    # Path (relative to mut.yaml) to the fpv.yaml that owns the proof.
+    fpv_config: str = field(rename="fpv_config")
+    # Name of the verification inside that fpv.yaml to use as the oracle.
+    verification: str
+
+
+# ---- scope (optional; no-op for single-file leaf blocks) -------------------
+
+
+@serde
+class MutScopeFile:
+    include: list[str] = field(default_factory=list)
+    exclude: list[str] = field(default_factory=list)
+
+
+# ---- campaign config (one mut.yaml) ----------------------------------------
+
+
+@serde
+class MutConfigFile:
+    filetype: Literal["mut_config"] = field(rename="rtl-buddy-filetype")
+    model: str
+    model_path: str = field(rename="model_path")
+    # SystemVerilog file to mutate, relative to mut.yaml. Must be one of
+    # the model's source files and must live within the model directory
+    # (the directory containing models.yaml) so per-mutant isolation can
+    # copy the tree and splice the mutant in.
+    design_file: str = field(rename="design_file")
+    operators: list[str]
+    verify: MutVerifyFile
+    name: str | None = None
+    top: str | None = None
+    budget: MutBudgetFile = field(default_factory=MutBudgetFile)
+    scope: MutScopeFile = field(default_factory=MutScopeFile)
+
+    def initialise(self, config_dir: str) -> "MutConfig":
+        if not self.operators:
+            raise FatalRtlBuddyError("mut.yaml: operators list is empty")
+        for op in self.operators:
+            if op not in _VALID_OPERATORS:
+                raise FatalRtlBuddyError(
+                    f"mut.yaml: operator '{op}' is not one of "
+                    f"{', '.join(_VALID_OPERATORS)}"
+                )
+        if self.budget.schedule not in _VALID_SCHEDULES:
+            raise FatalRtlBuddyError(
+                f"mut.yaml: schedule '{self.budget.schedule}' is not one of "
+                f"{', '.join(_VALID_SCHEDULES)}"
+            )
+
+        model = ModelConfigLoader(os.path.join(config_dir, self.model_path)).get_model(
+            self.model
+        )
+        design_file = os.path.normpath(os.path.join(config_dir, self.design_file))
+        fpv_config = os.path.normpath(os.path.join(config_dir, self.verify.fpv_config))
+
+        return MutConfig(
+            name=self.name or self.model,
+            model=model,
+            top=self.top or self.model,
+            design_file=design_file,
+            operators=list(self.operators),
+            fpv_config=fpv_config,
+            verification=self.verify.verification,
+            budget=MutBudget(
+                max_mutants=self.budget.max_mutants,
+                per_module_cap=self.budget.per_module_cap,
+                time_budget_minutes=self.budget.time_budget_minutes,
+                schedule=self.budget.schedule,
+            ),
+            scope_include=list(self.scope.include),
+            scope_exclude=list(self.scope.exclude),
+        )
+
+
+@dataclass
+class MutConfig:
+    name: str
+    model: ModelConfig
+    top: str
+    design_file: str
+    operators: list[str]
+    fpv_config: str
+    verification: str
+    budget: MutBudget
+    scope_include: list[str] = dc_field(default_factory=list)
+    scope_exclude: list[str] = dc_field(default_factory=list)
+
+    def get_name(self) -> str:
+        return self.name
+
+    def get_model(self) -> ModelConfig:
+        return self.model
+
+    def get_design_file(self) -> str:
+        return self.design_file
+
+    def get_operators(self) -> list[str]:
+        return self.operators
+
+    def __str__(self):
+        return pprint.pformat(self)
+
+
+class MutSuiteConfig:
+    """Loads a single ``mut.yaml`` into a resolved :class:`MutConfig`."""
+
+    def __init__(self, path: str):
+        self.path = path
+        try:
+            with open(path, "r") as f:
+                data = from_yaml(MutConfigFile, f.read())
+        except Exception as e:
+            log_event(
+                logger,
+                logging.ERROR,
+                "mut_suite_config.load_failed",
+                path=path,
+                error=e,
+            )
+            raise FatalRtlBuddyError(f'failed to load "{path}"') from e
+
+        config_dir = os.path.dirname(os.path.abspath(path))
+        try:
+            self.config = data.initialise(config_dir)
+        except FatalRtlBuddyError:
+            raise
+        except Exception as e:
+            log_event(
+                logger,
+                logging.ERROR,
+                "mut_suite_config.malformed",
+                path=path,
+                error=e,
+            )
+            raise FatalRtlBuddyError(f"{path}: mut config malformed") from e
+
+    def get_config(self) -> MutConfig:
+        return self.config
+
+    def get_path(self) -> str:
+        return self.path
+
+    def __str__(self):
+        return pprint.pformat(self.config)

--- a/src/rtl_buddy/logging_utils.py
+++ b/src/rtl_buddy/logging_utils.py
@@ -215,13 +215,20 @@ def get_stdout_console() -> Console:
 
 
 def emit_console_text(
-    text: str, *, style: str | None = None, stream: str = "stderr"
+    text: str,
+    *,
+    style: str | None = None,
+    stream: str = "stderr",
+    markup: bool = True,
 ) -> None:
     console = get_stdout_console() if stream == "stdout" else get_stderr_console()
+    # Pass markup=False for text that may contain literal square brackets
+    # (e.g. exception messages with `pkg[extra]` install hints) so Rich
+    # doesn't swallow them as style tags.
     if is_machine_mode():
-        console.print(text, highlight=False)
+        console.print(text, highlight=False, markup=markup)
     else:
-        console.print(text, style=style, highlight=False)
+        console.print(text, style=style, highlight=False, markup=markup)
 
 
 @contextmanager

--- a/src/rtl_buddy/rtl_buddy.py
+++ b/src/rtl_buddy/rtl_buddy.py
@@ -18,6 +18,7 @@ from .config import RegConfig, RootConfig, SuiteConfig, TestConfig
 from .config.root import _discover_root_cfg
 from .config.cdc import CdcRegConfig, CdcSuiteConfig
 from .config.fpv import FpvRegConfig, FpvSuiteConfig
+from .config.mut import MutSuiteConfig
 from .config.model import ModelConfig, ModelConfigLoader
 from .config.pnr import PnrSuiteConfig
 from .config.power import PowerRegConfig, PowerSuiteConfig
@@ -37,6 +38,8 @@ from .runner.cdc_runner import CdcRunner
 from .runner.cdc_results import CdcSkipResults
 from .runner.fpv_runner import FpvRunner
 from .runner.fpv_results import FpvSkipResults
+from .runner.mut_runner import MutRunner
+from .runner.mut_results import MutResults
 from .runner.test_results import SetupFailResults, SkipResults
 from .runner.test_runner import RunDepth, TestRunner
 from .runner.pnr_runner import PnrRunner
@@ -142,6 +145,9 @@ class RtlBuddy:
         self.spec_app = typer.Typer(
             help="spec traceability commands", no_args_is_help=True
         )
+        self.mut_app = typer.Typer(
+            help="mutation testing (rb mut)", no_args_is_help=True
+        )
         self.axi_profile_app = typer.Typer(
             help=("profile AXI interconnect performance via rtl-buddy-axi-profiler"),
             no_args_is_help=True,
@@ -234,6 +240,16 @@ class RtlBuddy:
         self.app.command("fpv-regression", help="run FPV regression")(
             self.do_fpv_regression
         )
+        self.mut_app.command(
+            "list", help="enumerate mutation candidate sites without mutating"
+        )(self.do_mut_list)
+        self.mut_app.command(
+            "run", help="generate mutants, score against an FPV proof, report"
+        )(self.do_mut_run)
+        self.mut_app.command(
+            "score", help="recompute mutation score from a saved report"
+        )(self.do_mut_score)
+        self.app.add_typer(self.mut_app, name="mut", help="mutation testing")
         self.app.add_typer(hub_app, name="hub", help="manage the rtl-buddy-hub daemon")
         self.app.add_typer(
             skill_app, name="skill", help="manage the rtl_buddy agent skill"
@@ -291,7 +307,7 @@ class RtlBuddy:
             exc.show(file=sys.stderr)
             return exc.exit_code
         except (FatalRtlBuddyError, FilelistError) as exc:
-            emit_console_text(str(exc), style="red")
+            emit_console_text(str(exc), style="red", markup=False)
             if self.machine:
                 # Machine consumers parse stdout JSON; a silent stdout
                 # forces them to scrape stderr for an ad-hoc message.
@@ -3474,6 +3490,176 @@ class RtlBuddy:
                 metadata=[f"Reg Level: {reg_level}"],
             )
         raise typer.Exit(exit_code)
+
+    # --- mutation testing (rb mut) -----------------------------------------
+
+    def _mut_work_dir(self, suite_cfg: MutSuiteConfig) -> str:
+        campaign = suite_cfg.get_config().get_name()
+        base = Path(suite_cfg.get_path()).resolve().parent
+        return str(base / "artefacts" / "mut" / campaign)
+
+    def _render_mut_summary(self, title, results: MutResults):
+        rows = []
+        for o in results.outcomes:
+            rows.append(
+                {
+                    "mutant": o.mutant_id,
+                    "operator": o.operator,
+                    "outcome": o.outcome.upper(),
+                    "verdict": o.verdict,
+                    "predicted": ", ".join(o.predicted_signals) or "-",
+                    "diff": o.diff_summary,
+                }
+            )
+        columns = [
+            ("mutant", "Mutant"),
+            ("operator", "Operator"),
+            ("outcome", "Outcome"),
+            ("verdict", "Verdict"),
+            ("predicted", "Predicted Signals"),
+            ("diff", "Mutation"),
+        ]
+        score = results.score()
+        score_str = f"{score * 100:.1f}%" if score is not None else "n/a"
+        metadata = [
+            f"Mutation score: {score_str} "
+            f"(killed {results.killed()} / scored {results.scored_total()})",
+            f"Survived: {results.survived()}   Errored: {results.errored()}   "
+            f"Baseline: {results.baseline_verdict}",
+        ]
+        misses = results.predicted_observable_misses()
+        if misses:
+            metadata.append(
+                f"Predicted-observable misses (weak properties): "
+                f"{', '.join(m.mutant_id for m in misses)}"
+            )
+        render_summary(
+            title=title,
+            columns=columns,
+            rows=rows,
+            logger=logger,
+            metadata=metadata,
+        )
+
+    def do_mut_list(
+        self,
+        mut_config: Annotated[
+            str,
+            typer.Option("-c", "--mut-config", help="mut.yaml to use"),
+        ] = "mut.yaml",
+    ):
+        """
+        enumerate mutation candidate sites without mutating
+        """
+        ctx = self._enter_command_context(primary_config=mut_config)
+        suite_cfg = MutSuiteConfig(path=str(ctx.primary_config))
+        log_event(
+            logger,
+            logging.INFO,
+            "command.mut_list",
+            command="mut list",
+            mut_config=mut_config,
+        )
+        runner = MutRunner(
+            name=self.name + "/mut_runner",
+            root_cfg=self.root_cfg,
+            mut_cfg=suite_cfg.get_config(),
+            work_dir=self._mut_work_dir(suite_cfg),
+        )
+        sites = runner.list_candidates()
+        if self.machine:
+            self._emit_machine_result("mut list", 0, sites=sites)
+        else:
+            rows = [
+                {
+                    "operator": s["operator"],
+                    "loc": f"{s['line']}:{s['column']}",
+                    "snippet": s["snippet"],
+                }
+                for s in sites
+            ]
+            render_summary(
+                title=f"Mutation Candidates ({len(sites)})",
+                columns=[
+                    ("operator", "Operator"),
+                    ("loc", "Line:Col"),
+                    ("snippet", "Snippet"),
+                ],
+                rows=rows,
+                logger=logger,
+            )
+        raise typer.Exit(0)
+
+    def do_mut_run(
+        self,
+        mut_config: Annotated[
+            str,
+            typer.Option("-c", "--mut-config", help="mut.yaml to use"),
+        ] = "mut.yaml",
+    ):
+        """
+        generate mutants, score them against an FPV proof, and report
+        """
+        ctx = self._enter_command_context(primary_config=mut_config)
+        suite_cfg = MutSuiteConfig(path=str(ctx.primary_config))
+        log_event(
+            logger,
+            logging.INFO,
+            "command.mut_run",
+            command="mut run",
+            mut_config=mut_config,
+        )
+        work_dir = self._mut_work_dir(suite_cfg)
+        runner = MutRunner(
+            name=self.name + "/mut_runner",
+            root_cfg=self.root_cfg,
+            mut_cfg=suite_cfg.get_config(),
+            work_dir=work_dir,
+        )
+        results = runner.run()
+
+        report_path = os.path.join(work_dir, "mut_report.json")
+        with open(report_path, "w") as f:
+            json.dump(results.as_report(), f, indent=2)
+
+        exit_code = 0 if results.is_pass() else 1
+        if self.machine:
+            self._emit_machine_result("mut run", exit_code, report=results.as_report())
+        else:
+            self._render_mut_summary("Mutation Testing Results", results)
+            emit_console_text(f"Report written to {report_path}", style="cyan")
+        raise typer.Exit(exit_code)
+
+    def do_mut_score(
+        self,
+        report: Annotated[
+            str,
+            typer.Argument(help="path to a mut_report.json from a previous run"),
+        ],
+    ):
+        """
+        recompute mutation score from a saved report
+        """
+        report_path = (
+            report if os.path.isabs(report) else str(self.invocation_cwd / report)
+        )
+        if not os.path.isfile(report_path):
+            raise FatalRtlBuddyError(f"mut report not found: {report_path}")
+        with open(report_path, "r") as f:
+            data = json.load(f)
+        results = MutResults.from_report(data)
+        log_event(
+            logger,
+            logging.INFO,
+            "command.mut_score",
+            command="mut score",
+            report=report_path,
+        )
+        if self.machine:
+            self._emit_machine_result("mut score", 0, report=results.as_report())
+        else:
+            self._render_mut_summary("Mutation Score", results)
+        raise typer.Exit(0)
 
     def do_cmd_wave(
         self,

--- a/src/rtl_buddy/runner/mut_results.py
+++ b/src/rtl_buddy/runner/mut_results.py
@@ -1,0 +1,119 @@
+"""Result records for an ``rb mut`` mutation campaign.
+
+A campaign produces one :class:`MutantOutcome` per mutant plus an
+aggregate :class:`MutResults`. The mutation score is the standard
+``killed / (killed + survived)`` — ``errored`` mutants (those that
+broke elaboration) are dropped from the denominator so a buggy mutant
+never inflates or deflates the score.
+"""
+
+from __future__ import annotations
+
+import pprint
+from dataclasses import dataclass, field
+
+KILLED = "killed"
+SURVIVED = "survived"
+ERRORED = "errored"
+
+
+@dataclass
+class MutantOutcome:
+    mutant_id: str
+    operator: str
+    outcome: str  # one of KILLED / SURVIVED / ERRORED
+    diff_summary: str
+    verdict: str  # the FPV verdict string for this mutant (PASS/FAIL/NA)
+    # Signals the operator predicted it would perturb (xeno
+    # Prediction.perturbs_signals). A SURVIVED mutant with a non-empty
+    # prediction is the highest-signal "your property set is too weak"
+    # finding, so we keep it for the summary.
+    predicted_signals: list[str] = field(default_factory=list)
+
+    def is_predicted_observable_miss(self) -> bool:
+        return self.outcome == SURVIVED and bool(self.predicted_signals)
+
+
+class MutResults:
+    def __init__(
+        self,
+        name: str,
+        outcomes: list[MutantOutcome],
+        baseline_verdict: str,
+    ):
+        self.name = name
+        self.outcomes = outcomes
+        self.baseline_verdict = baseline_verdict
+
+    def killed(self) -> int:
+        return sum(1 for o in self.outcomes if o.outcome == KILLED)
+
+    def survived(self) -> int:
+        return sum(1 for o in self.outcomes if o.outcome == SURVIVED)
+
+    def errored(self) -> int:
+        return sum(1 for o in self.outcomes if o.outcome == ERRORED)
+
+    def scored_total(self) -> int:
+        return self.killed() + self.survived()
+
+    def score(self) -> float | None:
+        """Mutation score = killed / (killed + survived), or None when
+        nothing was scorable (every mutant errored / no mutants)."""
+        total = self.scored_total()
+        if total == 0:
+            return None
+        return self.killed() / total
+
+    def predicted_observable_misses(self) -> list[MutantOutcome]:
+        return [o for o in self.outcomes if o.is_predicted_observable_miss()]
+
+    def is_pass(self) -> bool:
+        # A campaign "passes" when it produced a scorable result. Score
+        # gating (e.g. fail under a threshold) is a separate concern; the
+        # command exits non-zero only on fatal errors.
+        return self.score() is not None
+
+    def as_report(self) -> dict:
+        """JSON-serialisable report consumed by ``rb mut score``."""
+        return {
+            "name": self.name,
+            "baseline_verdict": self.baseline_verdict,
+            "killed": self.killed(),
+            "survived": self.survived(),
+            "errored": self.errored(),
+            "score": self.score(),
+            "mutants": [
+                {
+                    "mutant_id": o.mutant_id,
+                    "operator": o.operator,
+                    "outcome": o.outcome,
+                    "verdict": o.verdict,
+                    "diff_summary": o.diff_summary,
+                    "predicted_signals": o.predicted_signals,
+                }
+                for o in self.outcomes
+            ],
+        }
+
+    @classmethod
+    def from_report(cls, report: dict) -> "MutResults":
+        outcomes = [
+            MutantOutcome(
+                mutant_id=m["mutant_id"],
+                operator=m["operator"],
+                outcome=m["outcome"],
+                diff_summary=m.get("diff_summary", ""),
+                verdict=m.get("verdict", "NA"),
+                predicted_signals=m.get("predicted_signals", []),
+            )
+            for m in report.get("mutants", [])
+        ]
+        return cls(
+            name=report.get("name", "mut"),
+            outcomes=outcomes,
+            baseline_verdict=report.get("baseline_verdict", "NA"),
+        )
+
+    def __str__(self):
+        return "mut_results: " + pprint.pformat(self.as_report())

--- a/src/rtl_buddy/runner/mut_runner.py
+++ b/src/rtl_buddy/runner/mut_runner.py
@@ -1,0 +1,292 @@
+"""Mutation-campaign runner for ``rb mut``.
+
+Orchestrates the external ``rtl-buddy-xeno`` mutation engine against the
+existing ``rb fpv`` proof harness:
+
+1. enumerate / generate mutants of a single design file (xeno),
+2. materialise each mutant into an isolated copy of the model source
+   tree (the original design file is never touched),
+3. re-run the named FPV verification against the mutated tree,
+4. score ``killed`` (verdict flipped vs the unmutated baseline) vs
+   ``survived`` vs ``errored`` (mutant broke elaboration).
+
+xeno is an optional dependency — it pulls in the Verible / pyslang
+toolchain via its ``[verible]`` / ``[slang]`` extras — so it is
+imported lazily here. ``rb mut`` is the only entry point that needs it;
+the rest of rtl_buddy (and its test suite) runs without it installed.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+import os
+import shutil
+import time
+from pathlib import Path
+
+from ..config.fpv import FpvSuiteConfig
+from ..config.mut import MutConfig
+from ..errors import FatalRtlBuddyError
+from ..logging_utils import log_event
+from .fpv_runner import FpvRunner
+from .mut_results import ERRORED, KILLED, SURVIVED, MutantOutcome, MutResults
+
+logger = logging.getLogger(__name__)
+
+
+_XENO_INSTALL_HINT = (
+    "rb mut requires the rtl-buddy-xeno mutation engine, which is not "
+    "installed. Install it with:\n"
+    '    pip install "rtl-buddy-xeno[verible,slang]"\n'
+    "(the [verible] and [slang] extras pull the Verible CST + pyslang "
+    "toolchain the structural operators need)."
+)
+
+
+class MutRunner:
+    def __init__(self, name: str, root_cfg, mut_cfg: MutConfig, work_dir: str):
+        self.name = name
+        self.root_cfg = root_cfg
+        self.mut_cfg = mut_cfg
+        self.work_dir = work_dir
+
+    # --- xeno bridge --------------------------------------------------------
+
+    @staticmethod
+    def _load_xeno():
+        try:
+            import rtl_buddy_xeno
+        except ImportError as e:
+            raise FatalRtlBuddyError(_XENO_INSTALL_HINT) from e
+        return rtl_buddy_xeno
+
+    def _kinds(self, xeno):
+        """Map the config's operator strings onto xeno MutationKinds."""
+        try:
+            return [xeno.MutationKind(op) for op in self.mut_cfg.get_operators()]
+        except ValueError as e:
+            # Config already validates against _VALID_OPERATORS, so this
+            # only fires if xeno's enum drifts from our local list.
+            raise FatalRtlBuddyError(
+                f"rb mut: operator not recognised by installed rtl-buddy-xeno: {e}"
+            ) from e
+
+    def _mutator(self, xeno):
+        design_file = self.mut_cfg.get_design_file()
+        if not os.path.isfile(design_file):
+            raise FatalRtlBuddyError(f"rb mut: design_file not found: {design_file}")
+        return xeno.Mutator.from_sv(Path(design_file))
+
+    def _effective_count(self) -> int:
+        budget = self.mut_cfg.budget
+        count = budget.max_mutants
+        if budget.per_module_cap is not None:
+            # Single design file == single module for this slice, so the
+            # per-module cap is just a tighter ceiling on the total.
+            count = min(count, budget.per_module_cap)
+        return count
+
+    def _schedule(self, xeno):
+        if self.mut_cfg.budget.schedule == "round_robin":
+            return xeno.Schedule.ROUND_ROBIN
+        return xeno.Schedule.SEQUENTIAL
+
+    # --- list ---------------------------------------------------------------
+
+    def list_candidates(self) -> list[dict]:
+        """Enumerate candidate sites without mutating (``rb mut list``)."""
+        xeno = self._load_xeno()
+        mutator = self._mutator(xeno)
+        sites = []
+        for site in mutator.candidates(kinds=self._kinds(xeno)):
+            sites.append(
+                {
+                    "operator": site.kind.value,
+                    "line": site.line,
+                    "column": site.column,
+                    "snippet": site.snippet,
+                }
+            )
+        return sites
+
+    # --- run ----------------------------------------------------------------
+
+    def run(self) -> MutResults:
+        xeno = self._load_xeno()
+        mutator = self._mutator(xeno)
+        kinds = self._kinds(xeno)
+
+        baseline_fpv_cfg = self._load_oracle_cfg()
+        self._validate_design_in_model()
+
+        Path(self.work_dir).mkdir(parents=True, exist_ok=True)
+
+        baseline_verdict = self._run_baseline(baseline_fpv_cfg)
+        if baseline_verdict != "PASS":
+            log_event(
+                logger,
+                logging.WARNING,
+                "mut_runner.baseline_not_pass",
+                campaign=self.mut_cfg.get_name(),
+                verdict=baseline_verdict,
+            )
+
+        outcomes: list[MutantOutcome] = []
+        deadline = self._deadline()
+        for idx, mutant in enumerate(
+            mutator.generate(
+                kinds=kinds,
+                count=self._effective_count(),
+                seed=0,
+                schedule=self._schedule(xeno),
+            )
+        ):
+            if deadline is not None and time.monotonic() > deadline:
+                log_event(
+                    logger,
+                    logging.INFO,
+                    "mut_runner.time_budget_reached",
+                    campaign=self.mut_cfg.get_name(),
+                    generated=idx,
+                )
+                break
+            outcomes.append(
+                self._score_mutant(idx, mutant, baseline_fpv_cfg, baseline_verdict)
+            )
+
+        return MutResults(
+            name=self.mut_cfg.get_name(),
+            outcomes=outcomes,
+            baseline_verdict=baseline_verdict,
+        )
+
+    # --- internals ----------------------------------------------------------
+
+    def _load_oracle_cfg(self):
+        suite = FpvSuiteConfig(path=self.mut_cfg.fpv_config)
+        # Raises FatalRtlBuddyError if the named verification is absent.
+        return suite.get_verifications(self.mut_cfg.verification)[0]
+
+    def _model_dir(self) -> str:
+        model = self.mut_cfg.get_model()
+        if not model.path:
+            raise FatalRtlBuddyError(
+                "rb mut: model has no resolved path; cannot isolate mutants"
+            )
+        return os.path.dirname(os.path.abspath(model.path))
+
+    def _design_relpath(self) -> str:
+        return os.path.relpath(self.mut_cfg.get_design_file(), self._model_dir())
+
+    def _validate_design_in_model(self) -> None:
+        rel = self._design_relpath()
+        if rel.startswith(".."):
+            raise FatalRtlBuddyError(
+                f"rb mut: design_file ({self.mut_cfg.get_design_file()}) must live "
+                f"within the model directory ({self._model_dir()}) so per-mutant "
+                "isolation can copy the source tree."
+            )
+
+    def _run_baseline(self, baseline_fpv_cfg) -> str:
+        suite_dir = os.path.join(self.work_dir, "baseline")
+        Path(suite_dir).mkdir(parents=True, exist_ok=True)
+        results = FpvRunner(
+            name=self.name + "/baseline",
+            root_cfg=self.root_cfg,
+            fpv_cfg=baseline_fpv_cfg,
+            suite_dir=suite_dir,
+        ).run()
+        return results.results.get("result", "NA")
+
+    def _materialise_mutant(self, mutant_id: str, mutant_sv: str):
+        """Copy the model tree, splice in the mutant, return a per-mutant
+        ModelConfig pointing at the copy."""
+        mutant_root = os.path.join(self.work_dir, mutant_id)
+        model_src = os.path.join(mutant_root, "model_src")
+        if os.path.exists(model_src):
+            shutil.rmtree(model_src)
+        shutil.copytree(self._model_dir(), model_src)
+
+        spliced = os.path.join(model_src, self._design_relpath())
+        with open(spliced, "w") as f:
+            f.write(mutant_sv)
+
+        orig_model = self.mut_cfg.get_model()
+        copied_models_yaml = os.path.join(
+            model_src, os.path.basename(os.path.abspath(orig_model.path))
+        )
+        return dataclasses.replace(orig_model, path=copied_models_yaml), mutant_root
+
+    def _score_mutant(
+        self, idx: int, mutant, baseline_fpv_cfg, baseline_verdict: str
+    ) -> MutantOutcome:
+        operator = mutant.kind.value
+        mutant_id = f"m{idx:04d}_{operator}"
+        predicted = sorted(getattr(mutant.prediction, "perturbs_signals", []) or [])
+
+        try:
+            mutant_model, mutant_root = self._materialise_mutant(mutant_id, mutant.sv)
+            mutant_fpv_cfg = dataclasses.replace(
+                baseline_fpv_cfg,
+                model=mutant_model,
+                name=f"{baseline_fpv_cfg.get_name()}__{mutant_id}",
+            )
+            results = FpvRunner(
+                name=self.name + "/" + mutant_id,
+                root_cfg=self.root_cfg,
+                fpv_cfg=mutant_fpv_cfg,
+                suite_dir=mutant_root,
+            ).run()
+            verdict = results.results.get("result", "NA")
+        except FatalRtlBuddyError as e:
+            # A mutant that breaks elaboration / the build is errored, not
+            # scored — dropped from the denominator.
+            log_event(
+                logger,
+                logging.INFO,
+                "mut_runner.mutant_errored",
+                campaign=self.mut_cfg.get_name(),
+                mutant=mutant_id,
+                error=str(e),
+            )
+            return MutantOutcome(
+                mutant_id=mutant_id,
+                operator=operator,
+                outcome=ERRORED,
+                diff_summary=mutant.diff_summary,
+                verdict="ERROR",
+                predicted_signals=predicted,
+            )
+
+        if verdict in ("NA", "ERROR"):
+            outcome = ERRORED
+        elif verdict != baseline_verdict:
+            outcome = KILLED
+        else:
+            outcome = SURVIVED
+
+        log_event(
+            logger,
+            logging.DEBUG,
+            "mut_runner.mutant_scored",
+            campaign=self.mut_cfg.get_name(),
+            mutant=mutant_id,
+            operator=operator,
+            verdict=verdict,
+            outcome=outcome,
+        )
+        return MutantOutcome(
+            mutant_id=mutant_id,
+            operator=operator,
+            outcome=outcome,
+            diff_summary=mutant.diff_summary,
+            verdict=verdict,
+            predicted_signals=predicted,
+        )
+
+    def _deadline(self) -> float | None:
+        mins = self.mut_cfg.budget.time_budget_minutes
+        if mins is None:
+            return None
+        return time.monotonic() + mins * 60.0

--- a/tests/test_mut.py
+++ b/tests/test_mut.py
@@ -1,0 +1,369 @@
+"""Tests for the ``rb mut`` slice: mut.yaml config, the missing-xeno
+guard, and the MutRunner orchestration (candidate listing, mutant
+materialisation, FPV-verdict -> outcome classification, scoring).
+
+The external ``rtl-buddy-xeno`` engine is replaced with an in-process
+stub so the orchestration is exercised without the Verible / pyslang
+toolchain. The FPV proof is faked by patching ``FpvRunner`` to read the
+spliced design file and return a verdict driven by markers in the
+mutant source.
+"""
+
+from __future__ import annotations
+
+import enum
+import os
+import sys
+import types
+from dataclasses import dataclass, field
+from pathlib import Path
+from textwrap import dedent
+from unittest.mock import patch
+
+import pytest
+
+from rtl_buddy.config.mut import MutSuiteConfig
+from rtl_buddy.errors import FatalRtlBuddyError
+from rtl_buddy.runner.mut_results import ERRORED, KILLED, SURVIVED, MutResults
+from rtl_buddy.runner.fpv_results import FpvFailResults, FpvPassResults
+
+
+# ---------------------------------------------------------------------------
+# Project fixture: a leaf design + models.yaml + fpv.yaml + mut.yaml
+# ---------------------------------------------------------------------------
+
+_DESIGN_SV = dedent(
+    """\
+    module leaf (input logic clk, input logic en, output logic [2:0] cnt);
+      always_ff @(posedge clk) if (en) cnt <= cnt + 1'b1;
+    endmodule
+    """
+)
+
+
+def _write_project(root: Path) -> Path:
+    design_dir = root / "design" / "leaf"
+    design_dir.mkdir(parents=True)
+    (design_dir / "leaf.sv").write_text(_DESIGN_SV)
+    (design_dir / "models.yaml").write_text(
+        dedent(
+            """\
+            rtl-buddy-filetype: model_config
+            models:
+              - name: "leaf"
+                filelist: ["-v leaf.sv"]
+            """
+        )
+    )
+
+    fpv_dir = root / "fpv" / "leaf"
+    fpv_dir.mkdir(parents=True)
+    (fpv_dir / "fpv.yaml").write_text(
+        dedent(
+            """\
+            rtl-buddy-filetype: fpv_config
+            verifications:
+              - name: "leaf_safety"
+                desc: "safety"
+                tool: "sby"
+                model: "leaf"
+                model_path: "../../design/leaf/models.yaml"
+                top: "leaf"
+                properties: []
+                mode: "bmc"
+                depth: 16
+            """
+        )
+    )
+
+    mut_path = fpv_dir / "mut.yaml"
+    mut_path.write_text(
+        dedent(
+            """\
+            rtl-buddy-filetype: mut_config
+            model: "leaf"
+            model_path: "../../design/leaf/models.yaml"
+            design_file: "../../design/leaf/leaf.sv"
+            operators: [arith_flip, cond_const, assign_drop]
+            verify:
+              fpv_config: "fpv.yaml"
+              verification: "leaf_safety"
+            budget:
+              max_mutants: 10
+              schedule: round_robin
+            """
+        )
+    )
+    return mut_path
+
+
+# ---------------------------------------------------------------------------
+# Stub rtl-buddy-xeno
+# ---------------------------------------------------------------------------
+
+
+class _MutationKind(enum.StrEnum):
+    ARITH_FLIP = "arith_flip"
+    BIT_OP_FLIP = "bit_op_flip"
+    COND_NEGATE = "cond_negate"
+    COND_CONST = "cond_const"
+    ASSIGN_DROP = "assign_drop"
+    PORT_BINDING_SWAP = "port_binding_swap"
+
+
+class _Schedule(enum.StrEnum):
+    SEQUENTIAL = "sequential"
+    ROUND_ROBIN = "round_robin"
+
+
+@dataclass(frozen=True)
+class _Prediction:
+    rationale: str = "stub"
+    perturbs_signals: frozenset = field(default_factory=frozenset)
+    perturbs_liveness: bool = False
+
+
+@dataclass(frozen=True)
+class _Mutant:
+    sv: str
+    diff_summary: str
+    seed: int
+    prediction: _Prediction
+    kind: _MutationKind
+
+
+@dataclass(frozen=True)
+class _Site:
+    kind: _MutationKind
+    line: int
+    column: int
+    snippet: str
+    prediction: _Prediction
+
+
+# Three mutants: one killed (FAIL marker), one survived (PASS) with a
+# prediction (-> predicted-observable miss), one errored (build break).
+_STUB_MUTANTS = [
+    _Mutant(
+        sv="// KILL\n" + _DESIGN_SV,
+        diff_summary="+ -> -",
+        seed=1,
+        prediction=_Prediction(perturbs_signals=frozenset({"cnt"})),
+        kind=_MutationKind.ARITH_FLIP,
+    ),
+    _Mutant(
+        sv="// survive\n" + _DESIGN_SV,
+        diff_summary="cond -> 1",
+        seed=2,
+        prediction=_Prediction(perturbs_signals=frozenset({"cnt"})),
+        kind=_MutationKind.COND_CONST,
+    ),
+    _Mutant(
+        sv="// ERR\n" + _DESIGN_SV,
+        diff_summary="drop assign",
+        seed=3,
+        prediction=_Prediction(),
+        kind=_MutationKind.ASSIGN_DROP,
+    ),
+]
+
+_STUB_SITES = [
+    _Site(_MutationKind.ARITH_FLIP, 2, 40, "+", _Prediction()),
+    _Site(_MutationKind.COND_CONST, 2, 22, "en", _Prediction()),
+]
+
+
+class _Mutator:
+    def __init__(self, parent_sv: str):
+        self.parent_sv = parent_sv
+
+    @classmethod
+    def from_sv(cls, path):
+        return cls(Path(path).read_text())
+
+    def generate(self, kinds, count, seed=0, schedule=None):
+        yield from _STUB_MUTANTS[:count]
+
+    def candidates(self, kinds):
+        yield from _STUB_SITES
+
+
+@pytest.fixture
+def stub_xeno(monkeypatch):
+    mod = types.ModuleType("rtl_buddy_xeno")
+    mod.Mutator = _Mutator
+    mod.MutationKind = _MutationKind
+    mod.Schedule = _Schedule
+    mod.Mutant = _Mutant
+    mod.Site = _Site
+    mod.Prediction = _Prediction
+    monkeypatch.setitem(sys.modules, "rtl_buddy_xeno", mod)
+    return mod
+
+
+# A fake FpvRunner: reads the spliced .sv next to the model and maps a
+# marker comment to a verdict. Baseline (unmutated) source has no marker
+# -> PASS.
+class _FakeFpvRunner:
+    def __init__(self, name, root_cfg, fpv_cfg, suite_dir):
+        self.fpv_cfg = fpv_cfg
+
+    def run(self):
+        model = self.fpv_cfg.get_model()
+        design_dir = Path(os.path.dirname(model.path))
+        sv = next(design_dir.glob("*.sv")).read_text()
+        if "ERR" in sv:
+            raise FatalRtlBuddyError("elaboration failed")
+        if "KILL" in sv:
+            return FpvFailResults(name="x", mode="bmc", depth=16)
+        return FpvPassResults(name="x", mode="bmc", depth=16)
+
+
+# ---------------------------------------------------------------------------
+# Config tests
+# ---------------------------------------------------------------------------
+
+
+def test_mut_config_loads(tmp_path):
+    mut_path = _write_project(tmp_path)
+    cfg = MutSuiteConfig(path=str(mut_path)).get_config()
+    assert cfg.get_name() == "leaf"
+    assert cfg.top == "leaf"
+    assert cfg.get_operators() == ["arith_flip", "cond_const", "assign_drop"]
+    assert cfg.verification == "leaf_safety"
+    assert cfg.budget.schedule == "round_robin"
+    assert cfg.get_design_file().endswith("leaf.sv")
+    assert os.path.isfile(cfg.get_design_file())
+
+
+def test_mut_config_rejects_unknown_operator(tmp_path):
+    mut_path = _write_project(tmp_path)
+    text = mut_path.read_text().replace("arith_flip", "frobnicate")
+    mut_path.write_text(text)
+    with pytest.raises(FatalRtlBuddyError, match="operator 'frobnicate'"):
+        MutSuiteConfig(path=str(mut_path))
+
+
+def test_mut_config_rejects_bad_schedule(tmp_path):
+    mut_path = _write_project(tmp_path)
+    text = mut_path.read_text().replace("round_robin", "fifo")
+    mut_path.write_text(text)
+    with pytest.raises(FatalRtlBuddyError, match="schedule 'fifo'"):
+        MutSuiteConfig(path=str(mut_path))
+
+
+# ---------------------------------------------------------------------------
+# Runner tests
+# ---------------------------------------------------------------------------
+
+
+def _runner(tmp_path, mut_path):
+    from rtl_buddy.runner.mut_runner import MutRunner
+
+    cfg = MutSuiteConfig(path=str(mut_path)).get_config()
+    return MutRunner(
+        name="test",
+        root_cfg=None,
+        mut_cfg=cfg,
+        work_dir=str(tmp_path / "work"),
+    )
+
+
+def test_missing_xeno_raises_with_install_hint(tmp_path):
+    # No stub_xeno fixture here, and xeno is not installed in CI.
+    assert "rtl_buddy_xeno" not in sys.modules
+    mut_path = _write_project(tmp_path)
+    runner = _runner(tmp_path, mut_path)
+    with pytest.raises(FatalRtlBuddyError, match="rtl-buddy-xeno"):
+        runner.list_candidates()
+
+
+def test_operator_mapping_to_kinds(tmp_path, stub_xeno):
+    mut_path = _write_project(tmp_path)
+    runner = _runner(tmp_path, mut_path)
+    kinds = runner._kinds(stub_xeno)
+    assert [k.value for k in kinds] == ["arith_flip", "cond_const", "assign_drop"]
+
+
+def test_list_candidates(tmp_path, stub_xeno):
+    mut_path = _write_project(tmp_path)
+    runner = _runner(tmp_path, mut_path)
+    sites = runner.list_candidates()
+    assert len(sites) == 2
+    assert sites[0]["operator"] == "arith_flip"
+    assert sites[0]["line"] == 2
+
+
+def test_run_scores_mutants(tmp_path, stub_xeno):
+    mut_path = _write_project(tmp_path)
+    runner = _runner(tmp_path, mut_path)
+    with patch("rtl_buddy.runner.mut_runner.FpvRunner", _FakeFpvRunner):
+        results = runner.run()
+
+    assert isinstance(results, MutResults)
+    assert results.baseline_verdict == "PASS"
+    assert results.killed() == 1
+    assert results.survived() == 1
+    assert results.errored() == 1
+    # score = killed / (killed + survived) = 1/2, errored dropped.
+    assert results.score() == pytest.approx(0.5)
+
+    outcomes = {o.operator: o.outcome for o in results.outcomes}
+    assert outcomes["arith_flip"] == KILLED
+    assert outcomes["cond_const"] == SURVIVED
+    assert outcomes["assign_drop"] == ERRORED
+
+
+def test_run_flags_predicted_observable_miss(tmp_path, stub_xeno):
+    mut_path = _write_project(tmp_path)
+    runner = _runner(tmp_path, mut_path)
+    with patch("rtl_buddy.runner.mut_runner.FpvRunner", _FakeFpvRunner):
+        results = runner.run()
+    misses = results.predicted_observable_misses()
+    # The survived COND_CONST mutant predicted perturbs_signals={cnt}.
+    assert len(misses) == 1
+    assert misses[0].operator == "cond_const"
+    assert misses[0].predicted_signals == ["cnt"]
+
+
+def test_run_does_not_touch_original_source(tmp_path, stub_xeno):
+    mut_path = _write_project(tmp_path)
+    original = (tmp_path / "design" / "leaf" / "leaf.sv").read_text()
+    runner = _runner(tmp_path, mut_path)
+    with patch("rtl_buddy.runner.mut_runner.FpvRunner", _FakeFpvRunner):
+        runner.run()
+    assert (tmp_path / "design" / "leaf" / "leaf.sv").read_text() == original
+
+
+def test_design_file_outside_model_dir_errors(tmp_path, stub_xeno):
+    mut_path = _write_project(tmp_path)
+    # Point design_file outside the model directory.
+    stray = tmp_path / "stray.sv"
+    stray.write_text(_DESIGN_SV)
+    text = mut_path.read_text().replace(
+        'design_file: "../../design/leaf/leaf.sv"',
+        f'design_file: "{stray}"',
+    )
+    mut_path.write_text(text)
+    runner = _runner(tmp_path, mut_path)
+    with patch("rtl_buddy.runner.mut_runner.FpvRunner", _FakeFpvRunner):
+        with pytest.raises(FatalRtlBuddyError, match="must live within the model"):
+            runner.run()
+
+
+# ---------------------------------------------------------------------------
+# Report round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_report_round_trip(tmp_path, stub_xeno):
+    mut_path = _write_project(tmp_path)
+    runner = _runner(tmp_path, mut_path)
+    with patch("rtl_buddy.runner.mut_runner.FpvRunner", _FakeFpvRunner):
+        results = runner.run()
+    report = results.as_report()
+    restored = MutResults.from_report(report)
+    assert restored.killed() == results.killed()
+    assert restored.survived() == results.survived()
+    assert restored.errored() == results.errored()
+    assert restored.score() == results.score()


### PR DESCRIPTION
## Summary

First vertical slice of `rb mut` (the mutation-testing harness sketched in #206). Drives the external [`rtl-buddy-xeno`](https://github.com/rtl-buddy/rtl-buddy-xeno) AST mutator against the existing `rb fpv` proof harness and scores killed/survived/errored.

- **`config/mut.py`** — `mut.yaml` schema: `design_file`, `operators` (mapped 1:1 onto `rtl_buddy_xeno.MutationKind`, validated without importing xeno so YAML parsing stays toolchain-free), `verify` (fpv.yaml + verification name as the kill oracle), `budget` (max_mutants / per_module_cap / time_budget_minutes / schedule), optional no-op `scope`.
- **`runner/mut_runner.py`** — `MutRunner`: lazy-imports xeno; `list_candidates()` → `Mutator.candidates`; `run()` runs a baseline proof, generates mutants, materialises each into an **isolated copy** of the model tree (original source never touched), reruns the named FPV verification via the existing `FpvRunner`, classifies verdict-vs-baseline.
- **`runner/mut_results.py`** — `MutResults`: `score = killed / (killed + survived)` (errored dropped from the denominator), predicted-observable-miss detection (survived mutant whose xeno `Prediction.perturbs_signals` is non-empty), JSON report round-trip for `rb mut score`.
- **`rtl_buddy.py`** — wires the `mut` sub-typer (`list` / `run` / `score`) + results table.
- **`logging_utils.py`** — `emit_console_text` gains `markup=`; the fatal-error printer passes `markup=False` so Rich stops swallowing `pkg[extra]` install hints (latent bug that also affected the axi-profiler hint).

## Notes / deliberate deferrals

- **xeno is not declared as a dependency** — it isn't on PyPI yet, and a hard/optional git dep would break `uv lock`/CI. It's lazy-imported with a clear `pip install "rtl-buddy-xeno[verible,slang]"` hint instead. Declare the `[mut]` extra once xeno publishes.
- **Scope graph-ingestion deferred** — single-file leaf designs don't need rtl-buddy-view `instance_path` filtering; `scope:` is accepted as a no-op. Generalises later for hierarchical designs.
- **Docs page + SKILL.md** mention for `rb mut` to follow.
- The end-to-end acceptance run (a `killed` via the safety proof on the template's `demo_fpv_counter`) is blocked on rtl-buddy-project-template#39 (the demo's safety property is currently vacuous).

## Test plan

- [x] `tests/test_mut.py` (11 tests) — config load/validation, missing-xeno hint, operator→kind mapping, candidate listing, scoring (killed/survived/errored), predicted-observable miss, original-source-untouched, design-file-outside-model guard, report round-trip. xeno + `FpvRunner` are stubbed so orchestration is exercised without the Verible/pyslang toolchain or a real solver.
- [x] Full suite: 973 passed, 10 skipped; ruff clean.
- [x] End-to-end `rb mut list` through real config discovery surfaces the xeno install hint (exit 2).

Part of #206.