### PR TITLE
docs: document v5 hook cwd contract and require migration pages for major bumps

### DIFF
--- a/docs/concepts/plugins.md
+++ b/docs/concepts/plugins.md
@@ -97,6 +97,29 @@ If a pre-processing script raises an exception, the affected test is marked as a
 
 See the template repo for a working example.
 
+## Hook working directory
+
+`sweep` and `preproc` hooks execute via `exec()` inside the `rb` process and share its working directory, which stays at `invocation_cwd` — the directory you ran `rb` from. It is **not** the suite directory. Always build paths from the injected `suite_dir` and `artifact_dir` variables; never call `os.getcwd()` to locate the suite.
+
+```python
+import os
+out = os.path.join(artifact_dir, "gen.sv")   # correct
+out = os.path.join(os.getcwd(), "gen.sv")     # wrong — invocation cwd
+```
+
+If a hook delegates to a third-party generator that writes relative to `os.getcwd()` and exposes no output-directory argument, wrap the call in a `chdir` to the suite and restore it afterwards:
+
+```python
+prev = os.getcwd()
+os.chdir(suite_dir)
+try:
+    gen_dir = third_party_generate(...)   # writes relative to cwd
+finally:
+    os.chdir(prev)
+```
+
+This anchoring behavior changed in v5; see [Migrating from v4 to v5](../migrations/v4-to-v5.md) and the [execution context](execution-context.md) reference.
+
 ## Post-processing
 
 The `postproc` hook is parsed from config but the runtime flow currently relies on built-in post-processing. Custom post-processing support is planned for a future release.

--- a/docs/development/guidelines.md
+++ b/docs/development/guidelines.md
@@ -167,6 +167,7 @@ After meaningful `rtl_buddy` changes:
 5. If behavior, YAML schema, version expectations, or validation workflows changed, update user docs and the bundled skill if agents rely on the behavior.
 6. If release or packaging behavior changed, verify wheel inclusion rules and update downstream integrations after release.
 7. If you discovered or introduced a quirk or non-conventional behavior, add an entry to `docs/known-issues.md`. Treat this as a default step, not an afterthought.
