### PR TITLE
feat(mut): simulation regression as a kill oracle (#227)

### DIFF
--- a/src/rtl_buddy/config/mut.py
+++ b/src/rtl_buddy/config/mut.py
@@ -70,10 +70,18 @@ class MutBudget:
 
 @serde
 class MutVerifyFile:
-    # Path (relative to mut.yaml) to the fpv.yaml that owns the proof.
-    fpv_config: str = field(rename="fpv_config")
-    # Name of the verification inside that fpv.yaml to use as the oracle.
-    verification: str
+    # FPV oracle: a verification inside an fpv.yaml. A mutant is killed
+    # when the proof flips from PASS to FAIL.
+    fpv_config: str | None = field(rename="fpv_config", default=None)
+    verification: str | None = None
+    # Simulation oracle: a tests.yaml run with SVA assertions compiled in.
+    # A mutant is killed when a test FAILs or an assertion fires.
+    test_config: str | None = field(rename="test_config", default=None)
+    # Optional subset of test names to run; empty = every test in the suite.
+    tests: list[str] = field(default_factory=list)
+    # Compile SVA in (Verilator --assert). Defaults on — the sim oracle is
+    # far weaker without assertions firing.
+    assertions: bool = True
 
 
 # ---- scope (optional; no-op for single-file leaf blocks) -------------------
@@ -120,11 +128,34 @@ class MutConfigFile:
                 f"{', '.join(_VALID_SCHEDULES)}"
             )
 
+        # At least one kill oracle must be configured.
+        has_fpv = bool(self.verify.fpv_config)
+        has_sim = bool(self.verify.test_config)
+        if not has_fpv and not has_sim:
+            raise FatalRtlBuddyError(
+                "mut.yaml: verify must configure at least one kill oracle "
+                "(fpv_config + verification, and/or test_config)"
+            )
+        if has_fpv and not self.verify.verification:
+            raise FatalRtlBuddyError(
+                "mut.yaml: verify.fpv_config requires verify.verification "
+                "(the verification name to use as the oracle)"
+            )
+
         model = ModelConfigLoader(os.path.join(config_dir, self.model_path)).get_model(
             self.model
         )
         design_file = os.path.normpath(os.path.join(config_dir, self.design_file))
