### PR TITLE
feat(mut): scope graph-ingestion for hierarchical mutation campaigns

### DIFF
--- a/src/rtl_buddy/config/mut.py
+++ b/src/rtl_buddy/config/mut.py
@@ -215,6 +215,15 @@ class MutConfig:
     def has_sim_oracle(self) -> bool:
         return self.test_config is not None
 
+    def get_scope_include(self) -> list[str]:
+        return self.scope_include
+
+    def get_scope_exclude(self) -> list[str]:
+        return self.scope_exclude
+
+    def has_scope(self) -> bool:
+        return bool(self.scope_include or self.scope_exclude)
+
     def __str__(self):
         return pprint.pformat(self)
 

--- a/src/rtl_buddy/runner/mut_results.py
+++ b/src/rtl_buddy/runner/mut_results.py
@@ -29,6 +29,10 @@ class MutantOutcome:
     # prediction is the highest-signal "your property set is too weak"
     # finding, so we keep it for the summary.
     predicted_signals: list[str] = field(default_factory=list)
+    # Model-relative origin file this mutant was spliced into. Populated
+    # only for scoped (multi-file) campaigns; empty for the single-file
+    # default path.
+    file: str = ""
 
     def is_predicted_observable_miss(self) -> bool:
         return self.outcome == SURVIVED and bool(self.predicted_signals)
@@ -40,10 +44,14 @@ class MutResults:
         name: str,
         outcomes: list[MutantOutcome],
         baseline_verdict: str,
+        per_file: dict[str, dict[str, int]] | None = None,
     ):
         self.name = name
         self.outcomes = outcomes
         self.baseline_verdict = baseline_verdict
+        # Per-file (per-module) killed/survived/errored breakdown, recorded
+        # only for scoped multi-file campaigns. None for single-file runs.
+        self.per_file = per_file
 
     def killed(self) -> int:
         return sum(1 for o in self.outcomes if o.outcome == KILLED)
@@ -76,7 +84,7 @@ class MutResults:
 
     def as_report(self) -> dict:
         """JSON-serialisable report consumed by ``rb mut score``."""
-        return {
+        report = {
             "name": self.name,
             "baseline_verdict": self.baseline_verdict,
             "killed": self.killed(),
@@ -91,10 +99,16 @@ class MutResults:
                     "verdict": o.verdict,
                     "diff_summary": o.diff_summary,
                     "predicted_signals": o.predicted_signals,
+                    "file": o.file,
                 }
                 for o in self.outcomes
             ],
         }
+        # Per-file breakdown is emitted only when a scope was active, so a
+        # single-file report stays shaped exactly as before.
+        if self.per_file:
+            report["per_file"] = self.per_file
+        return report
 
     @classmethod
     def from_report(cls, report: dict) -> "MutResults":
@@ -106,6 +120,8 @@ class MutResults:
                 diff_summary=m.get("diff_summary", ""),
                 verdict=m.get("verdict", "NA"),
                 predicted_signals=m.get("predicted_signals", []),
+                # Tolerant of pre-scope reports that have no "file" key.
+                file=m.get("file", ""),
             )
             for m in report.get("mutants", [])
         ]
@@ -113,6 +129,8 @@ class MutResults:
             name=report.get("name", "mut"),
             outcomes=outcomes,
             baseline_verdict=report.get("baseline_verdict", "NA"),
+            # Optional; absent in single-file / pre-scope reports.
+            per_file=report.get("per_file"),
         )
 
     def __str__(self):

--- a/src/rtl_buddy/runner/mut_runner.py
+++ b/src/rtl_buddy/runner/mut_runner.py
@@ -24,6 +24,8 @@ the rest of rtl_buddy (and its test suite) runs without it installed.
 from __future__ import annotations
 
 import dataclasses
+import fnmatch
+import json
 import logging
 import os
 import shutil
@@ -106,11 +108,108 @@ class MutRunner:
             return xeno.Schedule.ROUND_ROBIN
         return xeno.Schedule.SEQUENTIAL
 