+8. If the change is a `version/major` bump, add or update the `docs/migrations/vN-to-vM.md` page (and its `mkdocs.yml` nav entry) covering every breaking behavior change. See [Releases](#releases).
 
 ## Bundled Skill
 
@@ -235,3 +236,7 @@ Pre-releases are cut from feature branches by workflow dispatch and should not b
 
 Docs publishing, PyPI publishing, and downstream template updates depend on that sequence.
 Do not push a template pin for an unreleased `rtl_buddy` version.
+
+Every `version/major` bump must ship a migration page at `docs/migrations/vN-to-vM.md`, added to the `mkdocs.yml` nav, before merge.
+The page documents every breaking behavior change — moved outputs, changed defaults, removed or renamed config fields, and any contract that downstream projects or hook scripts depend on — and tells readers what to update.
+A recurring failure mode is a silent contract change buried in a PR description; the migration page is where it must live so users and agents find it.

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -16,6 +16,25 @@ VCS is recommended for stable random testing due to its hierarchical instance se
 
 If you require reproducible randomized testing on macOS (where VCS is not available), this is a known limitation.
 
+## Hook scripts run at the invocation directory, not the suite
+
+`sweep` and `preproc` hooks execute via `exec()` inside the `rb` process and share its working directory, which is `invocation_cwd` — your shell's cwd — not the suite directory. Resolve suite-local inputs and outputs from the injected `suite_dir` / `artifact_dir` variables, never from `os.getcwd()`.
+
+The footgun is a hook that delegates to a **third-party generator** which writes its outputs relative to `os.getcwd()` and offers no output-directory argument. Under v4, `regression` chdir'd into each suite so such a generator dropped files under the suite; under v5 it drops them under the invocation directory instead (e.g. polluting the repo root when running `regression` from there). The failure is silent: generation "succeeds", but the test fails much later at sim time with a generic `cannot open <suite_dir>/<gen_dir>/<file>`. It only reproduces when `invocation_cwd != suite_dir`, so it passes when run from inside the suite and fails under `regression` from the repo root.
+
+Wrap the generator call in a `chdir` to the suite (restore afterwards):
+
+```python
+prev = os.getcwd()
+os.chdir(suite_dir)
+try:
+    gen_dir = third_party_generate(...)   # writes relative to cwd
+finally:
+    os.chdir(prev)
+```
+
+See [Migrating from v4 to v5](migrations/v4-to-v5.md) for the full behavior change.
+
 ## VCS hierarchical seed file
 
 When using VCS with hierarchical instance seeding (`-xlrm hier_inst_seed`), VCS writes a `HierInstanceSeed.txt` file in the simulation directory after the run. `rtl_buddy` looks for this file to record the seed for reproducibility.

--- a/docs/migrations/v2-to-v3.md
+++ b/docs/migrations/v2-to-v3.md
@@ -33,6 +33,8 @@ Compile outputs (`compile.log`, `run.f`) remain at `artefacts/{test_name}/` — 
 
 Hook scripts that previously relied on suite-relative file paths resolving from the simulator working directory must now resolve those paths explicitly. Use the preproc hook's `suite_dir` variable for suite-local inputs; keep output filenames artifact-relative when they should land under `artefacts/{test_name}/`.
 
+> v5 went further: hooks no longer run from the suite directory at all. See [Migrating from v4 to v5](v4-to-v5.md#hook-scripts-run-at-the-invocation-directory).
+
 ### Symlinks
 
 The convenience symlinks `test.log`, `test.err`, and `test.randseed` at the suite root still exist and still point to the latest run.

--- a/docs/migrations/v4-to-v5.md
+++ b/docs/migrations/v4-to-v5.md
@@ -13,10 +13,12 @@ v5 introduces [`ExecutionContext`](../concepts/execution-context.md): every conf
 | `rtl_buddy.log` location | invocation cwd | command root (`dirname(<primary config>)`) |
 | `regression` per-suite cwd | `os.chdir()` into each suite | no chdir; each suite re-anchors its own file log |
 | `root_config.yaml` discovery | walks up from invocation cwd | walks up from command root |
-| `hier`, `axi-profile` outputs | invocation cwd | resolved config's command root |
+| `hier`, `axi-profile` *default* outputs / artefacts | invocation cwd | resolved config's command root |
 | Coverage `outdir` / `source_roots` | invocation cwd | command root |
 
 For most projects this is transparent — artefacts simply land in the predictable place (under the suite's `artefacts/`) whether you run from the suite directory or the repo root.
+
+**Explicit output paths are unchanged.** A value you pass on the command line — `hier -o diagram.svg`, `axi-profile ... -o report.html`, `filelist <model> out.f` — still resolves relative to your shell's cwd (`invocation_cwd`), matching normal shell behavior. Only the command-managed artefacts and default output locations moved to the command root. If your CI passes `-o`, keep looking where you told it to write; do not redirect those to `dirname(models.yaml)`/`dirname(tests.yaml)`.
 
 ## Hook scripts run at the invocation directory
 

--- a/docs/migrations/v4-to-v5.md
+++ b/docs/migrations/v4-to-v5.md
@@ -1,0 +1,64 @@
+---
+description: How to migrate an rtl_buddy project from v4 to v5, covering the ExecutionContext change that anchors all outputs on the primary config file.
+---
+
+# Migrating from v4 to v5
+
+## Outputs anchor on the config file, not your shell
+
+v5 introduces [`ExecutionContext`](../concepts/execution-context.md): every config-driven command anchors its outputs on the directory containing its primary config (the **command root**), regardless of where you invoke `rb` from. Previously some flows wrote relative to the invocation directory, which scattered scratch files into whatever tree you happened to be standing in.
+
+| Behavior | v4 | v5 |
+|----------|----|-----|
+| `rtl_buddy.log` location | invocation cwd | command root (`dirname(<primary config>)`) |
+| `regression` per-suite cwd | `os.chdir()` into each suite | no chdir; each suite re-anchors its own file log |
+| `root_config.yaml` discovery | walks up from invocation cwd | walks up from command root |
+| `hier`, `axi-profile` outputs | invocation cwd | resolved config's command root |
+| Coverage `outdir` / `source_roots` | invocation cwd | command root |
+
+For most projects this is transparent — artefacts simply land in the predictable place (under the suite's `artefacts/`) whether you run from the suite directory or the repo root.
+
+## Hook scripts run at the invocation directory
+
+This is the one change most likely to break existing projects.
+
+`sweep` and `preproc` hooks execute via `exec()` inside the `rb` process and share its working directory. **The change is specific to `regression`:** in v4 it did `os.chdir()` into each suite, so hooks ran from the suite directory; v5 removes that chdir, so hooks now run at `invocation_cwd` — your shell's directory — like every other command.
+
+Single-suite `test` and `randtest` are unaffected here: their hook working directory was already `invocation_cwd` in v4, so nothing changes for them. (Their *artefact* locations do move under the suite in v5 — see the table above — but that is anchored independently of the hook's cwd.)
+
+In all cases, hooks receive `suite_dir` and `artifact_dir` as namespace variables. Build paths from those:
+
+```python
+# inside a sweep / preproc script
+import os
+out = os.path.join(artifact_dir, "gen.sv")          # correct
+stim = os.path.join(suite_dir, "vectors", "in.txt")  # correct
+out = os.path.join(os.getcwd(), "gen.sv")            # wrong — invocation cwd
+```
+
+Any hook that called `os.getcwd()` (directly or indirectly) to find the suite will break.
+
+### Third-party generators that write relative to cwd
+
+If a hook delegates to a generator you don't control — one that writes its outputs relative to `os.getcwd()` and exposes no output-directory parameter — `suite_dir`/`artifact_dir` can't help, because you can't tell the generator where to write. Wrap the call in a `chdir` to the suite (restore afterwards):
+
+```python
+prev = os.getcwd()
+os.chdir(suite_dir)
+try:
+    gen_dir = third_party_generate(...)   # writes relative to cwd
+finally:
+    os.chdir(prev)
+```
+
+See [Quirks & Known Issues](../known-issues.md) for the failure signature when this is missed.
+
+## What to update
+
+### CI scripts
+
+Scripts that looked for `rtl_buddy.log` in the invocation directory should look under the command root (`dirname(<primary config>)`) instead.
+
+### Hook scripts
+
+Replace any `os.getcwd()` usage with `suite_dir` or `artifact_dir`. For uncontrollable generators, use the `chdir(suite_dir)` pattern above.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -66,6 +66,7 @@ nav:
   - Migrations:
       - Submodule to uv: migrations/submodule-to-uv.md
       - v2 to v3: migrations/v2-to-v3.md
+      - v4 to v5: migrations/v4-to-v5.md
   - Quirks & Known Issues: known-issues.md
   - Contributing: CONTRIBUTING.md
 

--- a/src/rtl_buddy/skill/SKILL.md
+++ b/src/rtl_buddy/skill/SKILL.md
@@ -7,7 +7,7 @@ description: Use rtl_buddy to orchestrate SystemVerilog compile/sim workflows, r
 
 Run `rtl-buddy --version` at the top of every run summary.
 
-Use this skill for agent-specific workflow rules only. For command syntax or schema details, start with `rb --help`, `rb <subcommand> --help`, `rtl-buddy docs list`, `rtl-buddy docs show agents`, and `rtl-buddy --machine docs show reference/yaml`.
+Use this skill for agent-specific workflow rules only. For command syntax or schema details, start with `rb --help`, `rb <subcommand> --help`, `rtl-buddy docs list`, `rtl-buddy docs show agents`, and `rtl-buddy --machine docs show reference/yaml`. When behavior surprises you (silent failures, paths landing in the wrong place, hook cwd), check `rtl-buddy docs show known-issues` first.
 
 ## Always use `--machine`
 


### PR DESCRIPTION
## Summary

The `#219` ExecutionContext change (shipped in **v5.0.0**) left `sweep`/`preproc` hooks running at `invocation_cwd` instead of the suite directory. This was noted in the PR description but never surfaced where hook authors look, and there was no v4→v5 migration page. The recurring footgun: a hook that delegates to a third-party generator writing relative to `os.getcwd()` silently drops files in the wrong place — passing when run from inside the suite, failing under `regression` from the repo root with a generic `cannot open ...` at sim time.

This is docs-only.

## Changes

- **New `docs/migrations/v4-to-v5.md`** — the ExecutionContext anchoring changes (log location, `root_config` discovery, coverage roots, regression cwd) and the hook-cwd contract. Scoped accurately: only `regression` chdir'd in v4; single-suite `test`/`randtest` hook cwd is **unchanged**. Added to nav; cross-linked from `v2-to-v3.md`.
- **`docs/known-issues.md`** — new Quirks entry for the generator-writes-to-cwd case, with the `os.chdir(suite_dir)` workaround.
- **`docs/concepts/plugins.md`** — new "Hook working directory" section on the page hook authors actually read (scoped to `sweep`/`preproc`, since `postproc` is parsed-but-not-executed).
- **`docs/development/guidelines.md`** — require a `docs/migrations/vN-to-vM.md` page for every `version/major` bump (Releases + Required Follow-Through). This is the durable fix so a silent contract change can't hide in a PR description again.
- **`src/rtl_buddy/skill/SKILL.md`** — surface `docs show known-issues` up front (still 50/60 lines).

## Validation

- `uv run --group docs mkdocs build --strict` — clean (links, nav, frontmatter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)