-        fpv_config = os.path.normpath(os.path.join(config_dir, self.verify.fpv_config))
+        fpv_config = (
+            os.path.normpath(os.path.join(config_dir, self.verify.fpv_config))
+            if self.verify.fpv_config
+            else None
+        )
+        test_config = (
+            os.path.normpath(os.path.join(config_dir, self.verify.test_config))
+            if self.verify.test_config
+            else None
+        )
 
         return MutConfig(
             name=self.name or self.model,
@@ -134,6 +165,9 @@ class MutConfigFile:
             operators=list(self.operators),
             fpv_config=fpv_config,
             verification=self.verify.verification,
+            test_config=test_config,
+            tests=list(self.verify.tests),
+            assertions=self.verify.assertions,
             budget=MutBudget(
                 max_mutants=self.budget.max_mutants,
                 per_module_cap=self.budget.per_module_cap,
@@ -152,9 +186,14 @@ class MutConfig:
     top: str
     design_file: str
     operators: list[str]
-    fpv_config: str
-    verification: str
     budget: MutBudget
+    # FPV oracle (optional)
+    fpv_config: str | None = None
+    verification: str | None = None
+    # Sim oracle (optional)
+    test_config: str | None = None
+    tests: list[str] = dc_field(default_factory=list)
+    assertions: bool = True
     scope_include: list[str] = dc_field(default_factory=list)
     scope_exclude: list[str] = dc_field(default_factory=list)
 
@@ -169,6 +208,12 @@ class MutConfig:
 
     def get_operators(self) -> list[str]:
         return self.operators
+
+    def has_fpv_oracle(self) -> bool:
+        return self.fpv_config is not None
+
+    def has_sim_oracle(self) -> bool:
+        return self.test_config is not None
 
     def __str__(self):
         return pprint.pformat(self)

--- a/src/rtl_buddy/rtl_buddy.py
+++ b/src/rtl_buddy/rtl_buddy.py
@@ -3615,6 +3615,7 @@ class RtlBuddy:
             root_cfg=self.root_cfg,
             mut_cfg=suite_cfg.get_config(),
             work_dir=work_dir,
+            rtl_builder_mode=self.rtl_builder_mode or "debug",
         )
         results = runner.run()
 

--- a/src/rtl_buddy/runner/mut_runner.py
+++ b/src/rtl_buddy/runner/mut_runner.py
@@ -1,14 +1,19 @@
 """Mutation-campaign runner for ``rb mut``.
 
-Orchestrates the external ``rtl-buddy-xeno`` mutation engine against the
-existing ``rb fpv`` proof harness:
+Orchestrates the external ``rtl-buddy-xeno`` mutation engine against one
+or more kill oracles:
 
 1. enumerate / generate mutants of a single design file (xeno),
 2. materialise each mutant into an isolated copy of the model source
    tree (the original design file is never touched),
-3. re-run the named FPV verification against the mutated tree,
-4. score ``killed`` (verdict flipped vs the unmutated baseline) vs
-   ``survived`` vs ``errored`` (mutant broke elaboration).
+3. re-evaluate each configured oracle against the mutated tree:
+   - **FPV** — re-prove a named ``fpv.yaml`` verification (killed when
+     the verdict flips vs the unmutated baseline),
+   - **sim** — re-run a ``tests.yaml`` suite with SVA assertions
+     compiled in (killed when a test FAILs or an assertion fires),
+4. score ``killed`` (any oracle caught it) / ``survived`` (every oracle
+   passed) / ``errored`` (the mutant broke the build under every oracle,
+   so it can't be scored — dropped from the denominator).
 
 xeno is an optional dependency — it pulls in the Verible / pyslang
 toolchain via its ``[verible]`` / ``[slang]`` extras — so it is
@@ -25,7 +30,6 @@ import shutil
 import time
 from pathlib import Path
 
-from ..config.fpv import FpvSuiteConfig
 from ..config.mut import MutConfig
 from ..errors import FatalRtlBuddyError
 from ..logging_utils import log_event
@@ -45,11 +49,21 @@ _XENO_INSTALL_HINT = (
 
 
 class MutRunner:
-    def __init__(self, name: str, root_cfg, mut_cfg: MutConfig, work_dir: str):
+    def __init__(
+        self,
+        name: str,
+        root_cfg,
+        mut_cfg: MutConfig,
+        work_dir: str,
+        rtl_builder_mode: str = "debug",
+    ):
         self.name = name
         self.root_cfg = root_cfg
         self.mut_cfg = mut_cfg
         self.work_dir = work_dir
+        # Builder mode handed to TestRunner for the sim oracle; unused by
+        # the FPV oracle. "debug" matches the rb-test default.
+        self.rtl_builder_mode = rtl_builder_mode
 
     # --- xeno bridge --------------------------------------------------------
 
@@ -117,20 +131,31 @@ class MutRunner:
         mutator = self._mutator(xeno)
         kinds = self._kinds(xeno)
 
-        baseline_fpv_cfg = self._load_oracle_cfg()
         self._validate_design_in_model()
-
         Path(self.work_dir).mkdir(parents=True, exist_ok=True)
 
-        baseline_verdict = self._run_baseline(baseline_fpv_cfg)
-        if baseline_verdict != "PASS":
-            log_event(
-                logger,
-                logging.WARNING,
-                "mut_runner.baseline_not_pass",
-                campaign=self.mut_cfg.get_name(),
-                verdict=baseline_verdict,
-            )
+        # Load + baseline each configured oracle. Baselines are expected to
+        # PASS on the unmutated design; a non-passing baseline means the
+        # oracle is broken (warn, but keep going — every mutant will then
+        # look "killed" and the user can see why).
+        fpv_cfg = self._load_fpv_cfg() if self.mut_cfg.has_fpv_oracle() else None
+        fpv_baseline = self._baseline_fpv(fpv_cfg) if fpv_cfg is not None else None
+        sim_baseline = self._baseline_sim() if self.mut_cfg.has_sim_oracle() else None
+        for label, verdict in (("fpv", fpv_baseline), ("sim", sim_baseline)):
+            if verdict is not None and verdict != "PASS":
+                log_event(
+                    logger,
+                    logging.WARNING,
+                    "mut_runner.baseline_not_pass",
+                    campaign=self.mut_cfg.get_name(),
+                    oracle=label,
+                    verdict=verdict,
+                )
+        baseline_verdict = " ".join(
+            f"{label}={v}"
+            for label, v in (("fpv", fpv_baseline), ("sim", sim_baseline))
+            if v is not None
+        )
 
         outcomes: list[MutantOutcome] = []
         deadline = self._deadline()
@@ -151,22 +176,15 @@ class MutRunner:
                     generated=idx,
                 )
                 break
-            outcomes.append(
-                self._score_mutant(idx, mutant, baseline_fpv_cfg, baseline_verdict)
-            )
+            outcomes.append(self._score_mutant(idx, mutant, fpv_cfg, fpv_baseline))
 
         return MutResults(
             name=self.mut_cfg.get_name(),
             outcomes=outcomes,
-            baseline_verdict=baseline_verdict,
+            baseline_verdict=baseline_verdict or "NA",
         )
 
-    # --- internals ----------------------------------------------------------
-
-    def _load_oracle_cfg(self):
-        suite = FpvSuiteConfig(path=self.mut_cfg.fpv_config)
-        # Raises FatalRtlBuddyError if the named verification is absent.
-        return suite.get_verifications(self.mut_cfg.verification)[0]
+    # --- mutant materialisation ---------------------------------------------
 
     def _model_dir(self) -> str:
         model = self.mut_cfg.get_model()
@@ -188,20 +206,9 @@ class MutRunner:
                 "isolation can copy the source tree."
             )
 
-    def _run_baseline(self, baseline_fpv_cfg) -> str:
-        suite_dir = os.path.join(self.work_dir, "baseline")
-        Path(suite_dir).mkdir(parents=True, exist_ok=True)
-        results = FpvRunner(
-            name=self.name + "/baseline",
-            root_cfg=self.root_cfg,
-            fpv_cfg=baseline_fpv_cfg,
-            suite_dir=suite_dir,
-        ).run()
-        return results.results.get("result", "NA")
-
     def _materialise_mutant(self, mutant_id: str, mutant_sv: str):
         """Copy the model tree, splice in the mutant, return a per-mutant
-        ModelConfig pointing at the copy."""
+        ModelConfig pointing at the copy plus the mutant's work root."""
         mutant_root = os.path.join(self.work_dir, mutant_id)
         model_src = os.path.join(mutant_root, "model_src")
         if os.path.exists(model_src):
@@ -218,34 +225,144 @@ class MutRunner:
         )
         return dataclasses.replace(orig_model, path=copied_models_yaml), mutant_root
 