+    # --- scope graph ingestion ----------------------------------------------
+
+    def _scope_graph_json(self) -> dict:
+        """Run rtl-buddy-view (via the existing RtlBuddyView wrapper) to a
+        JSON file under the work dir and load it.
+
+        Only called when ``self.mut_cfg.has_scope()``. ``RtlBuddyView.run()``
+        streams JSON to the ``--output`` file and returns a returncode (it
+        does NOT return stdout), so we read the file back. The wrapper raises
+        ``FatalRtlBuddyError`` if the binary is missing — let that propagate.
+        """
+        from ..tools.hier_rtl_buddy_view import RtlBuddyView
+
+        out = os.path.join(self.work_dir, "scope", "hier.json")
+        Path(os.path.dirname(out)).mkdir(parents=True, exist_ok=True)
+        rc = RtlBuddyView(
+            name=self.name + "/mut-scope",
+            model_cfg=self.mut_cfg.get_model(),
+            suite_dir=self.work_dir,
+            format="json",
+            output=out,
+        ).run()
+        if rc != 0 or not os.path.isfile(out):
+            raise FatalRtlBuddyError(
+                "rb mut: scope requires a hierarchy graph but rtl-buddy-view "
+                f"failed (rc={rc}); run `rb hier {self.mut_cfg.get_model().name} "
+                "--format json` to diagnose"
+            )
+        with open(out) as f:
+            data = json.load(f)
+        major = str(data.get("schema_version", "")).split(".")[0]
+        if major != "1":
+            raise FatalRtlBuddyError(
+                "rb mut: unexpected hier schema_version "
+                f"{data.get('schema_version')!r} (expected 1.x)"
+            )
+        return data
+
+    def _scoped_source_files(self) -> list[str]:
+        """Resolve scope.include/exclude against the hier graph.
+
+        Glob-matches each include/exclude pattern (stdlib shell glob via
+        ``fnmatch``) against THREE targets per node: the dotted instance
+        path (``node["id"]``), the node's absolute source file, and that
+        file relative to the model dir. A node is in scope when include is
+        empty OR any include matches, and no exclude matches.
+
+        Returns the sorted, de-duplicated set of in-scope source files
+        (absolute paths). Raises ``FatalRtlBuddyError`` when the resolved
+        set is empty or any file escapes the model dir.
+        """
+        inc = self.mut_cfg.get_scope_include()
+        exc = self.mut_cfg.get_scope_exclude()
+        data = self._scope_graph_json()
+        model_dir = self._model_dir()
+
+        kept: set[str] = set()
+        for node in data.get("nodes", []):
+            src = (node.get("source") or {}).get("file")
+            if not src:
+                continue
+            abspath = os.path.normpath(os.path.abspath(src))
+            rel = os.path.relpath(abspath, model_dir)
+            targets = (node.get("id", ""), abspath, rel)
+            included = (not inc) or any(
+                fnmatch.fnmatch(t, p) for p in inc for t in targets
+            )
+            excluded = any(fnmatch.fnmatch(t, p) for p in exc for t in targets)
+            if included and not excluded:
+                kept.add(abspath)
+
+        if not kept:
+            raise FatalRtlBuddyError(
+                "rb mut: scope.include/exclude selected no source files from "
+                f"the hierarchy of model '{self.mut_cfg.get_model().name}' "
+                f"(include={inc!r}, exclude={exc!r})"
+            )
+        for f in kept:
+            rel = os.path.relpath(f, model_dir)
+            if rel.startswith(".."):
+                raise FatalRtlBuddyError(
+                    f"rb mut: scoped source file ({f}) must live within the "
+                    f"model directory ({model_dir}) so per-mutant isolation "
+                    "can copy the source tree."
+                )
+        files = sorted(kept)
+        log_event(
+            logger,
+            logging.INFO,
+            "mut_runner.scope_resolved",
+            campaign=self.mut_cfg.get_name(),
+            files=len(files),
+        )
+        return files
+
     # --- list ---------------------------------------------------------------
 
     def list_candidates(self) -> list[dict]:
         """Enumerate candidate sites without mutating (``rb mut list``)."""
         xeno = self._load_xeno()
+        if self.mut_cfg.has_scope():
+            return self._list_candidates_scoped(xeno)
         mutator = self._mutator(xeno)
         sites = []
         for site in mutator.candidates(kinds=self._kinds(xeno)):
@@ -124,10 +223,43 @@ class MutRunner:
             )
         return sites
 
