### PR TITLE
docs: make Quirks & Known Issues a living, highlighted guideline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ This repo is the source-of-truth implementation of the `rtl_buddy` CLI.
 
 Read these before opening issues or PRs, or before changing runtime behavior:
 
-- [docs/development/guidelines.md](docs/development/guidelines.md) — engineering rules: execution contexts, path ownership, artifact layout, subprocesses, dependencies, logging, errors, validation, releases, **issue triage**, and **milestones**.
+- [docs/development/guidelines.md](docs/development/guidelines.md) — engineering rules: execution contexts, path ownership, artifact layout, subprocesses, dependencies, logging, errors, validation, releases, **quirks & known issues**, **issue triage**, and **milestones**.
 - [docs/development/docs.md](docs/development/docs.md) — documentation authoring rules.
 - [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md) — contributor entry point that links to both.
 

--- a/docs/development/guidelines.md
+++ b/docs/development/guidelines.md
@@ -16,6 +16,12 @@ Downstream RTL projects and automation depend on them.
 Prefer targeted changes over broad refactors.
 When a change intentionally alters a contract, update docs, tests, generated references, and downstream validation assets in the same PR.
 
+## Quirks and Known Issues
+
+When behavior does not follow convention — a surprising default, a simulator-specific workaround, a non-obvious gotcha, or anything that works differently than a reader would reasonably expect — record it on the [Quirks & Known Issues](../known-issues.md) page.
+
+That page is the canonical home for non-conventional behavior. Keep it alive: write the quirk down as you hit or introduce it, rather than leaving it in commit history or tribal memory. Use one `##` section per quirk, name it after the behavior, and say what a user or agent should do about it.
+
 ## Execution Contexts
 
 Keep command execution rooted in explicit contexts rather than ambient `os.getcwd()`:
@@ -160,6 +166,7 @@ After meaningful `rtl_buddy` changes:
 4. If docs changed, keep frontmatter valid and run the docs build. See [Documentation Guidelines](docs.md).
 5. If behavior, YAML schema, version expectations, or validation workflows changed, update user docs and the bundled skill if agents rely on the behavior.
 6. If release or packaging behavior changed, verify wheel inclusion rules and update downstream integrations after release.
+7. If you discovered or introduced a quirk or non-conventional behavior, add an entry to `docs/known-issues.md`. Treat this as a default step, not an afterthought.
 
 ## Bundled Skill
 

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -1,9 +1,12 @@
 ---
-description: Known issues with rtl_buddy and workarounds for simulator-specific behaviors.
+description: Quirks, non-conventional behaviors, and known issues with rtl_buddy, including workarounds for simulator-specific behaviors.
 ---
 
-# Known Issues
-List of known issues with rtl_buddy and how it uses VCS, Verilator, etc.
+# Quirks & Known Issues
+
+The home for rtl_buddy behavior that does not follow convention: quirks, surprising defaults, simulator-specific workarounds, and known limitations. If something tripped you up because it works differently than you'd expect, add it here so the next person — or agent — finds it first.
+
+Keep this page alive. When you hit or introduce a quirk, write it down rather than leaving it in commit history or someone's memory. Use one `##` section per quirk, name it after the behavior, and say what to do about it.
 
 ## Instance pRNG seeding with Verilator
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -66,7 +66,7 @@ nav:
   - Migrations:
       - Submodule to uv: migrations/submodule-to-uv.md
       - v2 to v3: migrations/v2-to-v3.md
-  - Known Issues: known-issues.md
+  - Quirks & Known Issues: known-issues.md
   - Contributing: CONTRIBUTING.md
 
 extra:


### PR DESCRIPTION
## Why

The Quirks & Known Issues page wasn't referenced anywhere in the engineering guidelines, and was scoped narrowly to simulator behavior. The goal: highlight it in the dev guidelines and make recording quirks (anything that doesn't follow convention) a standing habit — keep the page alive.

## Changes

- **`docs/development/guidelines.md`** — new `## Quirks and Known Issues` section establishing the page as the canonical home for non-conventional behavior, plus a new Required Follow-Through item (#7) to record quirks as a default step.
- **`docs/known-issues.md`** — broadened from simulator-only to quirks generally; retitled **Quirks & Known Issues**; added a "keep it alive" contribution note and a one-`##`-per-quirk convention. Slug stays `known-issues.md`, so `rb docs show known-issues` and existing links are unaffected.
- **`AGENTS.md`** — added "quirks & known issues" to the canonical-guidelines summary so it's visible at the entry point.
- **`mkdocs.yml`** — nav label updated to "Quirks & Known Issues".

## Validation

- `scripts/check_docs_frontmatter.py --check` — pass.
- `mkdocs build --strict` — pass.

## Note on release

No `version/*` label applied — this is docs-only and needs no PyPI release. Apply `version/patch` on merge if you want the docs site re-deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)