-    def _score_mutant(
-        self, idx: int, mutant, baseline_fpv_cfg, baseline_verdict: str
-    ) -> MutantOutcome:
+    # --- FPV oracle ---------------------------------------------------------
+
+    def _load_fpv_cfg(self):
+        from ..config.fpv import FpvSuiteConfig
+
+        suite = FpvSuiteConfig(path=self.mut_cfg.fpv_config)
+        # Raises FatalRtlBuddyError if the named verification is absent.
+        return suite.get_verifications(self.mut_cfg.verification)[0]
+
+    def _baseline_fpv(self, fpv_cfg) -> str:
+        suite_dir = os.path.join(self.work_dir, "baseline_fpv")
+        Path(suite_dir).mkdir(parents=True, exist_ok=True)
+        results = FpvRunner(
+            name=self.name + "/baseline_fpv",
+            root_cfg=self.root_cfg,
+            fpv_cfg=fpv_cfg,
+            suite_dir=suite_dir,
+        ).run()
+        return results.results.get("result", "NA")
+
+    def _eval_fpv(self, fpv_cfg, mutant_model, mutant_root, mutant_id, baseline):
+        """Return (outcome, "fpv=<verdict>") for the FPV oracle."""
+        try:
+            mutant_fpv_cfg = dataclasses.replace(
+                fpv_cfg,
+                model=mutant_model,
+                name=f"{fpv_cfg.get_name()}__{mutant_id}",
+            )
+            results = FpvRunner(
+                name=self.name + "/" + mutant_id + "/fpv",
+                root_cfg=self.root_cfg,
+                fpv_cfg=mutant_fpv_cfg,
+                suite_dir=os.path.join(mutant_root, "fpv"),
+            ).run()
+            verdict = results.results.get("result", "NA")
+        except FatalRtlBuddyError:
+            return ERRORED, "fpv=ERROR"
+        if verdict in ("NA", "ERROR"):
+            return ERRORED, "fpv=ERROR"
+        outcome = KILLED if verdict != baseline else SURVIVED
+        return outcome, f"fpv={verdict}"
+
+    # --- sim oracle ---------------------------------------------------------
+
+    def _sim_suite_dir(self) -> str:
+        return os.path.dirname(os.path.abspath(self.mut_cfg.test_config))
+
+    def _sim_tests(self, suite):
+        names = self.mut_cfg.tests or [None]
+        tests = []
+        for name in names:
+            tests.extend(suite.get_tests(name))
+        return tests
+
+    def _run_one_test(self, test_cfg, suite_dir, name_suffix):
+        from .test_runner import TestRunner
+
+        return TestRunner(
+            name=self.name + "/" + name_suffix,
+            root_cfg=self.root_cfg,
+            test_cfg=test_cfg,
+            rtl_builder_mode=self.rtl_builder_mode,
+            test_runner_mode={"sim_to_stdout": False},
+            suite_dir=suite_dir,
+        ).run()
+
+    @staticmethod
+    def _is_build_error(results) -> bool:
+        # A mutant that won't compile is "errored", not killed. These
+        # result classes all signal a failure *before* the design's
+        # behaviour was actually exercised.
+        return type(results).__name__ in (
+            "CompileFailResults",
+            "FilelistFailResults",
+            "SetupFailResults",
+        )
+
+    @staticmethod
+    def _assertion_fired(results) -> bool:
+        return (results.results.get("assertions") or {}).get("fired", 0) > 0
+
+    def _baseline_sim(self) -> str:
+        from ..config.suite import SuiteConfig
+
+        suite = SuiteConfig(path=self.mut_cfg.test_config)
+        suite_dir = self._sim_suite_dir()
+        all_pass = True
+        scored = False
+        for tcfg in self._sim_tests(suite):
+            mt = dataclasses.replace(tcfg, assertions=self.mut_cfg.assertions)
+            res = self._run_one_test(mt, suite_dir, "baseline_sim")
+            scored = True
+            if (not res.is_pass()) or self._assertion_fired(res):
+                all_pass = False
+        if not scored:
+            return "NA"
+        return "PASS" if all_pass else "FAIL"
+
+    def _eval_sim(self, mutant_model, mutant_id):
+        """Return (outcome, "sim=<verdict>") for the sim oracle.
+
+        Killed when any selected test FAILs or fires an assertion;
+        build failures are errored (dropped), not killed.
+        """
+        from ..config.suite import SuiteConfig
+
+        suite = SuiteConfig(path=self.mut_cfg.test_config)
+        suite_dir = self._sim_suite_dir()
+        killed = False
+        scored = False
+        for tcfg in self._sim_tests(suite):
+            mt = dataclasses.replace(
+                tcfg, model=mutant_model, assertions=self.mut_cfg.assertions
+            )
+            res = self._run_one_test(mt, suite_dir, mutant_id + "/sim")
+            if self._is_build_error(res):
+                continue
+            scored = True
+            if (not res.is_pass()) or self._assertion_fired(res):
+                killed = True
+        if not scored:
+            return ERRORED, "sim=ERROR"
+        return (KILLED if killed else SURVIVED), ("sim=FAIL" if killed else "sim=PASS")
+
+    # --- scoring ------------------------------------------------------------
+
+    def _score_mutant(self, idx: int, mutant, fpv_cfg, fpv_baseline) -> MutantOutcome:
         operator = mutant.kind.value
         mutant_id = f"m{idx:04d}_{operator}"
         predicted = sorted(getattr(mutant.prediction, "perturbs_signals", []) or [])
 
         try:
             mutant_model, mutant_root = self._materialise_mutant(mutant_id, mutant.sv)