+    def _list_candidates_scoped(self, xeno) -> list[dict]:
+        """Enumerate candidate sites across every scoped source file.
+
+        Each candidate carries a model-relative ``file`` key so multi-file
+        output disambiguates which scoped file the site belongs to. The
+        per-file ``per_module_cap`` (one scoped file == one module for this
+        slice) caps how many sites are reported per file.
+        """
+        kinds = self._kinds(xeno)
+        model_dir = self._model_dir()
+        cap = self.mut_cfg.budget.per_module_cap
+        sites: list[dict] = []
+        for source_file in self._scoped_source_files():
+            mutator = xeno.Mutator.from_sv(Path(source_file))
+            rel = os.path.relpath(source_file, model_dir)
+            n = 0
+            for site in mutator.candidates(kinds=kinds):
+                if cap is not None and n >= cap:
+                    break
+                sites.append(
+                    {
+                        "operator": site.kind.value,
+                        "line": site.line,
+                        "column": site.column,
+                        "snippet": site.snippet,
+                        "file": rel,
+                    }
+                )
+                n += 1
+        return sites
+
     # --- run ----------------------------------------------------------------
 
     def run(self) -> MutResults:
         xeno = self._load_xeno()
+        if self.mut_cfg.has_scope():
+            return self._run_scoped(xeno)
         mutator = self._mutator(xeno)
         kinds = self._kinds(xeno)
 
@@ -184,6 +316,97 @@ class MutRunner:
             baseline_verdict=baseline_verdict or "NA",
         )
 
+    def _run_scoped(self, xeno) -> MutResults:
+        """Multi-file campaign: resolve the scoped source files from the
+        hier graph, then mutate each one in turn, splicing every mutant back
+        into ITS origin file.
+
+        Budget semantics for the scoped slice (one scoped file == one
+        "module"):
+          - ``per_module_cap`` caps mutants generated PER scoped file;
+          - ``max_mutants`` is a GLOBAL ceiling across all scoped files —
+            once it is reached the campaign stops, even mid-file;
+          - the time budget applies across the whole campaign;
+          - the schedule is applied independently per file.
+        """
+        kinds = self._kinds(xeno)
+        Path(self.work_dir).mkdir(parents=True, exist_ok=True)
+
+        # Baseline each configured oracle on the unmutated design (same
+        # semantics as the single-file path).
+        fpv_cfg = self._load_fpv_cfg() if self.mut_cfg.has_fpv_oracle() else None
+        fpv_baseline = self._baseline_fpv(fpv_cfg) if fpv_cfg is not None else None
+        sim_baseline = self._baseline_sim() if self.mut_cfg.has_sim_oracle() else None
+        for label, verdict in (("fpv", fpv_baseline), ("sim", sim_baseline)):
+            if verdict is not None and verdict != "PASS":
+                log_event(
+                    logger,
+                    logging.WARNING,
+                    "mut_runner.baseline_not_pass",
+                    campaign=self.mut_cfg.get_name(),
+                    oracle=label,
+                    verdict=verdict,
+                )
+        baseline_verdict = " ".join(
+            f"{label}={v}"
+            for label, v in (("fpv", fpv_baseline), ("sim", sim_baseline))
+            if v is not None
+        )
+
+        source_files = self._scoped_source_files()
+        model_dir = self._model_dir()
+        per_file_cap = self.mut_cfg.budget.per_module_cap
+        global_cap = self.mut_cfg.budget.max_mutants
+
+        outcomes: list[MutantOutcome] = []
+        per_file: dict[str, dict[str, int]] = {}
+        deadline = self._deadline()
+        idx = 0
+        stop = False
+        for source_file in source_files:
+            if stop:
+                break
+            rel = os.path.relpath(source_file, model_dir)
+            count = global_cap - len(outcomes)
+            if per_file_cap is not None:
+                count = min(count, per_file_cap)
+            if count <= 0:
+                break
+            mutator = xeno.Mutator.from_sv(Path(source_file))
+            for mutant in mutator.generate(
+                kinds=kinds,
+                count=count,
+                seed=0,
+                schedule=self._schedule(xeno),
+            ):
+                if deadline is not None and time.monotonic() > deadline:
+                    log_event(
+                        logger,
+                        logging.INFO,
+                        "mut_runner.time_budget_reached",
+                        campaign=self.mut_cfg.get_name(),
+                        generated=idx,
+                    )
+                    stop = True
+                    break
+                outcome = self._score_mutant(
+                    idx, mutant, fpv_cfg, fpv_baseline, target_file=source_file
+                )
+                outcomes.append(outcome)
+                bucket = per_file.setdefault(rel, {KILLED: 0, SURVIVED: 0, ERRORED: 0})
+                bucket[outcome.outcome] += 1
+                idx += 1
+                if len(outcomes) >= global_cap:
+                    stop = True
+                    break
+
+        return MutResults(
+            name=self.mut_cfg.get_name(),
+            outcomes=outcomes,
+            baseline_verdict=baseline_verdict or "NA",
+            per_file=per_file,
+        )
+
     # --- mutant materialisation ---------------------------------------------
 
     def _model_dir(self) -> str:
