### PR TITLE
feat(hub): add Origin.NOTEBOOK so the axi-profiler notebook can peer

### DIFF
--- a/src/rtl_buddy/hub/protocol.py
+++ b/src/rtl_buddy/hub/protocol.py
@@ -51,6 +51,7 @@ class Origin(str, Enum):
     WAVE = "wave"
     SRC = "src"
     CLI = "cli"
+    NOTEBOOK = "notebook"
 
 
 class Kind(str, Enum):

--- a/src/rtl_buddy/hub/schema/hub-protocol-v1.json
+++ b/src/rtl_buddy/hub/schema/hub-protocol-v1.json
@@ -17,7 +17,7 @@
       "description": "RFC 4122 UUID for request/response correlation and loop-prevention dedupe."
     },
     "origin": {
-      "enum": ["view", "wave", "src", "cli"],
+      "enum": ["view", "wave", "src", "cli", "notebook"],
       "description": "Conceptual originator of the message; the loop-prevention discriminator."
     },
     "kind": {
@@ -493,14 +493,14 @@
                   "active_model":  { "type": ["string", "null"], "description": "Currently-active model name when the hub was started with --model NAME, else null." },
                   "selection":     { "type": ["object", "null"], "description": "Last selection_changed payload broadcast through the hub, plus the origin that produced it. Null when the hub has seen no selection yet.",
                                      "required": ["instance_path", "origin"], "additionalProperties": false,
-                                     "properties": { "instance_path": { "type": "string", "minLength": 1 }, "origin": { "enum": ["view", "wave", "src", "cli"] } } },
+                                     "properties": { "instance_path": { "type": "string", "minLength": 1 }, "origin": { "enum": ["view", "wave", "src", "cli", "notebook"] } } },
                   "cursor_time":   { "type": ["object", "null"], "description": "Last cursor_time_changed payload + origin. Null when no cursor event has fired.",
                                      "required": ["t_fs", "origin"], "additionalProperties": false,
-                                     "properties": { "t_fs": { "type": "string", "pattern": "^[0-9]+$" }, "origin": { "enum": ["view", "wave", "src", "cli"] } } },
+                                     "properties": { "t_fs": { "type": "string", "pattern": "^[0-9]+$" }, "origin": { "enum": ["view", "wave", "src", "cli", "notebook"] } } },
                   "wave_scope":    { "type": ["object", "null"], "description": "Last scope_changed payload + origin. Null when no scope event has fired.",
                                      "required": ["wave_scope", "origin"], "additionalProperties": false,
-                                     "properties": { "wave_scope": { "type": "string", "minLength": 1 }, "origin": { "enum": ["view", "wave", "src", "cli"] } } },
-                  "peers":         { "type": "array", "items": { "enum": ["view", "wave", "src", "cli"] }, "uniqueItems": true,
+                                     "properties": { "wave_scope": { "type": "string", "minLength": 1 }, "origin": { "enum": ["view", "wave", "src", "cli", "notebook"] } } },
+                  "peers":         { "type": "array", "items": { "enum": ["view", "wave", "src", "cli", "notebook"] }, "uniqueItems": true,
                                      "description": "Origins currently registered against the hub." },
                   "diagnostics_sources": { "type": "array", "items": { "type": "string", "minLength": 1 }, "uniqueItems": true,
                                            "description": "Names of producers with cached diagnostics_set bundles." }
@@ -517,13 +517,13 @@
       "then": {
         "properties": {
           "kind": { "const": "request" },
-          "origin": { "enum": ["view", "wave", "src", "cli"] },
+          "origin": { "enum": ["view", "wave", "src", "cli", "notebook"] },
           "payload": {
             "type": "object",
             "required": ["client", "version", "capabilities"],
             "additionalProperties": false,
             "properties": {
-              "client": { "enum": ["view", "wave", "src", "cli"] },
+              "client": { "enum": ["view", "wave", "src", "cli", "notebook"] },
               "version": { "type": "string", "minLength": 1, "description": "Semver of the client implementation." },
               "capabilities": { "type": "array", "items": { "type": "string", "minLength": 1 }, "uniqueItems": true },
               "takeover": { "type": "boolean", "description": "When true, instructs the hub to disconnect any existing registration for the same client slot before accepting this hello. Used by browser tabs that find an older tab already attached: the new tab requests takeover, the old tab gets bye-broadcast and its socket closed. Optional; default false." }
@@ -545,7 +545,7 @@
               "server_version": { "type": "string", "minLength": 1 },
               "registered_clients": {
                 "type": "array",
-                "items": { "enum": ["view", "wave", "src", "cli"] },
+                "items": { "enum": ["view", "wave", "src", "cli", "notebook"] },
                 "uniqueItems": true
               }
             }

--- a/tests/test_hub_protocol.py
+++ b/tests/test_hub_protocol.py
@@ -224,6 +224,15 @@ def test_make_hello_produces_valid_envelope():
     assert decode(raw) == env
 
 
+def test_make_hello_accepts_notebook_origin():
+    """The axi-profiler notebook registers as origin=notebook
+    (rtl-buddy-axi-profiler#48). decode() schema-validates, so a clean
+    round-trip proves the wire contract accepts the new origin."""
+    env = make_hello(client=Origin.NOTEBOOK, version="0.1.0", capabilities=[])
+    assert env.origin is Origin.NOTEBOOK
+    assert decode(encode(env)) == env
+
+
 def test_make_welcome_carries_request_id():
     hello = make_hello(client=Origin.VIEW, version="0.1.0", capabilities=[])
     welcome = make_welcome(


### PR DESCRIPTION
Adds `Origin.NOTEBOOK` to the hub so the axi-profiler marimo notebook can register as a distinct peer and receive SPA `selection_changed` broadcasts.

## Why

The notebook needs its own origin — `view` collides with the SPA, `cli` with `rb hub send` (the hub enforces one client per origin). The codec runtime-validates every envelope against the vendored `hub-protocol-v1.json`, so the notebook's `hello` only registers if `notebook` is in the `origin`/`client` enums.

## Changes

- `protocol.py`: `Origin.NOTEBOOK = "notebook"`.
- `schema/hub-protocol-v1.json`: add `"notebook"` to all origin/client/peers enums (re-vendored from rtl-buddy-view, which owns the contract).
- test: a notebook-origin `hello` round-trips through `encode`/`decode` (which schema-validates).

No CLI surface change → no `cli.md` regen.

## Coordinated change set

- **rtl-buddy/rtl-buddy-view#112** — canonical schema (source of the vendored copy).
- **rtl-buddy/rtl-buddy-axi-profiler#48** — `EventSync` sends `hello` as origin=notebook, consumes `selection_changed`.

## Pre-existing drift (untouched)

The vendored schema already carried a `view_capture` type not present in the rtl-buddy-view source, so `test_vendored_schema_matches_source_when_view_repo_present` is red **locally** — but it's **skipped in CI** (no view sibling checkout). That drift predates this PR; I kept `view_capture` rather than silently dropping it, and added only `notebook`.

## Verification

`pytest tests/test_hub_protocol.py tests/test_hub_server.py` green (the one local failure is the pre-existing drift test above). Verified end-to-end against a live hub: the axi-profiler `EventSync` registers as origin=notebook and a `rb hub send select <instance>` drives its selection.