-            mutant_fpv_cfg = dataclasses.replace(
-                baseline_fpv_cfg,
-                model=mutant_model,
-                name=f"{baseline_fpv_cfg.get_name()}__{mutant_id}",
-            )
-            results = FpvRunner(
-                name=self.name + "/" + mutant_id,
-                root_cfg=self.root_cfg,
-                fpv_cfg=mutant_fpv_cfg,
-                suite_dir=mutant_root,
-            ).run()
-            verdict = results.results.get("result", "NA")
-        except FatalRtlBuddyError as e:
-            # A mutant that breaks elaboration / the build is errored, not
-            # scored — dropped from the denominator.
+        except OSError as e:
             log_event(
                 logger,
-                logging.INFO,
-                "mut_runner.mutant_errored",
+                logging.WARNING,
+                "mut_runner.materialise_failed",
                 campaign=self.mut_cfg.get_name(),
                 mutant=mutant_id,
                 error=str(e),
@@ -259,12 +376,28 @@ class MutRunner:
                 predicted_signals=predicted,
             )
 
-        if verdict in ("NA", "ERROR"):
-            outcome = ERRORED
-        elif verdict != baseline_verdict:
-            outcome = KILLED
+        per_outcomes: list[str] = []
+        verdicts: list[str] = []
+        if fpv_cfg is not None:
+            o, v = self._eval_fpv(
+                fpv_cfg, mutant_model, mutant_root, mutant_id, fpv_baseline
+            )
+            per_outcomes.append(o)
+            verdicts.append(v)
+        if self.mut_cfg.has_sim_oracle():
+            o, v = self._eval_sim(mutant_model, mutant_id)
+            per_outcomes.append(o)
+            verdicts.append(v)
+
+        # Union semantics: killed if any oracle caught it; else survived if
+        # any oracle actually scored it; else errored (every oracle failed
+        # to build/evaluate the mutant).
+        if KILLED in per_outcomes:
+            overall = KILLED
+        elif SURVIVED in per_outcomes:
+            overall = SURVIVED
         else:
