### PR TITLE
fix(test): match Verilator --timing prefix in SVA assertion counter

### DIFF
--- a/src/rtl_buddy/tools/vlog_post.py
+++ b/src/rtl_buddy/tools/vlog_post.py
@@ -19,8 +19,11 @@ from ..logging_utils import log_event
 # Verilator emits SVA failures as a `%Error` line; the same shape covers
 # immediate and concurrent assertions. Cover hits are not surfaced as errors.
 # Example: `%Error: dut.sv:42: Assertion failed in top.dut: 'signal == expected'`
+# Under `--timing`, Verilator prefixes the line with the sim time, e.g.
+# `[500] %Error: tb_top.sv:32: Assertion failed in top.dut: 'assert' failed.`,
+# so the leading `[<time>] ` prefix is optional.
 _ASSERTION_FAILED_RE = re.compile(
-    r"^%Error[^:]*:\s*[^:]+:\s*\d+:\s*Assertion failed",
+    r"^(?:\[\d+\]\s+)?%Error[^:]*:\s*[^:]+:\s*\d+:\s*Assertion failed",
 )
 
 

--- a/tests/test_vlog_assertions.py
+++ b/tests/test_vlog_assertions.py
@@ -20,6 +20,21 @@ def test_count_assertion_failures_matches_verilator_error_lines(tmp_path):
     assert vlog_post.count_assertion_failures(str(log)) == 2
 
 
+def test_count_assertion_failures_matches_timing_prefixed_lines(tmp_path):
+    # Under Verilator's `--timing` flow, assertion-failure lines are prefixed
+    # with the sim time, e.g. `[500] %Error: ...`. The follow-up `$stop` line
+    # starts with a bare `%Error` but lacks "Assertion failed", so only the
+    # firing should be counted.
+    log = tmp_path / "test.log"
+    log.write_text(
+        "[500] %Error: tb_top.sv:32: Assertion failed in tb_top.CNT_MONOTONE: "
+        "'assert' failed.\n"
+        "%Error: ../../tb_top.sv:32: Verilog $stop\n"
+        "Aborting...\n",
+    )
+    assert vlog_post.count_assertion_failures(str(log)) == 1
+
+
 def test_count_assertion_failures_handles_missing_file(tmp_path):
     log = tmp_path / "exists.log"
     log.write_text("nothing fired\n")
@@ -76,6 +91,29 @@ def test_vlog_post_flips_pass_to_fail_when_assertion_fires(tmp_path):
     )
     post = vlog_post.VlogPost(
         name="t",
+        path=str(log),
+        err_path=None,
+        assertions_enabled=True,
+    )
+    results = post.get_results().results
+    assert results["result"] == "FAIL"
+    assert results["assertions"] == {"enabled": True, "fired": 1}
+    assert "SVA assertion failure" in results["desc"]
+
+
+def test_vlog_post_flips_na_to_fail_on_timing_abort(tmp_path):
+    # The issue-229 scenario: under `--timing`, a fired SVA aborts the sim
+    # before any PASS/FAIL marker is printed. Without the assertion override
+    # this would report NA; the timing-prefixed firing must flip it to FAIL.
+    log = tmp_path / "test.log"
+    log.write_text(
+        "[500] %Error: tb_top.sv:32: Assertion failed in tb_top.CNT_MONOTONE: "
+        "'assert' failed.\n"
+        "%Error: ../../tb_top.sv:32: Verilog $stop\n"
+        "Aborting...\n",
+    )
+    post = vlog_post.VlogPost(
+        name="smoke_with_sva",
         path=str(log),
         err_path=None,
         assertions_enabled=True,


### PR DESCRIPTION
## What

`rb test` with `assertions: true` failed to surface SVA firings under Verilator's `--timing` flow: the per-test `fired` counter stayed at `0` and the result reported `NA` instead of `FAIL`.

## Root cause

`count_assertion_failures()` in `src/rtl_buddy/tools/vlog_post.py` anchored its regex on `^%Error`, requiring the log line to start literally with `%Error`. Under `--timing`, Verilator prefixes assertion-failure lines with the sim time:

```
[500] %Error: tb_top.sv:32: Assertion failed in tb_top.CNT_MONOTONE: 'assert' failed.
```

so the regex never matched and the count returned `0`.

## Fix

Make the leading `[<time>] ` prefix optional in the regex:

```python
r"^(?:\[\d+\]\s+)?%Error[^:]*:\s*[^:]+:\s*\d+:\s*Assertion failed"
```

The follow-up `%Error: ... Verilog $stop` line still correctly does not match (no "Assertion failed").

The `NA`-vs-`FAIL` classification (issue's part 2) is already handled by the existing NA→FAIL override in `_merge_assertions`: it flips the result to `FAIL` whenever `fired > 0`. With the counter now matching, a fired SVA that aborts the sim classifies as `FAIL` automatically — no separate change needed.

## Tests

Extends `tests/test_vlog_assertions.py` with timing-prefixed fixtures:
- `test_count_assertion_failures_matches_timing_prefixed_lines` — counts the `[500] %Error: ... Assertion failed` firing and ignores the bare `%Error: ... $stop` line.
- `test_vlog_post_flips_na_to_fail_on_timing_abort` — the headline scenario: an aborted sim with no PASS/FAIL marker is flipped from `NA` to `FAIL`.

Full suite: `984 passed, 9 skipped`. The one unrelated failure (`test_hub_protocol::test_vendored_schema_matches_source_when_view_repo_present`) reproduces on the base branch — it depends on a local sibling `rtl-buddy-view` checkout and is not touched here.

Closes #229

🤖 Generated with [Claude Code](https://claude.com/claude-code)