@@ -194,8 +417,9 @@ class MutRunner:
             )
         return os.path.dirname(os.path.abspath(model.path))
 
-    def _design_relpath(self) -> str:
-        return os.path.relpath(self.mut_cfg.get_design_file(), self._model_dir())
+    def _design_relpath(self, target_file: str | None = None) -> str:
+        target = target_file or self.mut_cfg.get_design_file()
+        return os.path.relpath(target, self._model_dir())
 
     def _validate_design_in_model(self) -> None:
         rel = self._design_relpath()
@@ -206,16 +430,24 @@ class MutRunner:
                 "isolation can copy the source tree."
             )
 
-    def _materialise_mutant(self, mutant_id: str, mutant_sv: str):
+    def _materialise_mutant(
+        self, mutant_id: str, mutant_sv: str, target_file: str | None = None
+    ):
         """Copy the model tree, splice in the mutant, return a per-mutant
-        ModelConfig pointing at the copy plus the mutant's work root."""
+        ModelConfig pointing at the copy plus the mutant's work root.
+
+        ``target_file`` names the source file the mutant should be spliced
+        into (its origin file in a multi-file scoped campaign). When None
+        (the single-file / empty-scope path), it is the configured
+        ``design_file`` — keeping the no-scope behaviour byte-for-byte.
+        """
         mutant_root = os.path.join(self.work_dir, mutant_id)
         model_src = os.path.join(mutant_root, "model_src")
         if os.path.exists(model_src):
             shutil.rmtree(model_src)
         shutil.copytree(self._model_dir(), model_src)
 
-        spliced = os.path.join(model_src, self._design_relpath())
+        spliced = os.path.join(model_src, self._design_relpath(target_file))
         with open(spliced, "w") as f:
             f.write(mutant_sv)
 
@@ -351,13 +583,20 @@ class MutRunner:
 
     # --- scoring ------------------------------------------------------------
 
-    def _score_mutant(self, idx: int, mutant, fpv_cfg, fpv_baseline) -> MutantOutcome:
+    def _score_mutant(
+        self, idx: int, mutant, fpv_cfg, fpv_baseline, target_file: str | None = None
+    ) -> MutantOutcome:
         operator = mutant.kind.value
         mutant_id = f"m{idx:04d}_{operator}"
         predicted = sorted(getattr(mutant.prediction, "perturbs_signals", []) or [])
+        # Model-relative origin file, recorded only for scoped (multi-file)
+        # campaigns; empty for the single-file path (back-compat).
+        file_rel = self._design_relpath(target_file) if target_file else ""
 
         try:
-            mutant_model, mutant_root = self._materialise_mutant(mutant_id, mutant.sv)
+            mutant_model, mutant_root = self._materialise_mutant(
+                mutant_id, mutant.sv, target_file=target_file
+            )
         except OSError as e:
             log_event(
                 logger,
@@ -374,6 +613,7 @@ class MutRunner:
                 diff_summary=mutant.diff_summary,
                 verdict="ERROR",
                 predicted_signals=predicted,
+                file=file_rel,
             )
 
         per_outcomes: list[str] = []
@@ -416,6 +656,7 @@ class MutRunner:
             diff_summary=mutant.diff_summary,
             verdict=" ".join(verdicts) or "NA",
             predicted_signals=predicted,
+            file=file_rel,
         )
 
     def _deadline(self) -> float | None:

--- a/tests/test_mut.py
+++ b/tests/test_mut.py
@@ -618,3 +618,349 @@ def test_both_oracles_union_kill(tmp_path, monkeypatch):
     o = results.outcomes[0]
     assert o.outcome == KILLED
     assert "fpv=PASS" in o.verdict and "sim=FAIL" in o.verdict
+
+
+# ---------------------------------------------------------------------------
+# Scope graph-ingestion: a 2-module hierarchy (hier_top -> two leaf insts)
+# ---------------------------------------------------------------------------
+
+_HIER_TOP_SV = dedent(
+    """\
+    module hier_top (input logic clk, input logic en,
+                     output logic [2:0] a, output logic [2:0] b);
+      leaf u_alu_a (.clk(clk), .en(en), .cnt(a));
+      leaf u_alu_b (.clk(clk), .en(en), .cnt(b));
+    endmodule
+    """
+)
+
+
+def _write_hier_project(root: Path, scope_block: str) -> Path:
+    """A two-file hierarchy: hier_top.sv instantiates two leaf instances
+    from leaf.sv. Returns the mut.yaml path. ``scope_block`` is spliced
+    into mut.yaml verbatim (already indented as a top-level YAML key)."""
+    design_dir = root / "design" / "hier"
+    design_dir.mkdir(parents=True)
+    (design_dir / "leaf.sv").write_text(_DESIGN_SV)
+    (design_dir / "hier_top.sv").write_text(_HIER_TOP_SV)
+    (design_dir / "models.yaml").write_text(
+        dedent(
+            """\
+            rtl-buddy-filetype: model_config
+            models:
+              - name: "hier_top"
+                filelist: ["-v hier_top.sv", "-v leaf.sv"]
+            """
+        )
+    )
+
+    fpv_dir = root / "fpv" / "hier"
+    fpv_dir.mkdir(parents=True)
+    (fpv_dir / "fpv.yaml").write_text(
+        dedent(
+            """\
+            rtl-buddy-filetype: fpv_config
+            verifications:
+              - name: "hier_safety"
+                desc: "safety"
+                tool: "sby"
+                model: "hier_top"
+                model_path: "../../design/hier/models.yaml"
+                top: "hier_top"
+                properties: []
+                mode: "bmc"
+                depth: 16
+            """
+        )
+    )
+
+    mut_path = fpv_dir / "mut.yaml"
+    mut_path.write_text(
+        dedent(
+            """\
+            rtl-buddy-filetype: mut_config
+            model: "hier_top"
+            model_path: "../../design/hier/models.yaml"
+            design_file: "../../design/hier/leaf.sv"
+            operators: [arith_flip, cond_const]
+            verify:
+              fpv_config: "fpv.yaml"
+              verification: "hier_safety"
+            budget:
+              max_mutants: 10
+              schedule: sequential
+            """
+        )
+        + scope_block
+    )
+    return mut_path
+
+
+def _hier_runner(tmp_path, mut_path):
+    from rtl_buddy.runner.mut_runner import MutRunner
+
+    cfg = MutSuiteConfig(path=str(mut_path)).get_config()
+    return MutRunner(
+        name="test", root_cfg=None, mut_cfg=cfg, work_dir=str(tmp_path / "work")
+    )
+
+
+@pytest.fixture
+def stub_hier(monkeypatch):
+    """Patch MutRunner._scope_graph_json with a canned 2-module graph so
+    no real rtl-buddy-view subprocess is needed. Source files are derived
+    from the configured design_file's directory (design/hier/)."""
+
+    def _graph(self):
+        d = os.path.dirname(os.path.abspath(self.mut_cfg.get_design_file()))
+        return {
+            "schema_version": "1.1",
+            "top": "hier_top",
+            "edges": [],
+            "overlays_present": [],
+            "nodes": [
+                {
+                    "id": "hier_top",
+                    "module": "hier_top",
+                    "source": {"file": os.path.join(d, "hier_top.sv")},
+                },
+                {
+                    "id": "hier_top.u_alu_a",
+                    "module": "leaf",
+                    "source": {"file": os.path.join(d, "leaf.sv")},
+                },
+                {
+                    "id": "hier_top.u_alu_b",
+                    "module": "leaf",
+                    "source": {"file": os.path.join(d, "leaf.sv")},
+                },
+            ],
+        }
+
+    monkeypatch.setattr(
+        "rtl_buddy.runner.mut_runner.MutRunner._scope_graph_json", _graph
+    )
+
+
+# A scope-aware fake FpvRunner: scans every .sv in the spliced model tree
+# for a KILL / ERR marker (the multi-file tree has more than one .sv, so we
+# can't rely on the single-glob convention _FakeFpvRunner uses).
+class _ScopeFakeFpvRunner:
+    def __init__(self, name, root_cfg, fpv_cfg, suite_dir):
+        self.fpv_cfg = fpv_cfg
+
+    def run(self):
+        model = self.fpv_cfg.get_model()
+        design_dir = Path(os.path.dirname(model.path))
+        text = "".join(p.read_text() for p in sorted(design_dir.glob("*.sv")))
+        if "ERR" in text:
+            raise FatalRtlBuddyError("elaboration failed")
+        if "KILL" in text:
+            return FpvFailResults(name="x", mode="bmc", depth=16)
+        return FpvPassResults(name="x", mode="bmc", depth=16)
+
+
+def _install_scope_xeno(monkeypatch):
+    """A xeno stub whose Mutator is keyed by the file it was built from, so
+    every scoped file yields a mutant carrying a marker derived from that
+    file's basename. Lets a test prove each mutant was spliced into ITS
+    origin file."""
+
+    class _ScopeMutator:
+        def __init__(self, basename, text):
+            self.basename = basename
+            self.text = text
+
+        @classmethod
+        def from_sv(cls, path):
+            p = Path(path)
+            return cls(p.name, p.read_text())
+
+        def generate(self, kinds, count, seed=0, schedule=None):
+            # One mutant per file. Its sv prepends a per-file marker so the
+            # materialised file is identifiable.
+            yield _Mutant(
+                sv=f"// MUT {self.basename}\n" + self.text,
+                diff_summary=f"mutate {self.basename}",
+                seed=1,
+                prediction=_Prediction(),
+                kind=_MutationKind.ARITH_FLIP,
+            )
+
+        def candidates(self, kinds):
+            yield _Site(_MutationKind.ARITH_FLIP, 2, 1, "+", _Prediction())
+
+    mod = types.ModuleType("rtl_buddy_xeno")
+    mod.Mutator = _ScopeMutator
+    mod.MutationKind = _MutationKind
+    mod.Schedule = _Schedule
+    mod.Mutant = _Mutant
+    mod.Site = _Site
+    mod.Prediction = _Prediction
+    monkeypatch.setitem(sys.modules, "rtl_buddy_xeno", mod)
+    return mod
+
+
+def test_scope_empty_skips_graph(tmp_path, stub_xeno, monkeypatch):
+    # Default (no scope) project: the graph resolver must never be called.
+    mut_path = _write_project(tmp_path)
+    runner = _runner(tmp_path, mut_path)
+
+    def _boom(self):
+        raise AssertionError("_scope_graph_json must not run for empty scope")
+
+    monkeypatch.setattr(
+        "rtl_buddy.runner.mut_runner.MutRunner._scope_graph_json", _boom
+    )
+    # list works, run scores, neither touches the graph.
+    assert len(runner.list_candidates()) == 2
+    with patch("rtl_buddy.runner.mut_runner.FpvRunner", _FakeFpvRunner):
+        results = runner.run()
+    assert results.killed() == 1
+    assert results.survived() == 1
+    # No per-file breakdown for the single-file path.
+    assert results.per_file is None
+    assert "per_file" not in results.as_report()
+
+
+def test_scope_include_selects_files(tmp_path, stub_xeno, stub_hier):
+    mut_path = _write_hier_project(
+        tmp_path,
+        dedent(
+            """\
+            scope:
+              include: ["*/leaf.sv"]
+            """
+        ),
+    )
+    runner = _hier_runner(tmp_path, mut_path)
+    files = runner._scoped_source_files()
+    assert len(files) == 1
+    assert files[0].endswith("leaf.sv")
+    # list_candidates tags each site with the model-relative origin file.
+    sites = runner.list_candidates()
+    assert sites and all(s["file"] == "leaf.sv" for s in sites)
+
+
+def test_scope_exclude_drops_files(tmp_path, stub_xeno, stub_hier):
+    mut_path = _write_hier_project(
+        tmp_path,
+        dedent(
+            """\
+            scope:
+              exclude: ["*/leaf.sv"]
+            """
+        ),
+    )
+    runner = _hier_runner(tmp_path, mut_path)
+    files = runner._scoped_source_files()
+    # Excluding leaf.sv leaves only hier_top.sv.
+    assert len(files) == 1
+    assert files[0].endswith("hier_top.sv")
+
+
+def test_scope_instance_path_glob(tmp_path, stub_xeno, stub_hier):
+    # Match by dotted instance path, not by file glob.
+    mut_path = _write_hier_project(
+        tmp_path,
+        dedent(
+            """\
+            scope:
+              include: ["hier_top.u_alu_a"]
+            """
+        ),
+    )
+    runner = _hier_runner(tmp_path, mut_path)
+    files = runner._scoped_source_files()
+    # The instance maps to leaf.sv; only that file is in scope.
+    assert len(files) == 1
+    assert files[0].endswith("leaf.sv")
+
+
+def test_scope_empty_selection_errors(tmp_path, stub_xeno, stub_hier):
+    mut_path = _write_hier_project(
+        tmp_path,
+        dedent(
+            """\
+            scope:
+              include: ["*/nonexistent.sv"]
+            """
+        ),
+    )
+    runner = _hier_runner(tmp_path, mut_path)
+    with pytest.raises(FatalRtlBuddyError, match="selected no source files"):
+        runner._scoped_source_files()
+
+
+def test_scope_missing_view_binary(tmp_path, stub_xeno, monkeypatch):
+    # Do NOT stub _scope_graph_json; instead make RtlBuddyView.run raise as
+    # the real wrapper does when the binary is absent, and assert run()
+    # propagates it.
+    mut_path = _write_hier_project(
+        tmp_path,
+        dedent(
+            """\
+            scope:
+              include: ["*/leaf.sv"]
+            """
+        ),
+    )
+
+    def _no_binary(self):
+        raise FatalRtlBuddyError(
+            "hier: 'rtl-buddy-view' not found on PATH; install rtl-buddy-view"
+        )
+
+    monkeypatch.setattr(
+        "rtl_buddy.tools.hier_rtl_buddy_view.RtlBuddyView.run", _no_binary
+    )
+    runner = _hier_runner(tmp_path, mut_path)
+    with pytest.raises(FatalRtlBuddyError, match="rtl-buddy-view"):
+        with patch("rtl_buddy.runner.mut_runner.FpvRunner", _ScopeFakeFpvRunner):
+            runner.run()
+
+
+def test_scope_multifile_run(tmp_path, monkeypatch, stub_hier):
+    # Scope selects BOTH files; the stub yields one mutant per file, each
+    # spliced into ITS origin file. Both are scored, with a per-file
+    # breakdown in the report.
+    mut_path = _write_hier_project(
+        tmp_path,
+        dedent(
+            """\
+            scope:
+              include: ["*/hier_top.sv", "*/leaf.sv"]
+            """
+        ),
+    )
+    _install_scope_xeno(monkeypatch)
+    runner = _hier_runner(tmp_path, mut_path)
+    with patch("rtl_buddy.runner.mut_runner.FpvRunner", _ScopeFakeFpvRunner):
+        results = runner.run()
+
+    # One mutant per scoped file = two outcomes, both survived (no KILL/ERR
+    # marker -> the fake oracle PASSes == baseline).
+    assert len(results.outcomes) == 2
+    origin_files = sorted(o.file for o in results.outcomes)
+    assert origin_files == ["hier_top.sv", "leaf.sv"]
+
+    # Each mutant must have been spliced into its OWN origin file: the
+    # materialised model_src must carry the per-file marker in the matching
+    # file and leave the other file's marker absent.
+    for o in results.outcomes:
+        # The model dir is design/hier (it holds models.yaml), so the copied
+        # tree's root IS that dir and the model-relative file sits directly
+        # under model_src.
+        model_src = tmp_path / "work" / o.mutant_id / "model_src"
+        spliced = (model_src / o.file).read_text()
+        assert f"// MUT {o.file}" in spliced
+        other = "leaf.sv" if o.file == "hier_top.sv" else "hier_top.sv"
+        assert "// MUT" not in (model_src / other).read_text()
+
+    # Per-file breakdown present and summing to the scored totals.
+    report = results.as_report()
+    assert set(report["per_file"]) == {"hier_top.sv", "leaf.sv"}
+    total = sum(
+        v[SURVIVED] + v[KILLED] + v[ERRORED] for v in report["per_file"].values()
+    )
+    assert total == 2