-            outcome = SURVIVED
+            overall = ERRORED
 
         log_event(
             logger,
@@ -273,15 +406,15 @@ class MutRunner:
             campaign=self.mut_cfg.get_name(),
             mutant=mutant_id,
             operator=operator,
-            verdict=verdict,
-            outcome=outcome,
+            verdict=" ".join(verdicts),
+            outcome=overall,
         )
         return MutantOutcome(
             mutant_id=mutant_id,
             operator=operator,
-            outcome=outcome,
+            outcome=overall,
             diff_summary=mutant.diff_summary,
-            verdict=verdict,
+            verdict=" ".join(verdicts) or "NA",
             predicted_signals=predicted,
         )
 

--- a/tests/test_mut.py
+++ b/tests/test_mut.py
@@ -269,9 +269,10 @@ def _runner(tmp_path, mut_path):
     )
 
 
-def test_missing_xeno_raises_with_install_hint(tmp_path):
-    # No stub_xeno fixture here, and xeno is not installed in CI.
-    assert "rtl_buddy_xeno" not in sys.modules
+def test_missing_xeno_raises_with_install_hint(tmp_path, monkeypatch):
+    # Force the import to fail regardless of whether rtl-buddy-xeno is
+    # installed: a None entry in sys.modules makes the import raise.
+    monkeypatch.setitem(sys.modules, "rtl_buddy_xeno", None)
     mut_path = _write_project(tmp_path)
     runner = _runner(tmp_path, mut_path)
     with pytest.raises(FatalRtlBuddyError, match="rtl-buddy-xeno"):
@@ -301,7 +302,7 @@ def test_run_scores_mutants(tmp_path, stub_xeno):
         results = runner.run()
 
     assert isinstance(results, MutResults)
-    assert results.baseline_verdict == "PASS"
+    assert results.baseline_verdict == "fpv=PASS"
     assert results.killed() == 1
     assert results.survived() == 1
     assert results.errored() == 1
@@ -367,3 +368,253 @@ def test_report_round_trip(tmp_path, stub_xeno):
     assert restored.survived() == results.survived()
     assert restored.errored() == results.errored()
     assert restored.score() == results.score()
+
+
+# ---------------------------------------------------------------------------
+# Sim oracle
+# ---------------------------------------------------------------------------
+
+from dataclasses import dataclass as _dataclass  # noqa: E402
+from rtl_buddy.config.model import ModelConfig as _ModelConfig  # noqa: E402
+from rtl_buddy.runner.test_results import (  # noqa: E402
+    CompileFailResults as _CompileFailResults,
+    TestPassResults as _TestPassResults,
+    TestResults as _TestResults,
+)
+
+_MUT_YAML_SIM = dedent(
+    """\
+    rtl-buddy-filetype: mut_config
+    model: "leaf"
+    model_path: "../../design/leaf/models.yaml"
+    design_file: "../../design/leaf/leaf.sv"
+    operators: [arith_flip, cond_const]
+    verify:
+      test_config: "tests.yaml"
+    budget:
+      max_mutants: 10
+      schedule: round_robin
+    """
+)
+
+
+def _write_sim_mut(root, body):
+    """Write a mut.yaml (given body) plus a placeholder tests.yaml."""
+    fpv_dir = root / "fpv" / "leaf"
+    (fpv_dir / "tests.yaml").write_text("rtl-buddy-filetype: test_config\n")
+    mut_path = fpv_dir / "mut.yaml"
+    mut_path.write_text(body)
+    return mut_path
+
+
+@_dataclass
+class _FakeTestConfig:
+    name: str
+    model: object
+    assertions: bool
+
+
+def _fake_suite_factory(model_yaml):
+    class _FakeSuiteConfig:
+        def __init__(self, path):
+            self.path = path
+
+        def get_tests(self, name=None):
+            model = (
+                _ModelConfig(name="leaf", filelist=["-v leaf.sv"], path=model_yaml)
+                if model_yaml
+                else None
+            )
+            return [_FakeTestConfig(name="basic", model=model, assertions=False)]
+
+    return _FakeSuiteConfig
+
+
+# Marker-driven fake TestRunner, mirroring _FakeFpvRunner's convention:
+#   ERR -> compile failure (errored), KILL -> test FAIL (killed),
+#   ASSERT -> passes but an assertion fired (killed), else PASS (survived).
+class _FakeTestRunner:
+    def __init__(
+        self, name, root_cfg, test_cfg, rtl_builder_mode, test_runner_mode, suite_dir
+    ):
+        self.test_cfg = test_cfg
+
+    def run(self):
+        model = self.test_cfg.model
+        sv = next(Path(os.path.dirname(model.path)).glob("*.sv")).read_text()
+        if "ERR" in sv:
+            return _CompileFailResults(name="t")
+        if "KILL" in sv:
+            return _TestResults(name="t", results={"result": "FAIL", "desc": "x"})
+        if "ASSERT" in sv:
+            r = _TestPassResults(name="t")
+            r.results["assertions"] = {"enabled": True, "fired": 1}
+            return r
+        return _TestPassResults(name="t")
+
+
+def _install_sim_fakes(monkeypatch, model_yaml=None):
+    monkeypatch.setattr(
+        "rtl_buddy.config.suite.SuiteConfig", _fake_suite_factory(model_yaml)
+    )
+    monkeypatch.setattr("rtl_buddy.runner.test_runner.TestRunner", _FakeTestRunner)
+
+
+def _install_stub_xeno(monkeypatch, mutants):
+    class _SingleMutator:
+        @classmethod
+        def from_sv(cls, path):
+            return cls()
+
+        def generate(self, kinds, count, seed=0, schedule=None):
+            yield from mutants[:count]
+
+        def candidates(self, kinds):
+            return iter(())
+
+    mod = types.ModuleType("rtl_buddy_xeno")
+    mod.Mutator = _SingleMutator
+    mod.MutationKind = _MutationKind
+    mod.Schedule = _Schedule
+    mod.Mutant = _Mutant
+    mod.Prediction = _Prediction
+    monkeypatch.setitem(sys.modules, "rtl_buddy_xeno", mod)
+
+
+# ---- config ----
+
+
+def test_mut_config_sim_only(tmp_path):
+    _write_project(tmp_path)
+    mut_path = _write_sim_mut(tmp_path, _MUT_YAML_SIM)
+    cfg = MutSuiteConfig(path=str(mut_path)).get_config()
+    assert cfg.has_sim_oracle()
+    assert not cfg.has_fpv_oracle()
+    assert cfg.test_config.endswith("tests.yaml")
+    assert cfg.assertions is True
+
+
+def test_mut_config_both_oracles(tmp_path):
+    _write_project(tmp_path)
+    body = _MUT_YAML_SIM.replace(
+        'verify:\n  test_config: "tests.yaml"\n',
+        'verify:\n  fpv_config: "fpv.yaml"\n  verification: "leaf_safety"\n'
+        '  test_config: "tests.yaml"\n',
+    )
+    mut_path = _write_sim_mut(tmp_path, body)
+    cfg = MutSuiteConfig(path=str(mut_path)).get_config()
+    assert cfg.has_fpv_oracle() and cfg.has_sim_oracle()
+
+
+def test_mut_config_no_oracle_errors(tmp_path):
+    _write_project(tmp_path)
+    # Valid verify mapping but no oracle fields -> validation must fire.
+    body = _MUT_YAML_SIM.replace(
+        '  test_config: "tests.yaml"\n', "  assertions: true\n"
+    )
+    mut_path = _write_sim_mut(tmp_path, body)
+    with pytest.raises(FatalRtlBuddyError, match="at least one kill oracle"):
+        MutSuiteConfig(path=str(mut_path))
+
+
+# ---- sim scoring ----
+
+
+def _sim_runner(tmp_path):
+    from rtl_buddy.runner.mut_runner import MutRunner
+
+    mut_path = _write_sim_mut(tmp_path, _MUT_YAML_SIM)
+    cfg = MutSuiteConfig(path=str(mut_path)).get_config()
+    return MutRunner(
+        name="test", root_cfg=None, mut_cfg=cfg, work_dir=str(tmp_path / "work")
+    )
+
+
+@pytest.mark.parametrize(
+    "marker,expected",
+    [("KILL", KILLED), ("ASSERT", KILLED), ("survive", SURVIVED), ("ERR", ERRORED)],
+)
+def test_eval_sim_classification(tmp_path, monkeypatch, marker, expected):
+    _write_project(tmp_path)
+    _install_sim_fakes(monkeypatch, model_yaml=None)
+    runner = _sim_runner(tmp_path)
+    mutant_model, _root = runner._materialise_mutant(
+        "m0", f"// {marker}\n" + _DESIGN_SV
+    )
+    outcome, verdict = runner._eval_sim(mutant_model, "m0")
+    assert outcome == expected
+    assert verdict.startswith("sim=")
+
+
+def test_run_sim_oracle_scores(tmp_path, monkeypatch):
+    _write_project(tmp_path)
+    model_yaml = str(tmp_path / "design" / "leaf" / "models.yaml")
+    _install_sim_fakes(monkeypatch, model_yaml=model_yaml)
+    _install_stub_xeno(
+        monkeypatch,
+        [
+            _Mutant(
+                "// KILL\n" + _DESIGN_SV,
+                "k",
+                1,
+                _Prediction(),
+                _MutationKind.ARITH_FLIP,
+            ),
+            _Mutant(
+                "// survive\n" + _DESIGN_SV,
+                "s",
+                2,
+                _Prediction(),
+                _MutationKind.COND_CONST,
+            ),
+            _Mutant(
+                "// ERR\n" + _DESIGN_SV, "e", 3, _Prediction(), _MutationKind.ARITH_FLIP
+            ),
+        ],
+    )
+    runner = _sim_runner(tmp_path)
+    results = runner.run()
+    assert results.baseline_verdict == "sim=PASS"
+    assert results.killed() == 1
+    assert results.survived() == 1
+    assert results.errored() == 1
+
+
+def test_both_oracles_union_kill(tmp_path, monkeypatch):
+    # A mutant that the FPV proof misses but the sim assertion catches:
+    # "// ASSERT" has no KILL marker (fpv -> PASS/survived) but fires an
+    # assertion in sim -> the union verdict must be killed.
+    _write_project(tmp_path)
+    model_yaml = str(tmp_path / "design" / "leaf" / "models.yaml")
+    _install_sim_fakes(monkeypatch, model_yaml=model_yaml)
+    _install_stub_xeno(
+        monkeypatch,
+        [
+            _Mutant(
+                "// ASSERT\n" + _DESIGN_SV,
+                "a",
+                1,
+                _Prediction(),
+                _MutationKind.ARITH_FLIP,
+            )
+        ],
+    )
+    body = _MUT_YAML_SIM.replace(
+        'verify:\n  test_config: "tests.yaml"\n',
+        'verify:\n  fpv_config: "fpv.yaml"\n  verification: "leaf_safety"\n'
+        '  test_config: "tests.yaml"\n',
+    )
+    from rtl_buddy.runner.mut_runner import MutRunner
+
+    mut_path = _write_sim_mut(tmp_path, body)
+    cfg = MutSuiteConfig(path=str(mut_path)).get_config()
+    runner = MutRunner(
+        name="test", root_cfg=None, mut_cfg=cfg, work_dir=str(tmp_path / "work")
+    )
+    with patch("rtl_buddy.runner.mut_runner.FpvRunner", _FakeFpvRunner):
+        results = runner.run()
+    assert results.killed() == 1
+    assert results.survived() == 0
+    o = results.outcomes[0]
+    assert o.outcome == KILLED
+    assert "fpv=PASS" in o.verdict and "sim=FAIL" in o.verdict