### PR DESCRIPTION
Wires `mut.yaml` `scope.include`/`scope.exclude` into `rb mut`: it ingests the rtl-buddy-view hierarchy graph via `rb hier --format json`, filters candidate source files by instance path / source-file globs, runs the single-file mutator per scoped file, and splices each mutant back into its origin file. When `scope` is empty, `rb mut` keeps today's single-file leaf behaviour byte-for-byte.

### Design decisions for review

- Shape B-prime confirmed and implemented (NOT the plan's Shape-A hedge): no xeno change is needed for a real multi-file campaign. rtl_buddy calls `Mutator.from_sv(file)` per scoped file, so origin-file identity is the loop variable; each mutant is spliced back into ITS origin file. The plan's premise that `Site` carries no file field is irrelevant because we never need it — we track the file externally.
- Budget cap semantics for the scoped slice: `per_module_cap` caps mutants generated PER scoped file (one scoped file == one module for this slice); `max_mutants` is a GLOBAL ceiling across all scoped files (campaign stops once reached, possibly mid-file); the time budget spans the whole campaign; schedule is applied independently per file (each `from_sv` mutator gets its own `generate(schedule=...)` call with `seed=0`). The per-file count passed to `generate()` is `min(global_remaining, per_module_cap)`.
- `design_file` vs scope relationship: when scope is active, the scoped file-set (resolved from the graph) drives mutation, NOT `design_file`. `design_file` remains a required config field and is still used by the empty-scope path and by `_validate_design_in_model()` / baselining. I deliberately did NOT require `design_file` to be inside the scope set (the plan's Shape-A 'validate design_file in graph' guard was dropped, since Shape B-prime mutates the scoped files directly and `design_file` is just the default single-file target). Scoped files are each independently validated to live within the model dir.
- Tri-target glob match: each include/exclude pattern is `fnmatch`'d (stdlib shell glob) against THREE targets per node — `node['id']` (dotted instance_path), the absolute `source.file`, and `source.file` relative to the model dir. A node is in scope if include is empty OR any include matches any target, and no exclude matches any target. This lets users write instance-path globs (`hier_top.u_alu_a`), absolute-path globs, or relative-path globs (`*/leaf.sv`) interchangeably. Flagged in the plan's Risk 6 as needing review — kept the permissive tri-match.
- Per-file report breakdown: `MutResults` gains an optional `per_file` dict `{model_rel_file: {killed,survived,errored}}` emitted in `as_report()` ONLY when scope was active, so single-file reports keep their exact prior JSON shape. `MutantOutcome` gains `file: str = ''` (model-relative origin, empty for empty scope). `from_report()` tolerates reports lacking `file`/`per_file` (back-compat preserved; `test_report_round_trip` still passes).
- Empty-scope path kept byte-for-byte via early-return guards in `run()` and `list_candidates()` placed BEFORE any mutator/graph work. To guarantee no behavioural drift I duplicated the small baseline-computation block into `_run_scoped()` rather than extracting a shared helper that would alter the existing `run()` body — the task explicitly forbade routing the single file through a new generalized loop. `_materialise_mutant`/`_design_relpath`/`_score_mutant` gained optional `target_file` params that default to `design_file`, so the existing 2-arg `_materialise_mutant` test call and the empty-scope mutant ids/artefact dirs/report shape are unchanged.
- Graph ingestion reuses the existing `RtlBuddyView` wrapper with `output=<work>/scope/hier.json` (run() streams to the file and returns only a returncode, so the file is read back). `schema_version` is validated to be 1.x. Missing-binary surfaces as the wrapper's `FatalRtlBuddyError`, propagated unchanged.
- INFO event `mut_runner.scope_resolved` added; per AGENTS.md logging policy only WARNING/ERROR events need a `_human_message()` case, so no `_human_message` entry was added (the existing `baseline_not_pass` WARNING is reused).

Part of #206.

Note: when scope is used, rtl-buddy-view must be on PATH (the `rb hier --format json` ingestion shells out to it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