### PR DESCRIPTION
Closes #227. Follow-up to #226, which shipped `rb mut` with an FPV-only kill oracle. This adds the **simulation** oracle: run a mutant through `rb test` with SVA assertions compiled in (Verilator `--assert`, from #213) and score it `killed` when a test FAILs or an assertion fires.

## Changes

- **`config/mut.py`** — `verify:` now supports an FPV oracle (`fpv_config` + `verification`), a sim oracle (`test_config` + optional `tests` + `assertions`), or **both**; validates at least one is configured.
  ```yaml
  verify:
    fpv_config: ../../fpv/blk/fpv.yaml   # optional
    verification: blk_safety
    test_config: ../../verif/blk/tests.yaml   # optional
    tests: [basic]            # optional subset; default all
    assertions: true          # compile SVA in (default on)
  ```
- **`runner/mut_runner.py`** — per-mutant evaluation generalised to N oracles. The sim path reuses the existing mutant materialisation (isolated copy of the model tree), runs `TestRunner` with the model overridden to the mutant and `assertions` forced on, and classifies:
  - `killed` — a selected test FAILs **or** an SVA assertion fires (`results["assertions"]["fired"] > 0`),
  - `survived` — all selected tests PASS with no firings,
  - `errored` — the mutant broke the build (`CompileFail`/`Filelist`/`SetupFail` result types → dropped from the denominator).
  - **Union semantics** across oracles: a mutant is killed if *any* configured oracle catches it. `baseline_verdict` now reports per-oracle, e.g. `fpv=PASS sim=PASS`.

## Notes / limitations

- The sim oracle runs in the test suite's own directory (so testbench relative paths / incdirs resolve); per-mutant sim artefacts therefore overwrite under the suite's `artefacts/` rather than being retained per-mutant. Sequential-only, matching the campaign model. The FPV oracle remains fully isolated per mutant.
- `demo_fpv_counter` is FPV-only (no testbench), so the end-to-end sim demo needs a block with SVA in its TB; that demo wiring is a template-side follow-up (rtl-buddy/rtl-buddy-project-template) once the template's rtl_buddy/Python pins are bumped (tracked in #206).

## Test plan

- [x] `tests/test_mut.py` extended (xeno + `TestRunner` + `SuiteConfig` stubbed): oracle selection (fpv-only / sim-only / both / none→error); sim classification (test FAIL → killed, assertion fired → killed, PASS → survived, compile break → errored); and the **union** case where the FPV proof misses a mutant the sim assertion catches.
- [x] Full suite: 982 passed, 10 skipped; ruff clean.

Part of #206 / the #97 ABV umbrella.